### PR TITLE
Tests

### DIFF
--- a/src/Elastic.CommonSchema.Serilog/EcsTextFormatter.cs
+++ b/src/Elastic.CommonSchema.Serilog/EcsTextFormatter.cs
@@ -21,7 +21,7 @@ namespace Elastic.CommonSchema.Serilog
 		public EcsTextFormatter(EcsTextFormatterConfiguration configuration) =>
 			_configuration = configuration ?? new EcsTextFormatterConfiguration();
 
-		public void Format(LogEvent logEvent, TextWriter output)
+		public virtual void Format(LogEvent logEvent, TextWriter output)
 		{
 			var ecsEvent = LogEventConverter.ConvertToEcs(logEvent, _configuration);
 			var bytes = ecsEvent.Serialize();

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using Serilog.Events;
 #if NETSTANDARD
@@ -23,6 +24,28 @@ namespace Elastic.CommonSchema.Serilog
 	/// </summary>
 	public class LogEventConverter
 	{
+		private static class SpecialKeys
+		{
+			public const string DefaultLogger = "Elastic.CommonSchema.Serilog";
+
+			public const string SourceContext = nameof(SourceContext);
+			public const string EnvironmentUserName = nameof(EnvironmentUserName);
+			public const string Host = nameof(Host);
+			public const string ActionCategory = nameof(ActionCategory);
+			public const string ActionName = nameof(ActionName);
+			public const string ActionId = nameof(ActionId);
+			public const string ActionKind = nameof(ActionKind);
+			public const string ActionSeverity = nameof(ActionSeverity);
+			public const string ApplicationId = nameof(ApplicationId);
+			public const string ApplicationName = nameof(ApplicationName);
+			public const string ApplicationType = nameof(ApplicationType);
+			public const string ApplicationVersion = nameof(ApplicationVersion);
+			public const string ProcessName = nameof(ProcessName);
+			public const string ProcessId = nameof(ProcessId);
+			public const string ThreadId = nameof(ThreadId);
+			public const string MachineName = nameof(MachineName);
+		}
+
 		public static Base ConvertToEcs(LogEvent logEvent, IEcsTextFormatterConfiguration configuration)
 		{
 			var exceptions = logEvent.Exception != null
@@ -38,18 +61,10 @@ namespace Elastic.CommonSchema.Serilog
 				Log = GetLog(logEvent, exceptions, configuration),
 				Agent = GetAgent(logEvent),
 				Event = GetEvent(logEvent),
-				Metadata = GetMetadata(logEvent)
+				Metadata = GetMetadata(logEvent),
+				Process = GetProcess(logEvent, configuration.MapCurrentThread),
+				Host = GetHost(logEvent),
 			};
-
-			//TODO investigate
-			//Serilog sinks with default enrichments where do these end up?
-			//logEvent.Properties
-
-			if (configuration.MapCurrentThread)
-			{
-				var currentThread = Thread.CurrentThread;
-				ecsEvent.Process = GetProcess(currentThread);
-			}
 
 			if (configuration.MapHttpAdapter != null)
 			{
@@ -68,10 +83,11 @@ namespace Elastic.CommonSchema.Serilog
 			return ecsEvent;
 		}
 
+
 		private static IDictionary<string, object> GetMetadata(LogEvent logEvent)
 		{
 			var dict = new Dictionary<string, object>();
-
+			//TODO what does this do and where does it come from?
 			if (logEvent.Properties.TryGetValue("ActionPayload", out var actionPayload))
 			{
 				var logEventPropertyValues = (actionPayload as SequenceValue)?.Elements;
@@ -85,55 +101,163 @@ namespace Elastic.CommonSchema.Serilog
 							.Replace("]", string.Empty)
 							.Split(','))
 						.Select(value => new { Key = value[0].Trim(), Value = value[1].Trim() }))
-						dict.Add(item.Key, item.Value);
+						dict.Add(ToSnakeCase(item.Key), item.Value);
 				}
 			}
 
 			foreach (var logEventPropertyValue in logEvent.Properties)
 			{
+				switch (logEventPropertyValue.Key) {
+					// already mapped as structured ECS event
+					case SpecialKeys.SourceContext:
+					case SpecialKeys.EnvironmentUserName:
+					case SpecialKeys.Host:
+					case SpecialKeys.ActionCategory:
+					case SpecialKeys.ActionName:
+					case SpecialKeys.ActionId:
+					case SpecialKeys.ActionKind:
+					case SpecialKeys.ActionSeverity:
+					case SpecialKeys.ApplicationId:
+					case SpecialKeys.ApplicationName:
+					case SpecialKeys.ApplicationType:
+					case SpecialKeys.ApplicationVersion:
+					case SpecialKeys.ProcessName:
+					case SpecialKeys.ProcessId:
+					case SpecialKeys.ThreadId:
+					case SpecialKeys.MachineName:
+						continue;
+				}
+
 				if (logEventPropertyValue.Value is SequenceValue values)
 				{
-					dict.Add(logEventPropertyValue.Key, values.Elements.Select(e => e.ToString()).ToArray());
+					dict.Add(ToSnakeCase(logEventPropertyValue.Key), values.Elements.Select(e => e.ToString()).ToArray());
 					continue;
 				}
 
-				dict.Add(logEventPropertyValue.Key, logEventPropertyValue.Value.ToString());
+				dict.Add(ToSnakeCase(logEventPropertyValue.Key), logEventPropertyValue.Value);
 			}
