### PR TITLE
Read trace and transaction id from APM in EcsTextFormatter

### DIFF
--- a/src/Elastic.Apm.SerilogEnricher/ElasticApmEnricher.cs
+++ b/src/Elastic.Apm.SerilogEnricher/ElasticApmEnricher.cs
@@ -15,9 +15,9 @@ namespace Elastic.Apm.SerilogEnricher
 			if (Agent.Tracer.CurrentTransaction == null) return;
 
 			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-				"TransactionId", Agent.Tracer.CurrentTransaction.Id));
+				"ElasticApmTransactionId", Agent.Tracer.CurrentTransaction.Id));
 			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-				"TraceId", Agent.Tracer.CurrentTransaction.TraceId));
+				"ElasticApmTraceId", Agent.Tracer.CurrentTransaction.TraceId));
 		}
 	}
 }

--- a/src/Elastic.Apm.SerilogEnricher/readme.md
+++ b/src/Elastic.Apm.SerilogEnricher/readme.md
@@ -7,13 +7,13 @@ This enricher adds transaction id and trace id to every Serilog log message that
 ```
 var logger = new LoggerConfiguration()
    .Enrich.WithElasticApmCorrelationInfo()
-   .WriteTo.Console(outputTemplate: "[{TraceId} {TransactionId} {Message:lj} {NewLine}{Exception}")
+   .WriteTo.Console(outputTemplate: "[{ElasticApmTraceId} {ElasticApmTransactionId} {Message:lj} {NewLine}{Exception}")
    .CreateLogger();
 ```
 
 In the code snippet above `Enrich.WithElasticApmCorrelationInfo()` enables the enricher from this project, which will set 2 properties for log lines that are created during a transaction:
-- `TransactionId`
-- `TraceId`
+- `ElasticApmTransactionId`
+- `ElasticApmTraceId`
 
 As you can see, in the `outputTemplate` of the Console sink these two properties are printed. Of course they can be used with any other sink.
 

--- a/tests/Elastic.Apm.SerilogEnricher.Test/SerilogTests.cs
+++ b/tests/Elastic.Apm.SerilogEnricher.Test/SerilogTests.cs
@@ -55,14 +55,14 @@ namespace Elastic.Apm.SerilogEnricher.Test
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(1)
-				.Properties["TraceId"]
+				.Properties["ElasticApmTraceId"]
 				.ToString()
 				.Should()
 				.Be($"\"{traceId}\"");
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(1)
-				.Properties["TransactionId"]
+				.Properties["ElasticApmTransactionId"]
 				.ToString()
 				.Should()
 				.Be($"\"{transactionId}\"");
@@ -119,28 +119,28 @@ namespace Elastic.Apm.SerilogEnricher.Test
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(1)
-				.Properties["TraceId"]
+				.Properties["ElasticApmTraceId"]
 				.ToString()
 				.Should()
 				.Be($"\"{traceId}\"");
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(1)
-				.Properties["TransactionId"]
+				.Properties["ElasticApmTransactionId"]
 				.ToString()
 				.Should()
 				.Be($"\"{transactionId}\"");
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(2)
-				.Properties["TraceId"]
+				.Properties["ElasticApmTraceId"]
 				.ToString()
 				.Should()
 				.Be($"\"{traceId}\"");
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(2)
-				.Properties["TransactionId"]
+				.Properties["ElasticApmTransactionId"]
 				.ToString()
 				.Should()
 				.Be($"\"{transactionId}\"");

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
@@ -19,9 +19,11 @@
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
+        <PackageReference Include="Elastic.Apm" Version="1.2.0" />
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\..\src\Elastic.Apm.SerilogEnricher\Elastic.Apm.SerilogEnricher.csproj" />
       <ProjectReference Include="..\..\..\src\Elastic.CommonSchema.Serilog\Elastic.CommonSchema.Serilog.csproj" />
     </ItemGroup>
 

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
@@ -50,7 +50,6 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			string traceId = null;
 			string transactionId = null;
 
-
 			// Start a new activity to make sure it does not override Tracing.Trace.Id
 			Activity.Current = new Activity("test").Start();
 
