### PR TITLE
Use the log event severity if the property is not present.

### DIFF
--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -267,8 +267,8 @@ namespace Elastic.CommonSchema.Serilog
 					? actionKind.ToString().Replace("\"", "")
 					: null,
 				Severity = e.Properties.TryGetValue(SpecialKeys.ActionSeverity, out var actionSev)
-					? (long?)long.Parse(actionSev.ToString())
-					: null,
+					? long.Parse(actionSev.ToString())
+					: (int)e.Level,
 				Timezone = TimeZoneInfo.Local.StandardName
 			};
 


### PR DESCRIPTION
Set `event.severity` to numeric value.

Discussed here: https://github.com/elastic/ecs/issues/683#issuecomment-563248169