### PR TITLE
Increase Elastic.Apm dependency to 1.4.0

### DIFF
--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -14,6 +14,6 @@
       a lower NLog version
     -->
     <PackageReference Include="NLog" Version="4.5.4" />
-    <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm.SerilogEnricher/Elastic.Apm.SerilogEnricher.csproj
+++ b/src/Elastic.Apm.SerilogEnricher/Elastic.Apm.SerilogEnricher.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.0.0"/>
-    <PackageReference Include="Elastic.Apm" Version="1.2.0"/>
+    <PackageReference Include="Elastic.Apm" Version="1.4.0"/>
   </ItemGroup>
 </Project>

--- a/tests/Elastic.Apm.NLog.Test/Elastic.Apm.NLog.Test.csproj
+++ b/tests/Elastic.Apm.NLog.Test/Elastic.Apm.NLog.Test.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.4.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
+++ b/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.4.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.15" />
   </ItemGroup>
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="xunit.NLog" Version="1.1.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
-        <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+        <PackageReference Include="Elastic.Apm" Version="1.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
-        <PackageReference Include="Elastic.Apm" Version="1.2.0" />
+        <PackageReference Include="Elastic.Apm" Version="1.4.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Solves #61.

With this by default we'll have a version out which contains a fix to https://github.com/elastic/ecs-dotnet/issues/58. 