### PR TITLE
Microsoft.AspNetCore.Http.Abstractions ver. 2.1.0 has LTS

### DIFF
--- a/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
+++ b/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
@@ -10,8 +10,6 @@
       <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
     </ItemGroup>
     <ItemGroup>
-    <PackageReference Include="NLog" Version="4.5.4" />
-        <PackageReference Condition="$(DefineConstants.Contains(NETSTANDARD))" Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0.0" />
-        <Reference Condition="$(DefineConstants.Contains(FULLFRAMEWORK))" Include="System.Web" />
+      <PackageReference Include="NLog" Version="4.5.4" />
     </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.Serilog/Elastic.CommonSchema.Serilog.csproj
+++ b/src/Elastic.CommonSchema.Serilog/Elastic.CommonSchema.Serilog.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Serilog" Version="2.9.0.0" />
-        <PackageReference Condition="$(DefineConstants.Contains(NETSTANDARD))" Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0.0" />
+        <PackageReference Condition="$(DefineConstants.Contains(NETSTANDARD))" Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0.0" />
         <Reference Condition="$(DefineConstants.Contains(FULLFRAMEWORK))" Include="System.Web" />
     </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -9,12 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Serilog.Events;
-#if NETSTANDARD
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Abstractions;
-#else
-
-#endif
 
 namespace Elastic.CommonSchema.Serilog
 {


### PR DESCRIPTION
NetCore 2.1 has Long-Term-Support (LTS). Resolves #72