### PR TITLE
Add NLog LayoutRenderer to inject trace and transaction ids into logs

### DIFF
--- a/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
@@ -1,0 +1,20 @@
+﻿using System.Text;
+using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace Elastic.Apm.NLog
+{
+	[LayoutRenderer("ElasticApmTraceId")]
+	[ThreadSafe]
+	public class ApmTraceIdLayoutRenderer : LayoutRenderer
+	{
+		protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+		{
+			if (!Agent.IsConfigured) return;
+			if (Agent.Tracer.CurrentTransaction == null) return;
+
+			builder.Append(Agent.Tracer.CurrentTransaction.TraceId);
+		}
+	}
+}

--- a/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
@@ -1,0 +1,20 @@
+using System.Text;
+using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace Elastic.Apm.NLog
+{
+	[LayoutRenderer("ElasticApmTransactionId")]
+	[ThreadSafe]
+	public class ApmTransactionIdLayoutRenderer : LayoutRenderer
+	{
+		protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+		{
+			if (!Agent.IsConfigured) return;
+			if (Agent.Tracer.CurrentTransaction == null) return;
+
+			builder.Append(Agent.Tracer.CurrentTransaction.Id);
+		}
+	}
+}

--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.5.4" />
+    <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -2,6 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Title>Elastic APM NLog LayourRendrers</Title>
+    <Description>Inject APM TraceId and TransactionId automatically into your NLog logs</Description>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.5.4" />

--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/src/ecs-dotnet.sln
+++ b/src/ecs-dotnet.sln
@@ -40,6 +40,12 @@ ProjectSection(SolutionItems) = preProject
 	PublishArtifacts.build.props = PublishArtifacts.build.props
 EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.NLog", "Elastic.Apm.NLog\Elastic.Apm.NLog.csproj", "{A1DEDE4E-0876-41E8-8DF0-8F85EAF3FAFA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.NLog.Test", "..\tests\Elastic.Apm.NLog.Test\Elastic.Apm.NLog.Test.csproj", "{4755093F-5A27-4EF4-BC7F-DB8676E9B81A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.Test.Common", "..\tests\Elastic.Apm.Test.Common\Elastic.Apm.Test.Common.csproj", "{4E0D951B-FEC5-4043-913A-BED795892405}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +86,18 @@ Global
 		{4779DD6F-AE49-4A80-9F67-D9F2DB05E557}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4779DD6F-AE49-4A80-9F67-D9F2DB05E557}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4779DD6F-AE49-4A80-9F67-D9F2DB05E557}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1DEDE4E-0876-41E8-8DF0-8F85EAF3FAFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1DEDE4E-0876-41E8-8DF0-8F85EAF3FAFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1DEDE4E-0876-41E8-8DF0-8F85EAF3FAFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1DEDE4E-0876-41E8-8DF0-8F85EAF3FAFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4755093F-5A27-4EF4-BC7F-DB8676E9B81A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4755093F-5A27-4EF4-BC7F-DB8676E9B81A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4755093F-5A27-4EF4-BC7F-DB8676E9B81A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4755093F-5A27-4EF4-BC7F-DB8676E9B81A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E0D951B-FEC5-4043-913A-BED795892405}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E0D951B-FEC5-4043-913A-BED795892405}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E0D951B-FEC5-4043-913A-BED795892405}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E0D951B-FEC5-4043-913A-BED795892405}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{21FD7B39-5FDD-4432-B25E-8425D3EC46A3} = {432D5575-2347-4D3C-BF8C-3E38410C46CA}

--- a/tests/Elastic.Apm.NLog.Test/Elastic.Apm.NLog.Test.csproj
+++ b/tests/Elastic.Apm.NLog.Test/Elastic.Apm.NLog.Test.csproj
@@ -1,25 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+    </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Elastic.Apm" Version="1.2.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.3.0" />
+    <PackageReference Include="NLog" Version="4.6.4" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.Apm.SerilogEnricher\Elastic.Apm.SerilogEnricher.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Apm.NLog\Elastic.Apm.NLog.csproj" />
     <ProjectReference Include="..\Elastic.Apm.Test.Common\Elastic.Apm.Test.Common.csproj" />
   </ItemGroup>
