### PR TITLE
Fix pre-release package references

### DIFF
--- a/build/scripts/Releasing.fs
+++ b/build/scripts/Releasing.fs
@@ -6,11 +6,20 @@ module Release =
     
     let NugetPack (ArtifactsVersion(version)) = 
     
-        Tooling.DotNet.ExecIn "src" [ "pack"; 
-            "-c"; "Release";
-             (sprintf "-p:Version=%s" <| version.Full.ToString()); 
-             (sprintf "-p:CurrentVersion=%s" <| version.Full.ToString()); 
-             (sprintf "-p:CurrentAssemblyVersion=%s" <| version.Assembly.ToString()); 
-             (sprintf "-p:CurrentAssemblyFileVersion=%s" <| version.AssemblyFile.ToString()); 
-             "--output"; (sprintf "../%s" <| Paths.BuildOutput)
-        ] |> ignore
+        [|
+           "Elastic.Apm.NLog";
+           "Elastic.Apm.SerilogEnricher";
+           "Elastic.CommonSchema";
+           "Elastic.CommonSchema.BenchmarkDotNetExporter";
+           "Elastic.CommonSchema.Serilog";
+        |]
+            |> Seq.iter(fun project -> Tooling.DotNet.ExecIn (sprintf "src/%s" <| project) [ "pack"; 
+                "-c"; "Release";
+                 (sprintf "-p:Version=%s" <| version.Full.ToString()); 
+                 (sprintf "-p:CurrentVersion=%s" <| version.Full.ToString()); 
+                 (sprintf "-p:CurrentAssemblyVersion=%s" <| version.Assembly.ToString()); 
+                 (sprintf "-p:CurrentAssemblyFileVersion=%s" <| version.AssemblyFile.ToString()); 
+                 (sprintf "-p:NuspecFile=package.nuspec"); 
+                 (sprintf "-p:NuspecProperties=Version=%s" <| version.Full.ToString()); 
+                 "--output"; (sprintf "../../%s" <| Paths.BuildOutput)
+            ]) |> ignore

--- a/build/scripts/Versioning.fs
+++ b/build/scripts/Versioning.fs
@@ -131,7 +131,7 @@ module Versioning =
     let private validateDllStrongName dll name =
         match File.Exists dll with
         | true -> validate dll name 
-        | _ -> failwithf "Attemped to verify signature of %s but it was not found!" dll
+        | _ -> failwithf "Attempted to verify signature of %s but it was not found!" dll
 
     let ValidateArtifacts (ArtifactsVersion(version)) =
         let fileVersion = version.AssemblyFile

--- a/src/Elastic.Apm.NLog/package.nuspec
+++ b/src/Elastic.Apm.NLog/package.nuspec
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Elastic.Apm.NLog</id>
+    <version>$Version$</version>
+    <title>Elastic APM NLog Layout Renderers</title>
+    <authors>Elastic and contributors</authors>
+    <owners>Elastic and contributors</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <icon>nuget-icon.png</icon>
+    <projectUrl>https://github.com/elastic/ecs-dotnet</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/elastic/ecs-dotnet/master/build/nuget-icon.png</iconUrl>
+    <description>Enrich NLog logs with APM TraceId and TransactionId.</description>
+    <copyright>Elasticsearch BV</copyright>
+    <repository type="git" url="https://github.com/elastic/ecs-dotnet.git" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Elastic.Apm" version="1.2.0" exclude="Build,Analyzers" />
+        <dependency id="NLog" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\netstandard2.0\Elastic.Apm.NLog.pdb" target="lib\netstandard2.0\Elastic.Apm.NLog.pdb" />
+    <file src="bin\Release\netstandard2.0\Elastic.Apm.NLog.dll" target="lib\netstandard2.0\Elastic.Apm.NLog.dll" />
+    <file src="bin\Release\netstandard2.0\Elastic.Apm.NLog.xml" target="lib\netstandard2.0\Elastic.Apm.NLog.xml" />
+    <file src="..\..\build\nuget-icon.png" target="nuget-icon.png" />
+    <file src="..\..\license.txt" target="license.txt" />
+  </files>
+</package>