@@ -68,8 +67,8 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			var ecsEvents = ToEcsEvents(logEvents);
 			var (_, info) = ecsEvents.First();
 
-			info.Tracing.Trace.Id.Should().Be(traceId);
-			info.Tracing.Transaction.Id.Should().Be(transactionId);
+			info.Trace.Id.Should().Be(traceId);
+			info.Transaction.Id.Should().Be(transactionId);
 		});
 	}
 }

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
@@ -1,5 +1,7 @@
-using System;
+using System.Diagnostics;
 using System.Linq;
+using Elastic.Apm;
+using Elastic.Apm.SerilogEnricher;
 using FluentAssertions;
 using Serilog;
 using Xunit;
@@ -16,7 +18,8 @@ namespace Elastic.CommonSchema.Serilog.Tests
 				.Enrich.WithMachineName()
 				.Enrich.WithProcessId()
 				.Enrich.WithProcessName()
-				.Enrich.WithEnvironmentUserName();
+				.Enrich.WithEnvironmentUserName()
+				.Enrich.WithElasticApmCorrelationInfo();
 
 		[Fact]
 		public void EnrichmentsEndUpOnEcsLog() => TestLogger((logger, getLogEvents) =>
@@ -36,6 +39,37 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			info.Process.Name.Should().NotBeEmpty();
 			info.Process.Pid.Should().BeGreaterThan(0);
 			info.Process.Thread.Id.Should().NotBeNull().And.NotBe(info.Process.Pid);
+		});
+
+		[Fact]
+		public void ElasticApmEnrichmentsEndUpOnEcsLog() => TestLogger((logger, getLogEvents) =>
+		{
+			if (!Apm.Agent.IsConfigured)
+				Apm.Agent.Setup(new AgentComponents());
+
+			string traceId = null;
+			string transactionId = null;
+
+
+			// Start a new activity to make sure it does not override Tracing.Trace.Id
+			Activity.Current = new Activity("test").Start();
+
+			Apm.Agent.Tracer.CaptureTransaction("test", "test", (t)
+				=>
+			{
+				traceId = t.TraceId;
+				transactionId = t.Id;
+				logger.Information("My log message!");
+			});
+
+			var logEvents = getLogEvents();
+			logEvents.Should().HaveCount(1);
+
+			var ecsEvents = ToEcsEvents(logEvents);
+			var (_, info) = ecsEvents.First();
+
+			info.Tracing.Trace.Id.Should().Be(traceId);
+			info.Tracing.Transaction.Id.Should().Be(transactionId);
 		});
 	}
 }


### PR DESCRIPTION
Adds trace and transaction id to the generated logs in `EcsTextFormatter` in case the APM Agent is active.

Configuration:

```
Log.Logger = new LoggerConfiguration()
.Enrich.WithElasticApmCorrelationInfo()
.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri("http://localhost:9200"))
{
  CustomFormatter = new EcsTextFormatter()
})
.CreateLogger();
```

On this screenshot you see the output when I pass `EcsTextFormatter` to the serilog elasticsearch sink.

<img width="1716" alt="Screen Shot 2019-12-10 at 17 20 27" src="https://user-images.githubusercontent.com/1091853/70547595-736d0380-1b71-11ea-89f4-75231c6045cf.png">

I ran into 1 problem during testing with ASP.NET Core: It seems that some component uses the property `traceId` (my suspect is [serilog-aspnetcore](https://github.com/serilog/serilog-aspnetcore)), so our trace Id was overwritten by the Activity Id (`Activity.Current.Id`) and broke the navigation between logs and traces in Kibana.

This is yet another reason we should reuse that id. Nevertheless we don't have it right now, so I thought we just prefix our properties with `ElasticApm`, so we store the traceId with `logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ElasticApmTraceId", Agent.Tracer.CurrentTransaction.TraceId));`

The question is still open how to handle `Activity.Current.Id` - it could be added in `GetTracing(LogEvent logEvent)` as fallback. Happy to discuss it here, or in a follow up.