### PR TITLE
EcsTextFormatter should write lines to the textwriter to ensure log lines are seperated

### DIFF
--- a/src/Elastic.CommonSchema.Serilog/EcsTextFormatter.cs
+++ b/src/Elastic.CommonSchema.Serilog/EcsTextFormatter.cs
@@ -29,9 +29,8 @@ namespace Elastic.CommonSchema.Serilog
 			else
 			{
 				var bytes = ecsEvent.SerializeToUtf8Bytes();
-				output.Write(Encoding.UTF8.GetString(bytes));
+				output.WriteLine(Encoding.UTF8.GetString(bytes));
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
Fixes #46