--- a/src/Elastic.Apm.SerilogEnricher/package.nuspec
+++ b/src/Elastic.Apm.SerilogEnricher/package.nuspec
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Elastic.Apm.SerilogEnricher</id>
+    <version>$Version$</version>
+    <title>Elastic APM Serilog Enricher</title>
+    <authors>Elastic and contributors</authors>
+    <owners>Elastic and contributors</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <icon>nuget-icon.png</icon>
+    <projectUrl>https://github.com/elastic/ecs-dotnet</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/elastic/ecs-dotnet/master/build/nuget-icon.png</iconUrl>
+    <description>Enrich Serilog logs with APM TraceId and TransactionId.</description>
+    <copyright>Elasticsearch BV</copyright>
+    <repository type="git" url="https://github.com/elastic/ecs-dotnet.git" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="Elastic.Apm" version="1.2.0" exclude="Build,Analyzers" />
+        <dependency id="Serilog" version="2.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Elastic.Apm" version="1.2.0" exclude="Build,Analyzers" />
+        <dependency id="Serilog" version="2.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\net461\Elastic.Apm.SerilogEnricher.pdb" target="lib\net461\Elastic.Apm.SerilogEnricher.pdb" />
+    <file src="bin\Release\netstandard2.0\Elastic.Apm.SerilogEnricher.pdb" target="lib\netstandard2.0\Elastic.Apm.SerilogEnricher.pdb" />
+    <file src="bin\Release\net461\Elastic.Apm.SerilogEnricher.dll" target="lib\net461\Elastic.Apm.SerilogEnricher.dll" />
+    <file src="bin\Release\net461\Elastic.Apm.SerilogEnricher.xml" target="lib\net461\Elastic.Apm.SerilogEnricher.xml" />
+    <file src="bin\Release\netstandard2.0\Elastic.Apm.SerilogEnricher.dll" target="lib\netstandard2.0\Elastic.Apm.SerilogEnricher.dll" />
+    <file src="bin\Release\netstandard2.0\Elastic.Apm.SerilogEnricher.xml" target="lib\netstandard2.0\Elastic.Apm.SerilogEnricher.xml" />
+    <file src="..\..\build\nuget-icon.png" target="nuget-icon.png" />
+    <file src="..\..\license.txt" target="license.txt" />
+  </files>
+</package>

--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/package.nuspec
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/package.nuspec
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Elastic.CommonSchema.BenchmarkDotNetExporter</id>
+    <version>$Version$</version>
+    <title>Elastic Common Schema (ECS) BencharkDotNet exporter</title>
+    <authors>Elastic and contributors</authors>
+    <owners>Elastic and contributors</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <icon>nuget-icon.png</icon>
+    <projectUrl>https://github.com/elastic/ecs-dotnet</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/elastic/ecs-dotnet/master/build/nuget-icon.png</iconUrl>
+    <description>Exports BenchmarkDotNet benchmarks to Elastic Common Schema (ECS) format</description>
+    <copyright>Elasticsearch BV</copyright>
+    <repository type="git" url="https://github.com/elastic/ecs-dotnet.git" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="Elastic.CommonSchema" version="1.4.0" exclude="Build,Analyzers" />
+        <dependency id="BenchmarkDotNet" version="0.12.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Elastic.CommonSchema" version="1.4.0" exclude="Build,Analyzers" />
+        <dependency id="BenchmarkDotNet" version="0.12.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="Elastic.CommonSchema" version="1.4.0" exclude="Build,Analyzers" />
+        <dependency id="BenchmarkDotNet" version="0.12.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\net461\Elastic.CommonSchema.BenchmarkDotNetExporter.pdb" target="lib\net461\Elastic.CommonSchema.BenchmarkDotNetExporter.pdb" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.BenchmarkDotNetExporter.pdb" target="lib\netstandard2.0\Elastic.CommonSchema.BenchmarkDotNetExporter.pdb" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.BenchmarkDotNetExporter.pdb" target="lib\netstandard2.1\Elastic.CommonSchema.BenchmarkDotNetExporter.pdb" />
+    <file src="bin\Release\net461\Elastic.CommonSchema.BenchmarkDotNetExporter.dll" target="lib\net461\Elastic.CommonSchema.BenchmarkDotNetExporter.dll" />
+    <file src="bin\Release\net461\Elastic.CommonSchema.BenchmarkDotNetExporter.xml" target="lib\net461\Elastic.CommonSchema.BenchmarkDotNetExporter.xml" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.BenchmarkDotNetExporter.dll" target="lib\netstandard2.0\Elastic.CommonSchema.BenchmarkDotNetExporter.dll" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.BenchmarkDotNetExporter.xml" target="lib\netstandard2.0\Elastic.CommonSchema.BenchmarkDotNetExporter.xml" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.BenchmarkDotNetExporter.dll" target="lib\netstandard2.1\Elastic.CommonSchema.BenchmarkDotNetExporter.dll" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.BenchmarkDotNetExporter.xml" target="lib\netstandard2.1\Elastic.CommonSchema.BenchmarkDotNetExporter.xml" />
+    <file src="..\..\build\nuget-icon.png" target="nuget-icon.png" />
+    <file src="..\..\license.txt" target="license.txt" />
+  </files>
+</package>