-  
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
 
 </Project>

--- a/tests/Elastic.Apm.NLog.Test/NLogTests.cs
+++ b/tests/Elastic.Apm.NLog.Test/NLogTests.cs
@@ -1,0 +1,50 @@
+﻿using Elastic.Apm.Test.Common;
+using FluentAssertions;
+using NLog;
+using NLog.Targets;
+using Xunit;
+
+namespace Elastic.Apm.NLog.Test
+{
+	public class NLogTests
+	{
+		/// <summary>
+		/// Creates 1 simple transaction and makes sure that the log line created within the transaction has
+		/// the transaction and trace ids, and logs prior to and after the transaction do not have those.
+		/// </summary>
+		[Fact]
+		public void NLogWithTransaction()
+		{
+			var assembly = typeof(ApmTraceIdLayoutRenderer).Assembly;
+			global::NLog.Config.ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
+			Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender()));
+
+			var target = new MemoryTarget();
+			target.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}";
+
+			global::NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Debug);
+
+			var logger = LogManager.GetLogger("Example");
+
+			logger.Debug("PreTransaction");
+
+			string traceId = null;
+			string transactionId = null;
+
+			Agent.Tracer.CaptureTransaction("TestTransaction", "Test", t =>
+			{
+				traceId = t.TraceId;
+				transactionId = t.Id;
+				logger.Debug("InTransaction");
+			});
+
+			logger.Debug("PostTransaction");
+
+			target.Logs.Count.Should().Be(3);
+
+			target.Logs[0].Should().Be("||PreTransaction");
+			target.Logs[1].Should().Be($"{traceId}|{transactionId}|InTransaction");
+			target.Logs[2].Should().Be("||PostTransaction");
+		}
+	}
+}

--- a/tests/Elastic.Apm.SerilogEnricher.Test/SerilogTests.cs
+++ b/tests/Elastic.Apm.SerilogEnricher.Test/SerilogTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
-using Elastic.Apm.Report;
+using Elastic.Apm.Test.Common;
 using FluentAssertions;
 using Serilog;
 using Serilog.Sinks.InMemory;
@@ -152,16 +152,5 @@ namespace Elastic.Apm.SerilogEnricher.Test
 		}
 
 		public void Dispose() => InMemorySink.Instance.Dispose();
-	}
-
-	internal class NoopPayloadSender : IPayloadSender
-	{
-		public void QueueError(IError error) { }
-
-		public void QueueMetrics(IMetricSet metrics) { }
-
-		public void QueueSpan(ISpan span) { }
-
-		public void QueueTransaction(ITransaction transaction) { }
 	}
 }

--- a/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
+++ b/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
+++ b/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Elastic.Apm" Version="1.2.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Elastic.Apm.Test.Common/NoopPayloadSender.cs
+++ b/tests/Elastic.Apm.Test.Common/NoopPayloadSender.cs
@@ -1,0 +1,16 @@
+﻿using Elastic.Apm.Api;
+using Elastic.Apm.Report;
+
+namespace Elastic.Apm.Test.Common
+{
+	public class NoopPayloadSender : IPayloadSender
+	{
+		public void QueueError(IError error) { }
+
+		public void QueueMetrics(IMetricSet metrics) { }
+
+		public void QueueSpan(ISpan span) { }
+
+		public void QueueTransaction(ITransaction transaction) { }
+	}
+}


### PR DESCRIPTION
From https://github.com/elastic/apm-agent-dotnet/issues/244

Based on this discussion: https://github.com/NLog/NLog/issues/3726 

I gave up on Log4Net for now, details: https://github.com/elastic/apm-agent-dotnet/issues/662  

So, my current plan is that we'll offer APM log correlation integration for NLog and Serilog.