-
+			if (dict.Count == 0) return null;
 			return dict;
 		}
+		private static string ToSnakeCase(string s)
+		{
+			if (string.IsNullOrEmpty(s)) return s;
 
+			var sb = new StringBuilder();
+			for (var i = 0; i < s.Length; i++)
+			{
+				var c = s[i];
+				if (!char.IsUpper(c))
+				{
+					sb.Append(c);
+					continue;
+				}
+				// first
+				if (i == 0)
+					sb.Append(char.ToLowerInvariant(c));
+				else if (char.IsUpper(s[i - 1])) // WriteIO => write_io
+					sb.Append(char.ToLowerInvariant(c));
+				else
+				{
+					sb.Append("_");
+					sb.Append(char.ToLowerInvariant(c));
+				}
+			}
+			return sb.ToString();
+		}
+
+		private static Host GetHost(LogEvent e)
+		{
+			if (!e.Properties.TryGetValue(SpecialKeys.MachineName, out var machineName))
+				return null;
+
+			var host = new Host { Name = machineName.ToString() };
+			//todo map more uptime etc
+			return host;
+		}
 
 		private static Server GetServer(LogEvent e, IEcsTextFormatterConfiguration configuration)
 		{
-			var server = configuration.MapHttpAdapter != null ? configuration.MapHttpAdapter.Server : new Server();
-			server.User = e.Properties.TryGetValue("EnvironmentUserName", out var environmentUserName)
+			var server = configuration.MapHttpAdapter?.Server?? new Server();
+			server.User = e.Properties.TryGetValue(SpecialKeys.EnvironmentUserName, out var environmentUserName)
 				? new User { Name = environmentUserName.ToString() }
 				: null;
 
-			var hasHost = e.Properties.TryGetValue("Host", out var host);
+			var hasHost = e.Properties.TryGetValue(SpecialKeys.Host, out var host);
 			server.Address = hasHost ? host.ToString() : null;
 			server.Ip = hasHost ? host.ToString() : null;
 			return server;
 		}
 
-		private static Process GetProcess(Thread currentThread)
+		private static Process GetProcess(LogEvent e, bool mapFromCurrentThread)
 		{
-			if (currentThread == null)
+			LogEventPropertyValue processNameProp = null;
+			LogEventPropertyValue processIdProp = null;
+			LogEventPropertyValue threadIdProp = null;
+			e.Properties.TryGetValue(SpecialKeys.ProcessName, out processNameProp);
+			e.Properties.TryGetValue(SpecialKeys.ProcessId, out processIdProp);
+			e.Properties.TryGetValue(SpecialKeys.ThreadId, out threadIdProp);
+			if (processNameProp == null
+				&& processIdProp == null
+				&& threadIdProp == null
+				&& !mapFromCurrentThread)
 				return null;
+
+			var processName = processNameProp?.ToString();
+			var processId = processIdProp?.ToString();
+			var threadId = threadIdProp?.ToString();
+			var pid = int.TryParse(processId ?? "", out var p)
+				? p
+				: (int?)null;
+
+			if (!mapFromCurrentThread)
+			{
+				return new Process
+				{
+					Title = processName,
+					Name = processName,
+					Pid = pid,
+					Thread = int.TryParse(threadId ?? processId ?? "", out var id)
+						? new ProcessThread() { Id = id }
+						: null,
+				};
+			}
+
+			var currentThread = Thread.CurrentThread;
+			var process = TryGetProcess(pid);
 
 			return new Process
 			{
-				Title = currentThread.Name,
-				Name = currentThread.Name,
-				Executable = currentThread.ExecutionContext.GetType().ToString(),
+				Title = process?.MainWindowTitle,
+				Name = process?.ProcessName ?? processName,
+				Pid = process?.Id ?? pid,
+				Executable = process?.ProcessName ?? processName,
 				Thread = new ProcessThread { Id = currentThread.ManagedThreadId }
 			};
 		}
 
