### PR TITLE
Build and package Elastic.Apm.SerilogEnricher project

### DIFF
--- a/build/Elastic.Apm.SerilogEnricher.nuspec
+++ b/build/Elastic.Apm.SerilogEnricher.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+	<metadata>
+		<id>Elastic.Apm.SerilogEnricher</id>
+		<version>$version$</version>
+		<title>Elastic APM Serilog Enricher</title>
+		<authors>Elastic and contributors</authors>
+		<owners>Elastic</owners>
+		<license type="file">license.txt</license>
+		<projectUrl>https://github.com/elastic/ecs-dotnet</projectUrl>
+		<iconUrl>https://raw.githubusercontent.com/elastic/ecs-dotnet/master/build/nuget-icon.png</iconUrl>
+		<icon>images\nuget-icon.png</icon>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>Elastic.Apm.SerilogEnricher</description>
+		<summary>The Elastic Common Schema (ECS) defines a common set of fields for ingesting data into Elasticsearch. A common schema helps you correlate data from sources like logs and metrics or IT operations analytics and security analytics.</summary>
+		<releaseNotes>See https://github.com/elastic/ecs-dotnet/releases/tag/$version$</releaseNotes>
+		<copyright>2018-$year$ Elasticsearch BV</copyright>
+		<tags>elasticsearch,elastic,ecs,elasticcommonschema,serilog,apm,logging</tags>
+		<dependencies>
+			<group targetFramework=".NETStandard2.0"></group>
+			<group targetFramework="net461"></group>
+		</dependencies>
+	</metadata>
+	<files>
+		<file src="..\license.txt" target="" />
+		<file src="nuget-icon.png" target="images\" />
+	
+		<file src="output\Elastic.Apm.SerilogEnricher\netstandard2.0\Elastic.Apm.SerilogEnricher.dll" target="lib\netstandard2.0"/>
+		<file src="output\Elastic.Apm.SerilogEnricher\netstandard2.0\Elastic.Apm.SerilogEnricher.xml" target="lib\netstandard2.0"/>
+
+		<file src="output\Elastic.Apm.SerilogEnricher\net461\Elastic.Apm.SerilogEnricher.dll" target="lib\net461"/>
+		<file src="output\Elastic.Apm.SerilogEnricher\net461\Elastic.Apm.SerilogEnricher.xml" target="lib\net461"/>
+	</files>
+</package>

--- a/build/Elastic.CommonSchema.Serilog.nuspec
+++ b/build/Elastic.CommonSchema.Serilog.nuspec
@@ -14,7 +14,7 @@
 		<summary>The Elastic Common Schema (ECS) defines a common set of fields for ingesting data into Elasticsearch. A common schema helps you correlate data from sources like logs and metrics or IT operations analytics and security analytics. This package contains a Serilog integration for formatting errors in ECS JSON format.</summary>
 		<releaseNotes>See https://github.com/elastic/ecs-dotnet/releases/tag/$version$</releaseNotes>
 		<copyright>2018-$year$ Elasticsearch BV</copyright>
-		<tags>elasticsearch,elastic,ecs,elasticcommonschema</tags>
+		<tags>elasticsearch,elastic,ecs,elasticcommonschema,serilog,logging</tags>
         <frameworkAssemblies>
             <frameworkAssembly assemblyName="System.Web" targetFramework="net461" />
         </frameworkAssemblies>

--- a/build/scripts/Projects.fs
+++ b/build/scripts/Projects.fs
@@ -18,6 +18,7 @@ module Projects =
     type Project =
         | CommonSchema
         | CommonSchemaSerilog
+        | ApmSerilogEnricher
         
     type PrivateProject =
         | Generator
@@ -30,24 +31,28 @@ module Projects =
             seq [
                 Project Project.CommonSchema; 
                 Project Project.CommonSchemaSerilog; 
+                Project Project.ApmSerilogEnricher; 
                 PrivateProject PrivateProject.Generator
             ]
         static member AllPublishable =
             seq [
                 Project Project.CommonSchema
-                Project Project.CommonSchemaSerilog                
+                Project Project.CommonSchemaSerilog
+                Project Project.ApmSerilogEnricher
             ]
 
         member this.Name =
             match this with
             | Project CommonSchema -> "Elastic.CommonSchema"
             | Project CommonSchemaSerilog -> "Elastic.CommonSchema.Serilog"
+            | Project ApmSerilogEnricher -> "Elastic.Apm.SerilogEnricher"
             | PrivateProject Generator -> "Generator"
  
         member this.NugetId =
             match this with
             | Project CommonSchema -> "Elastic.CommonSchema"
             | Project CommonSchemaSerilog -> "Elastic.CommonSchema.Serilog"
+            | Project ApmSerilogEnricher -> "Elastic.Apm.SerilogEnricher"
             | _ -> this.Name
                 
         member this.Versioned name version =


### PR DESCRIPTION
Include the Elastic.Apm.SerilogEnricher project in the build and packaging process.

`<summary>` node in nuspec file needs writing.