### PR TITLE
Elastic.CommonSchema.BenchmarkDotNetExporter assembly has a private asset reference to the client.

### DIFF
--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Elastic.CommonSchema.BenchmarkDotNetExporter.csproj
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Elastic.CommonSchema.BenchmarkDotNetExporter.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.5.0" PrivateAssets="all" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR removes the `PrivateAssets="all"` attribute so that the client reference flows to the project.

Fixes #41.