+		private static System.Diagnostics.Process TryGetProcess(int? processId)
+		{
+			try
+			{
+				var pid = processId != null
+					? System.Diagnostics.Process.GetProcessById(processId.Value)
+					: System.Diagnostics.Process.GetCurrentProcess();
+				return pid;
+			}
+			catch (Exception)
+			{
+				return null;
+			}
+		}
+
 		private static Log GetLog(LogEvent e, IReadOnlyList<Exception> exceptions, IEcsTextFormatterConfiguration configuration)
 		{
-			var log = new Log { Level = e.Level.ToString("F"), Logger = "Elastic.CommonSchema.Serilog" };
+			var source = e.Properties.TryGetValue(SpecialKeys.SourceContext, out var context)
+				 ? context.ToString()
+				 : SpecialKeys.DefaultLogger ;
+
+			var log = new Log { Level = e.Level.ToString("F"), Logger = source};
 
 			if (configuration.MapExceptions)
 			{
@@ -153,53 +277,45 @@ namespace Elastic.CommonSchema.Serilog
 			var evnt = new Event
 			{
 				Created = e.Timestamp,
-				Category = e.Properties.ContainsKey("ActionCategory")
-					? e.Properties["ActionCategory"].ToString()
+				Category = e.Properties.TryGetValue(SpecialKeys.ActionCategory, out var c) ? c.ToString() : null,
+				Action = e.Properties.TryGetValue(SpecialKeys.ActionName, out var action) ? action.ToString().Replace("\"", "") : null,
+				Id = e.Properties.TryGetValue(SpecialKeys.ActionId, out var actionId)
+					? actionId.ToString().Replace("\"", "")
 					: null,
-				Action = e.Properties.ContainsKey("ActionName")
-					? e.Properties["ActionName"].ToString().Replace("\"", "")
+				Kind = e.Properties.TryGetValue(SpecialKeys.ActionKind, out var actionKind)
+					? actionKind.ToString().Replace("\"", "")
 					: null,
-				Id = e.Properties.ContainsKey("ActionId")
-					? e.Properties["ActionId"].ToString().Replace("\"", "")
-					: null,
-				Kind = e.Properties.ContainsKey("ActionKind")
-					? e.Properties["ActionKind"].ToString().Replace("\"", "")
-					: null,
-				Severity = e.Properties.ContainsKey("ActionSeverity")
-					? long.Parse(e.Properties["ActionSeverity"].ToString())
-					: 0
+				Severity = e.Properties.TryGetValue(SpecialKeys.ActionSeverity, out var actionSev)
+					? long.Parse(actionSev.ToString())
+					: 0,
+				Timezone = TimeZoneInfo.Local.StandardName
 			};
 
-#if NETSTANDARD
-            evnt.Timezone = TimeZoneInfo.Local.StandardName;
-#else
+			//Why does this get overriden in full framework?
+#if FULLFRAMEWORK
 			evnt.Timezone = TimeZone.CurrentTimeZone.StandardName;
 #endif
-
 			return evnt;
 		}
 
-		private static Agent GetAgent(LogEvent e) =>
-			e.Properties.ContainsKey("ApplicationId")
-			|| e.Properties.ContainsKey("ApplicationName")
-			|| e.Properties.ContainsKey("ApplicationType")
-			|| e.Properties.ContainsKey("ApplicationVersion")
-				? new Agent
-				{
-					Id = e.Properties.ContainsKey("ApplicationId")
-						? e.Properties["ApplicationId"].ToString()
-						: null,
-					Name = e.Properties.ContainsKey("ApplicationName")
-						? e.Properties["ApplicationName"].ToString()
-						: null,
-					Type = e.Properties.ContainsKey("ApplicationType")
-						? e.Properties["ApplicationType"].ToString()
-						: null,
-					Version = e.Properties.ContainsKey("ApplicationVersion")
-						? e.Properties["ApplicationVersion"].ToString()
-						: null
-				}
-				: null;
+		private static Agent GetAgent(LogEvent e)
+		{
+			Agent agent = null;
+
+			void Assign(string key, Action<Agent, string> assign)
+			{
+				if (!e.Properties.TryGetValue(key, out var v)) return;
+
+				agent ??= new Agent();
+				assign(agent, v.ToString());
+			}
+
+			Assign(SpecialKeys.ApplicationId, (a, v) => a.Id = v);
+			Assign(SpecialKeys.ApplicationName, (a, v) => a.Name = v);
+			Assign(SpecialKeys.ApplicationType, (a, v) => a.Type = v);
+			Assign(SpecialKeys.ApplicationVersion, (a, v) => a.Version = v);
+			return agent;
+		}
 
 		private static string CatchErrors(IReadOnlyCollection<Exception> errors)
 		{

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -292,8 +292,8 @@ namespace Elastic.CommonSchema.Serilog
 					? actionKind.ToString().Replace("\"", "")
 					: null,
 				Severity = e.Properties.TryGetValue(SpecialKeys.ActionSeverity, out var actionSev)
-					? long.Parse(actionSev.ToString())
-					: 0,
+					? (long?)long.Parse(actionSev.ToString())
+					: null,
 				Timezone = TimeZoneInfo.Local.StandardName
 			};
 

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -80,6 +80,8 @@ namespace Elastic.CommonSchema.Serilog
 
 			if (configuration.MapCustom != null) ecsEvent = configuration.MapCustom(ecsEvent);
 
+			ecsEvent.Message = logEvent.RenderMessage();
+
 			return ecsEvent;
 		}
 
