### PR TITLE
NLog Ecs Layout event Enrichment

### DIFF
--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -86,10 +86,11 @@ namespace Elastic.CommonSchema.NLog
 		public Layout ServerAddress { get; set; }
 		public Layout ServerIp { get; set; }
 		public Layout ServerUser { get; set; }
+
 		/// <summary>
-        /// Optional action to enrich the constructed <see cref="Base">EcsEvent</see> before it is serialized
-        /// </summary>
-        /// <remarks>This is called last in the chain of enrichment functions</remarks>
+		/// Optional action to enrich the constructed <see cref="Base">EcsEvent</see> before it is serialized
+		/// </summary>
+		/// <remarks>This is called last in the chain of enrichment functions</remarks>
 		public Action<Base,LogEventInfo> EnrichAction { get; set; }
 
 		[ArrayParameter(typeof(TargetPropertyWithContext), "tag")]
@@ -124,12 +125,12 @@ namespace Elastic.CommonSchema.NLog
 		}
 
 		/// <summary>
-        /// Override to supplement the ECS event parsing
-        /// </summary>
-        /// <param name="logEventInfo">The original log event</param>
-        /// <param name="ecsEvent">The EcsEvent to modify</param>
-        /// <returns>Enriched ECS Event</returns>
-        /// <remarks>Destructive for performance</remarks>
+		/// Override to supplement the ECS event parsing
+		/// </summary>
+		/// <param name="logEventInfo">The original log event</param>
+		/// <param name="ecsEvent">The EcsEvent to modify</param>
+		/// <returns>Enriched ECS Event</returns>
+		/// <remarks>Destructive for performance</remarks>
 		protected virtual void EnrichEvent(LogEventInfo logEventInfo,ref Base ecsEvent)
 		{
 		}

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -91,6 +91,11 @@ namespace Elastic.CommonSchema.NLog
 		public Layout ServerAddress { get; set; }
 		public Layout ServerIp { get; set; }
 		public Layout ServerUser { get; set; }
+		/// <summary>
+        /// Optional action to enrich the constructed <see cref="Base">EcsEvent</see> before it is serialized
+        /// </summary>
+        /// <remarks>This is called last in the chain of enrichment functions</remarks>
+		public Action<Base,LogEventInfo> EnrichAction { get; set; }
 
 		[ArrayParameter(typeof(TargetPropertyWithContext), "tag")]
 		public IList<TargetPropertyWithContext> Tags { get; } = new List<TargetPropertyWithContext>();
@@ -115,9 +120,23 @@ namespace Elastic.CommonSchema.NLog
 				Server = GetServer(logEventInfo),
 				Host = GetHost(logEventInfo)
 			};
-
+			//Give any deriving classes a chance to enrich the event
+			EnrichEvent(logEventInfo,ref ecsEvent);
+			//Allow programmatical actions to enrich before serializing
+			EnrichAction?.Invoke(ecsEvent, logEventInfo);
 			var output = ecsEvent.Serialize();
 			target.Append(output);
+		}
+
+		/// <summary>
+        /// Override to supplement the ECS event parsing
+        /// </summary>
+        /// <param name="logEventInfo">The original log event</param>
+        /// <param name="ecsEvent">The EcsEvent to modify</param>
+        /// <returns>Enriched ECS Event</returns>
+        /// <remarks>Destructive for performance</remarks>
+		protected virtual void EnrichEvent(LogEventInfo logEventInfo,ref Base ecsEvent)
+		{
 		}
 
 		protected override string GetFormattedMessage(LogEventInfo logEvent)


### PR DESCRIPTION
This PR allows for both programmatical and derivational enrichment of NLog ecs events before they are serialized.

Example:
`var tt = new EcsLayout()
{
	EnrichAction = (ecsEvent,logEvent) =>
	{
		if (ecsEvent.Event != null)
			ecsEvent.Event.Dataset = "someValue";
	}
}`

Or deriving a class from NLog.EcsLayout and overriding the EnrichEvent function.

Both ways are not needed but at least one is. Otherwise a class can't event be derived from [EcsLayout ](https://github.com/elastic/ecs-dotnet/blob/bbc0ff2cd25219e58b2f27956495e2bb8f314277/src/Elastic.CommonSchema.NLog/EcsLayout.cs#L20) and override the [RenderFormattedMessage ](https://github.com/elastic/ecs-dotnet/blob/bbc0ff2cd25219e58b2f27956495e2bb8f314277/src/Elastic.CommonSchema.NLog/EcsLayout.cs#L98) function because all of the called Get* functions are marked as private (so they too would have to be cloned). The only option, would be to derive, override the RenderFormattedMessage function, call the base implementation with a clean stringbuilder, deserialize the return, make changes, and reserialize... Which would just be silly...