--- a/src/Elastic.CommonSchema.Serilog/package.nuspec
+++ b/src/Elastic.CommonSchema.Serilog/package.nuspec
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Elastic.CommonSchema.Serilog</id>
+    <version>$Version$</version>
+    <title>Elastic Common Schema (ECS) Serilog Formatter</title>
+    <authors>Elastic and contributors</authors>
+    <owners>Elastic and contributors</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <icon>nuget-icon.png</icon>
+    <projectUrl>https://github.com/elastic/ecs-dotnet</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/elastic/ecs-dotnet/master/build/nuget-icon.png</iconUrl>
+    <description>Serilog TextFormatter that emits Elastic Common Schema (ECS) JSON.</description>
+    <copyright>Elasticsearch BV</copyright>
+    <repository type="git" url="https://github.com/elastic/ecs-dotnet.git" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="Elastic.CommonSchema" version="1.4.0" exclude="Build,Analyzers" />
+        <dependency id="Serilog" version="2.9.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Elastic.CommonSchema" version="1.4.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="2.2.0" exclude="Build,Analyzers" />
+        <dependency id="Serilog" version="2.9.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="Elastic.CommonSchema" version="1.4.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="2.2.0" exclude="Build,Analyzers" />
+        <dependency id="Serilog" version="2.9.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Web" targetFramework=".NETFramework4.6.1" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="bin\Release\net461\Elastic.CommonSchema.Serilog.pdb" target="lib\net461\Elastic.CommonSchema.Serilog.pdb" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.Serilog.pdb" target="lib\netstandard2.0\Elastic.CommonSchema.Serilog.pdb" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.Serilog.pdb" target="lib\netstandard2.1\Elastic.CommonSchema.Serilog.pdb" />
+    <file src="bin\Release\net461\Elastic.CommonSchema.Serilog.dll" target="lib\net461\Elastic.CommonSchema.Serilog.dll" />
+    <file src="bin\Release\net461\Elastic.CommonSchema.Serilog.xml" target="lib\net461\Elastic.CommonSchema.Serilog.xml" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.Serilog.dll" target="lib\netstandard2.0\Elastic.CommonSchema.Serilog.dll" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.Serilog.xml" target="lib\netstandard2.0\Elastic.CommonSchema.Serilog.xml" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.Serilog.dll" target="lib\netstandard2.1\Elastic.CommonSchema.Serilog.dll" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.Serilog.xml" target="lib\netstandard2.1\Elastic.CommonSchema.Serilog.xml" />
+    <file src="..\..\build\nuget-icon.png" target="nuget-icon.png" />
+    <file src="..\..\license.txt" target="license.txt" />
+  </files>
+</package>

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- TODO do we care to ilmerge this? -->
-    <PackageReference Include="System.Text.Json" Version="4.7.0-preview3.19551.4"/>
+    <PackageReference Include="System.Text.Json" Version="4.7.*"/>
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema/package.nuspec
+++ b/src/Elastic.CommonSchema/package.nuspec
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Elastic.CommonSchema</id>
+    <version>$Version$</version>
+    <title>Elastic Common Schema (ECS) Types</title>
+    <authors>Elastic and contributors</authors>
+    <owners>Elastic and contributors</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <icon>nuget-icon.png</icon>
+    <projectUrl>https://github.com/elastic/ecs-dotnet</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/elastic/ecs-dotnet/master/build/nuget-icon.png</iconUrl>
+    <description>Maps Elastic Common Schema (ECS) to .NET types including (de)serialization using System.Text.Json</description>
+    <copyright>Elasticsearch BV</copyright>
+    <repository type="git" url="https://github.com/elastic/ecs-dotnet.git" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Text.Json" version="4.7.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Text.Json" version="4.7.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="System.Text.Json" version="4.7.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\net461\Elastic.CommonSchema.pdb" target="lib\net461\Elastic.CommonSchema.pdb" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.pdb" target="lib\netstandard2.0\Elastic.CommonSchema.pdb" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.pdb" target="lib\netstandard2.1\Elastic.CommonSchema.pdb" />
+    <file src="bin\Release\net461\Elastic.CommonSchema.dll" target="lib\net461\Elastic.CommonSchema.dll" />
+    <file src="bin\Release\net461\Elastic.CommonSchema.xml" target="lib\net461\Elastic.CommonSchema.xml" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.dll" target="lib\netstandard2.0\Elastic.CommonSchema.dll" />
+    <file src="bin\Release\netstandard2.0\Elastic.CommonSchema.xml" target="lib\netstandard2.0\Elastic.CommonSchema.xml" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.dll" target="lib\netstandard2.1\Elastic.CommonSchema.dll" />
+    <file src="bin\Release\netstandard2.1\Elastic.CommonSchema.xml" target="lib\netstandard2.1\Elastic.CommonSchema.xml" />
+    <file src="..\..\build\nuget-icon.png" target="nuget-icon.png" />
+    <file src="..\..\license.txt" target="license.txt" />
+  </files>
+</package>


### PR DESCRIPTION
It does not appear possible to specify an alternate nuspec dependancy version for `dotnet pack`, such that the pre-release dependancy is replaced with a stable version.

This commit modifies the build process to use `nuspec` files that offer finer control over the dependancy versions.