@@ -133,12 +135,16 @@ namespace Elastic.CommonSchema.Serilog
 					dict.Add(ToSnakeCase(logEventPropertyValue.Key), values.Elements.Select(e => e.ToString()).ToArray());
 					continue;
 				}
-
-				dict.Add(ToSnakeCase(logEventPropertyValue.Key), logEventPropertyValue.Value);
+				if (logEventPropertyValue.Value is ScalarValue sv)
+					dict.Add(ToSnakeCase(logEventPropertyValue.Key), sv.Value);
+				else
+					dict.Add(ToSnakeCase(logEventPropertyValue.Key), logEventPropertyValue.Value);
 			}
 			if (dict.Count == 0) return null;
 			return dict;
 		}
+
+		//TODO this should live in Log.MetaData as custom dictionary converter
 		private static string ToSnakeCase(string s)
 		{
 			if (string.IsNullOrEmpty(s)) return s;

--- a/src/Elastic.CommonSchema/Base.Serialization.cs
+++ b/src/Elastic.CommonSchema/Base.Serialization.cs
@@ -12,5 +12,8 @@ namespace Elastic.CommonSchema
 	public partial class Base
 	{
 		public byte[] Serialize() => JsonSerializer.Serialize(this, StandardResolver.ExcludeNull);
+
+		public static Base Deserialize(string s) =>
+			JsonSerializer.Deserialize<Base>(s, StandardResolver.ExcludeNull);
 	}
 }

--- a/src/Elastic.CommonSchema/Base.Serialization.cs
+++ b/src/Elastic.CommonSchema/Base.Serialization.cs
@@ -11,9 +11,9 @@ namespace Elastic.CommonSchema
 	[JsonFormatter(typeof(BaseJsonFormatter))]
 	public partial class Base
 	{
-		public byte[] Serialize() => JsonSerializer.Serialize(this, StandardResolver.ExcludeNull);
+		public byte[] Serialize() => JsonSerializer.Serialize(this, StandardResolver.ExcludeNullSnakeCase);
 
 		public static Base Deserialize(string s) =>
-			JsonSerializer.Deserialize<Base>(s, StandardResolver.ExcludeNull);
+			JsonSerializer.Deserialize<Base>(s, StandardResolver.ExcludeNullSnakeCase);
 	}
 }

--- a/src/Elastic.CommonSchema/Log.Serialization.cs
+++ b/src/Elastic.CommonSchema/Log.Serialization.cs
@@ -11,6 +11,6 @@ namespace Elastic.CommonSchema
 	[JsonFormatter(typeof(LogJsonFormatter))]
 	public partial class Log
 	{
-		public byte[] Serialize() => JsonSerializer.Serialize(this, StandardResolver.ExcludeNull);
+		public byte[] Serialize() => JsonSerializer.Serialize(this, StandardResolver.ExcludeNullSnakeCase);
 	}
 }

