### PR TITLE
NLog EcsLayout - Write directly to StringBuilder instead of string allocation

### DIFF
--- a/src/Elastic.CommonSchema.NLog/ReusableUtf8JsonWriter.cs
+++ b/src/Elastic.CommonSchema.NLog/ReusableUtf8JsonWriter.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace Elastic.CommonSchema.NLog
+{
+	internal sealed class ReusableUtf8JsonWriter
+	{
+		private Utf8JsonWriter _cachedJsonWriter;
+		private readonly System.IO.MemoryStream _cachedMemoryStream;
+		private readonly char[] _cachedEncodingBuffer;
+
+		public ReusableUtf8JsonWriter()
+		{
+			_cachedMemoryStream = new System.IO.MemoryStream(4 * 1024);
+			_cachedJsonWriter = new Utf8JsonWriter(_cachedMemoryStream);
+			_cachedEncodingBuffer = new char[1024];
+		}
+
+		public ReusableJsonWriter AllocateJsonWriter(StringBuilder text)
+		{
+			var writer = System.Threading.Interlocked.Exchange(ref _cachedJsonWriter, null);
+			return new ReusableJsonWriter(this, writer, text);
+		}
+
+		private void Return(Utf8JsonWriter writer, StringBuilder output)
+		{
+			writer.Flush();
+
+			if (_cachedMemoryStream.Length > 0)
+			{
+				if (!_cachedMemoryStream.TryGetBuffer(out var byteArray))
+					byteArray = new ArraySegment<byte>(_cachedMemoryStream.GetBuffer(), 0, (int)_cachedMemoryStream.Length);
+
+				CopyToStringBuilder(byteArray, _cachedEncodingBuffer, output);
+			}
+
+			writer.Reset();
+			_cachedMemoryStream.Position = 0;
+			_cachedMemoryStream.SetLength(0);
+			System.Threading.Interlocked.Exchange(ref _cachedJsonWriter, writer);
+		}
+
+		private static void CopyToStringBuilder(ArraySegment<byte> byteArray, char[] encodingBuffer, StringBuilder output)
+		{
+			var utf8encoder = Encoding.UTF8;
+			var byteCount = 0;
+			var charCount = 0;
+			for (int i = 0; i < byteArray.Count; i += encodingBuffer.Length)
+			{
+				byteCount = Math.Min(byteArray.Count - i, encodingBuffer.Length);
+				charCount = utf8encoder.GetChars(byteArray.Array, byteArray.Offset + i, byteCount, encodingBuffer, 0);
+				output.Append(encodingBuffer, 0, charCount);
+			}
+		}
+
+		internal struct ReusableJsonWriter : IDisposable
+		{
+			private readonly ReusableUtf8JsonWriter _owner;
+			private readonly Utf8JsonWriter _writer;
+			private readonly StringBuilder _output;
+
+			public ReusableJsonWriter(ReusableUtf8JsonWriter owner, Utf8JsonWriter writer, StringBuilder output)
+			{
+				_writer = writer;
+				_owner = writer != null ? owner : null;
+				_output = output;
+			}
+
+			public void Serialize(Base ecsEvent)
+			{
+				if (_writer != null)
+				{
+					ecsEvent.Serialize(_writer);
+				}
+				else
+				{
+					var result = ecsEvent.Serialize();
+					_output.Append(result);
+				}
+			}
+
+			public void Dispose()
+			{
+				if (_owner != null)
+				{
+					_owner.Return(_writer, _output);
+				}
+			}
+		}
+	}
+}

--- a/src/Elastic.CommonSchema/Base.Serialization.cs
+++ b/src/Elastic.CommonSchema/Base.Serialization.cs
@@ -106,6 +106,8 @@ namespace Elastic.CommonSchema
 			JsonSerializer.Serialize(writer, this, JsonConfiguration.SerializerOptions);
 		}
 
+		public void Serialize(Utf8JsonWriter writer) => JsonSerializer.Serialize(writer, this, JsonConfiguration.SerializerOptions);
+
 		public Task SerializeAsync(Stream stream, CancellationToken ctx = default) =>
 			JsonSerializer.SerializeAsync(stream, this, GetType(), SerializerOptions, ctx);
 	}

--- a/tests/Elastic.CommonSchema.NLog.Tests/LogTestsBase.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/LogTestsBase.cs
@@ -48,6 +48,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 
 			var loggingConfiguration = new Config.LoggingConfiguration();
 			loggingConfiguration.AddRule(LogLevel.Trace, LogLevel.Fatal, memoryTarget);
+			loggingConfiguration.DefaultCultureInfo = System.Globalization.CultureInfo.InvariantCulture;
 
 			var factory = new LogFactory(loggingConfiguration);
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/OutputTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/OutputTests.cs
@@ -17,7 +17,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 		{
 			logger.Info("My log message!");
 			logger.Info("Test output to NLog!");
-			Action sketchy = () => throw new Exception("I threw up.");
+			void sketchy() => throw new Exception("I threw up.");
 			var exception = Record.Exception(sketchy);
 			logger.Error(exception, "Here is an error.");
 			Assert.NotNull(exception);


### PR DESCRIPTION
Also recycles the same Utf8JsonWriter when possible (It is intended to be reused see also [Utf8JsonWriter.Reset](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.utf8jsonwriter.reset))