--- a/src/Elastic.CommonSchema/Serialization/BaseJsonFormatter.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/BaseJsonFormatter.Generated.cs
@@ -5,18 +5,19 @@
 /*
 IMPORTANT NOTE
 ==============
-This file has been generated. 
+This file has been generated.
 If you wish to submit a PR please modify the original csharp file and submit the PR with that change. Thanks!
 */
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Utf8Json;
 namespace Elastic.CommonSchema.Serialization
 {
 	internal class BaseJsonFormatter : IJsonFormatter<Base>
 	{
-		private static readonly IncrementingAutomataDictionary AutomataDictionary = new IncrementingAutomataDictionary
+		private static IncrementingAutomataDictionary AutomataDictionary { get; } = new IncrementingAutomataDictionary
 		{
 			// Base fields
 			{ "@timestamp" }, // 0
@@ -86,13 +87,13 @@ namespace Elastic.CommonSchema.Serialization
 				stringProp = reader.ReadString();
 				return true;
 			}
-			
+
 			while (reader.ReadIsInObject(ref count))
 			{
 				var propertyName = reader.ReadPropertyNameSegmentRaw();
 				if (AutomataDictionary.TryGetValue(propertyName, out var value))
 				{
-					_ = value switch
+					var read = _ = value switch
 					{
 						0 => ReadRef<DateTimeOffset?>(ref reader, ref @timestamp),
 						1 => ReadString(ref reader, ref loglevel),
@@ -136,7 +137,12 @@ namespace Elastic.CommonSchema.Serialization
 						39 => Read<Vulnerability>(ref reader, ecsEvent, (b, v) => b.Vulnerability = v),
 						_ => false
 					};
+					if (!read)
+					{
+						reader.ReadNext();
+					}
 				}
+				else reader.ReadNext();
 			}
 			ecsEvent.Log ??= new Log();
 			ecsEvent.Log.Level = loglevel;
@@ -200,7 +206,6 @@ namespace Elastic.CommonSchema.Serialization
 			if (value.Message != null)
 				writer.WriteString(value.Message);
 			else writer.WriteNull();
-			writer.WriteValueSeparator();
 		}
 
 		private static void WriteLogLevel(ref JsonWriter writer, Base value, IJsonFormatterResolver formatterResolver)
@@ -211,19 +216,19 @@ namespace Elastic.CommonSchema.Serialization
 			else writer.WriteNull();
 			writer.WriteValueSeparator();
 		}
-		
+
 		private static void WriteTimestamp(ref JsonWriter writer, Base value, IJsonFormatterResolver formatterResolver)
 		{
-			writer.WritePropertyName("timestamp");
+			writer.WritePropertyName("@timestamp");
 			var formatter = formatterResolver.GetFormatter<DateTimeOffset?>();
 			formatter.Serialize(ref writer, value.Timestamp, formatterResolver);
 			writer.WriteValueSeparator();
 		}
-		
+
 		private static void WriteProp<T>(ref JsonWriter writer, string key, T value, IJsonFormatterResolver formatterResolver)
 		{
 			if (value == null) return;
-			writer.WriteNameSeparator();
+			writer.WriteValueSeparator();
 			writer.WritePropertyName(key);
 			var formatter = formatterResolver.GetFormatter<T>();
 			formatter.Serialize(ref writer, value, formatterResolver);

--- a/src/Elastic.CommonSchema/Serialization/IncrementingAutomataDictionary.cs
+++ b/src/Elastic.CommonSchema/Serialization/IncrementingAutomataDictionary.cs
@@ -9,7 +9,7 @@ namespace Elastic.CommonSchema.Serialization
 {
 	internal class IncrementingAutomataDictionary : AutomataDictionary
 	{
-		private int _propertiesCount;
+		private int _propertiesCount = -1;
 
 		public void Add(string key) => Add(key, Interlocked.Increment(ref _propertiesCount));
 	}

--- a/src/Elastic.CommonSchema/Serialization/LogJsonFormatter .cs
+++ b/src/Elastic.CommonSchema/Serialization/LogJsonFormatter .cs
@@ -3,13 +3,79 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using Utf8Json;
 
 namespace Elastic.CommonSchema.Serialization
 {
-	internal class LogJsonFormatter : IJsonFormatter<Log>
+	internal partial class EcsUtf8JsonFormatterBase<TBase>
 	{
-		public Log Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver) => throw new NotImplementedException();
+		public bool ReadRef<T>(ref JsonReader reader, ref T set, IJsonFormatterResolver formatterResolver)
+		{
+			var formatter = formatterResolver.GetFormatter<T>();
+			set = formatter.Deserialize(ref reader, formatterResolver);
+			return true;
+		}
+		public bool Read<TProp>(ref JsonReader reader, TBase b, Action<TBase, TProp> set, IJsonFormatterResolver formatterResolver)
+		{
+			var formatter = formatterResolver.GetFormatter<TProp>();
+			set(b, formatter.Deserialize(ref reader, formatterResolver));
+			return true;
+		}
+
+		public static bool ReadString(ref JsonReader reader, ref string stringProp)
+		{
+			stringProp = reader.ReadString();
+			return true;
+		}
+	}
+
+
+	internal class LogJsonFormatter : EcsUtf8JsonFormatterBase<Log>, IJsonFormatter<Log>
+	{
+		private static IncrementingAutomataDictionary AutomataDictionary { get; } = new IncrementingAutomataDictionary
+		{
+			// Base fields
+			{ "origin" }, // 0
+			{ "original" }, // 1
+			{ "level" }, // 2
+			{ "syslog" }, // 3
+			{ "logger" }, // 4
+		};
+		public Log Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+		{
+			if (reader.ReadIsNull()) return null;
+
+			var count = 0;
+			var log = new Log();
+			string loglevel = null;
+			string original = null;
+			string logger = null;
+
+			while (reader.ReadIsInObject(ref count))
+			{
+				var propertyName = reader.ReadPropertyNameSegmentRaw();
+				if (AutomataDictionary.TryGetValue(propertyName, out var value))
+				{
+					var read = _ = value switch
+					{
+						0 => Read<LogOrigin>(ref reader, log, (b, v) => b.Origin = v, formatterResolver),
+						1 => ReadString(ref reader, ref original),
+						2 => ReadString(ref reader, ref loglevel),
+						3 => Read<LogSyslog[]>(ref reader, log, (b, v) => b.Syslog = v, formatterResolver),
+						4 => ReadString(ref reader, ref logger),
+						_ => false
+					};
+					if (!read)
+						reader.ReadNext();
+				}
+				else reader.ReadNext();
+			}
+			log.Level = loglevel;
+			log.Original = original;
+			log.Logger = logger;
+			return log;
+		}
 
 		public void Serialize(ref JsonWriter writer, Log value, IJsonFormatterResolver formatterResolver)
 		{

--- a/src/Generator/Views/BaseJsonFormatter.Generated.cshtml
+++ b/src/Generator/Views/BaseJsonFormatter.Generated.cshtml
@@ -41,6 +41,7 @@ namespace Elastic.CommonSchema.Serialization
 
 		public Base Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
+			if (reader.ReadIsNull()) return null;
 			var count = 0;
 			var ecsEvent = new Base();
 			string loglevel = null;
@@ -89,7 +90,10 @@ namespace Elastic.CommonSchema.Serialization
 </text>}
 						_ => false
 					};
+					if (!read)
+						reader.ReadNext();
 				}
+				else reader.ReadNext();
 			}
 			ecsEvent.Log ??= new Log();
 			ecsEvent.Log.Level = loglevel;
@@ -126,7 +130,6 @@ namespace Elastic.CommonSchema.Serialization
 			if (value.Message != null)
 				writer.WriteString(value.Message);
 			else writer.WriteNull();
-			writer.WriteValueSeparator();
 		}
 
 		private static void WriteLogLevel(ref JsonWriter writer, Base value, IJsonFormatterResolver formatterResolver)
@@ -140,7 +143,7 @@ namespace Elastic.CommonSchema.Serialization
 		
 		private static void WriteTimestamp(ref JsonWriter writer, Base value, IJsonFormatterResolver formatterResolver)
 		{
-			writer.WritePropertyName("timestamp");
+			writer.WritePropertyName("@(Raw("@"))timestamp)");
 			var formatter = formatterResolver.GetFormatter@(Raw("<DateTimeOffset?>"))();
 			formatter.Serialize(ref writer, value.Timestamp, formatterResolver);
 			writer.WriteValueSeparator();
@@ -149,7 +152,7 @@ namespace Elastic.CommonSchema.Serialization
 		private static void WriteProp@(Raw("<T>"))(ref JsonWriter writer, string key, T value, IJsonFormatterResolver formatterResolver)
 		{
 			if (value == null) return;
-			writer.WriteNameSeparator();
+			writer.WriteValueSeparator();
 			writer.WritePropertyName(key);
 			var formatter = formatterResolver.GetFormatter@(Raw("<T>"))();
 			formatter.Serialize(ref writer, value, formatterResolver);

--- a/src/ecs-dotnet.sln
+++ b/src/ecs-dotnet.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.CommonSchema.Serilo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.CommonSchema.Serilog.Test", "Elastic.CommonSchema.Serilog.Test\Elastic.CommonSchema.Serilog.Test.csproj", "{F3EECF86-A950-4CDE-82DD-DF270AFE86E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.CommonSchema.Serilog.Tests", "..\tests\Elastic.CommonSchema.Serilog.Tests\Elastic.CommonSchema.Serilog.Tests\Elastic.CommonSchema.Serilog.Tests.csproj", "{D7BA6070-909F-402E-A6F4-1CE54A7BE0B7}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Specification", "Specification\Specification.csproj", "{21FD7B39-5FDD-4432-B25E-8425D3EC46A3}"
 EndProject
 Global
@@ -58,6 +60,10 @@ Global
 		{F3EECF86-A950-4CDE-82DD-DF270AFE86E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3EECF86-A950-4CDE-82DD-DF270AFE86E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3EECF86-A950-4CDE-82DD-DF270AFE86E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7BA6070-909F-402E-A6F4-1CE54A7BE0B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7BA6070-909F-402E-A6F4-1CE54A7BE0B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7BA6070-909F-402E-A6F4-1CE54A7BE0B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7BA6070-909F-402E-A6F4-1CE54A7BE0B7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{21FD7B39-5FDD-4432-B25E-8425D3EC46A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{21FD7B39-5FDD-4432-B25E-8425D3EC46A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
@@ -9,6 +9,9 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.9.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+        <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
+        <PackageReference Include="Serilog.Enrichers.Thread" Version="3.2.0-dev-00747" />
         <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
         <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.21" />

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="5.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+        <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
+        <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.21" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\Elastic.CommonSchema.Serilog\Elastic.CommonSchema.Serilog.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.CommonSchema.Serilog.Tests
+{
+	public class EnrichmentsTests : LogTestsBase
+	{
+		public EnrichmentsTests(ITestOutputHelper output) : base(output) =>
+			LoggerConfiguration = LoggerConfiguration
+				.Enrich.WithThreadId()
+				.Enrich.WithThreadName()
+				.Enrich.WithMachineName()
+				.Enrich.WithProcessId()
+				.Enrich.WithProcessName()
+				.Enrich.WithEnvironmentUserName();
+
+		[Fact]
+		public void EnrichmentsEndUpOnEcsLog() => TestLogger((logger, getLogEvents) =>
+		{
+			logger.Information("My log message!");
+
+			var logEvents = getLogEvents();
+			logEvents.Should().HaveCount(1);
+
+			var ecsEvents = ToEcsEvents(logEvents);
+
+			var (_, info) = ecsEvents.First();
+			info.Log.Level.Should().Be("Information");
+			info.Error.Should().BeNull();
+
+			info.Host.Name.Should().NotBeEmpty();
+			info.Process.Name.Should().NotBeEmpty();
+			info.Process.Pid.Should().BeGreaterThan(0);
+			info.Process.Thread.Id.Should().NotBeNull().And.NotBe(info.Process.Pid);
+		});
+	}
+}

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/LogTestsBase.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/LogTestsBase.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.TestCorrelator;
+using Xunit.Abstractions;
+
+namespace Elastic.CommonSchema.Serilog.Tests
+{
+	public abstract class LogTestsBase
+	{
+		protected LoggerConfiguration LoggerConfiguration { get; set; }
+
+		protected EcsTextFormatter Formatter { get; } = new EcsTextFormatter();
+
+		public LogTestsBase(ITestOutputHelper output) =>
+			LoggerConfiguration = new LoggerConfiguration()
+				.MinimumLevel.Verbose()
+				//.WriteTo.Console(Formatter)
+				.WriteTo.TestOutput(output, formatter: Formatter, LogEventLevel.Verbose)
+				.WriteTo.TestCorrelator();
+
+		protected ILogger CreateLogger<T>() => LoggerConfiguration.CreateLogger().ForContext<T>();
+
+		protected void TestLogger(Action<ILogger, Func<List<LogEvent>>> act)
+		{
+			using var context = TestCorrelator.CreateContext();
+
+			static List<LogEvent> GetLogEvents() => TestCorrelator.GetLogEventsFromCurrentContext().ToList();
+			act(LoggerConfiguration.CreateLogger().ForContext(GetType()), GetLogEvents);
+		}
+
+		protected List<string> ToFormattedStrings(List<LogEvent> logEvents) =>
+			logEvents
+				.Select(l =>
+				{
+					using var stringWriter = new StringWriter();
+					Formatter.Format(l, stringWriter);
+					return stringWriter.ToString();
+				})
+				.ToList();
+
+		protected List<(string Json, Base Base)> ToEcsEvents(List<LogEvent> logEvents) =>
+			ToFormattedStrings(logEvents)
+				.Select(s => (s, Base.Deserialize(s)))
+				.ToList();
+	}
+}

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/MessageTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.CommonSchema.Serilog.Tests
+{
+	public class MessageTests : LogTestsBase
+	{
+		public MessageTests(ITestOutputHelper output) : base(output) =>
+			LoggerConfiguration = LoggerConfiguration
+				.Enrich.WithThreadId()
+				.Enrich.WithThreadName()
+				.Enrich.WithMachineName()
+				.Enrich.WithProcessId()
+				.Enrich.WithProcessName()
+				.Enrich.WithEnvironmentUserName();
+
+		[Fact]
+		public void SeesMessage() => TestLogger((logger, getLogEvents) =>
+		{
+			logger.Information("My log message!");
+
+			var logEvents = getLogEvents();
+			logEvents.Should().HaveCount(1);
+
+			var ecsEvents = ToEcsEvents(logEvents);
+
+			var (_, info) = ecsEvents.First();
+			info.Message.Should().Be("My log message!");
+		});
+
+		[Fact]
+		public void SeesMessageWithProp() => TestLogger((logger, getLogEvents) =>
+		{
+			logger.Information("Info {ValueX} {SomeY}", "X", 2.2);
+
+			var logEvents = getLogEvents();
+			logEvents.Should().HaveCount(1);
+
+			var ecsEvents = ToEcsEvents(logEvents);
+
+			var (_, info) = ecsEvents.First();
+			info.Message.Should().Be("Info \"X\" 2.2");
+			info.Metadata.Should().ContainKey("value_x");
+			info.Metadata.Should().ContainKey("some_y");
+
+			var x = info.Metadata["value_x"] as string;
+			x.Should().NotBeNull().And.Be("X");
+
+			var y = info.Metadata["some_y"] as double?;
+			y.Should().HaveValue().And.Be(2.2);
+
+		});
+	}
+}

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/OutputTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/OutputTests.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
-using Serilog.Events;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -26,10 +24,13 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			logEvents.Should().HaveCount(3);
 
 			var ecsEvents = ToEcsEvents(logEvents);
-			var error = ecsEvents.Last();
-			error.Base.Error.Should().NotBeNull();
-			var informational = ecsEvents.First();
-			informational.Base.Error.Should().BeNull();
+			var (_, error) = ecsEvents.Last();
+			error.Log.Level.Should().Be("Error");
+			error.Error.Should().NotBeNull();
+
+			var (_, info) = ecsEvents.First();
+			info.Log.Level.Should().Be("Information");
+			info.Error.Should().BeNull();
 		});
 	}
 }

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/UnitTest1.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/UnitTest1.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Serilog.Events;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.CommonSchema.Serilog.Tests
+{
+	public class OutputTests : LogTestsBase
+	{
+		public OutputTests(ITestOutputHelper output) : base(output) { }
+
+		[Fact]
+		public void LogMultiple() => TestLogger((logger, getLogEvents) =>
+		{
+			logger.Information("My log message!");
+			logger.Information("Test output to Serilog!");
+			Action sketchy = () => throw new Exception("I threw up.");
+			var exception = Record.Exception(sketchy);
+			logger.Error(exception, "Here is an error.");
+			Assert.NotNull(exception);
+
+			var logEvents = getLogEvents();
+			logEvents.Should().HaveCount(3);
+
+			var ecsEvents = ToEcsEvents(logEvents);
+			var error = ecsEvents.Last();
+			error.Base.Error.Should().NotBeNull();
+			var informational = ecsEvents.First();
+			informational.Base.Error.Should().BeNull();
+		});
+	}
+}


### PR DESCRIPTION
This adds a bunch of tests

* make sure `Base` can roundtrip serialization
* Add infra to easily test serilog integration
* Make sure we play nicely with default enrichers
* Prevent properties already persisted in the ECS tree to be written again under meta data
* metadata keys and object keys are now snake_case by default as per ECS recommendations.
   - This does not generically apply to all Dictionaries though
* make sure message is persisted


And various other fixes