### PR TITLE
NLog EcsLayout - Added support for Log Origin

### DIFF
--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -155,7 +155,7 @@ namespace Elastic.CommonSchema.NLog
 				{
 					Message = exception.Message,
 					StackTrace = CatchError(exception),
-					Code = exception.GetType().ToString()
+					Type = exception.GetType().ToString(),
 				}
 				: null;
 

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -27,6 +27,9 @@ namespace Elastic.CommonSchema.NLog
 		{
 			IncludeAllProperties = true;
 
+			LogOriginCallSiteMethod = "${exception:format=method}";
+			LogOriginCallSiteFile = "${exception:format=source}";
+
 			ProcessId = "${processid}";
 			ProcessName = "${processname:FullName=false}";
 			ProcessExecutable = "${processname:FullName=true}";
@@ -56,6 +59,10 @@ namespace Elastic.CommonSchema.NLog
 		/// ensure correct async context capture when necessary
 		/// </summary>
 		public Layout DisableThreadAgnostic => IncludeMdlc ? _disableThreadAgnostic : null;
+
+		public Layout LogOriginCallSiteMethod { get; set; }
+		public Layout LogOriginCallSiteFile { get; set; }
+		public Layout LogOriginCallSiteLine { get; set; }
 
 		public Layout EventAction { get; set; }
 		public Layout EventCategory { get; set; }
@@ -227,16 +234,39 @@ namespace Elastic.CommonSchema.NLog
 				: null;
 		}
 
-		private static Log GetLog(LogEventInfo logEventInfo)
+		private Log GetLog(LogEventInfo logEventInfo)
 		{
+			var logOriginMethod = LogOriginCallSiteMethod?.Render(logEventInfo);
+			var logOriginSourceFile = LogOriginCallSiteFile?.Render(logEventInfo);
+			var logOriginSourceLine = LogOriginCallSiteLine?.Render(logEventInfo);
+			var logOriginSourceLineNo = ParseLogOriginCallSiteLineNo(logOriginSourceLine);
+
+			var originFile = (!string.IsNullOrEmpty(logOriginSourceFile) || logOriginSourceLineNo.HasValue) ?
+				new OriginFile() { Line = logOriginSourceLineNo, Name = logOriginSourceFile } : null;
+
+			var origin = (originFile != null || !string.IsNullOrEmpty(logOriginMethod)) ?
+				new LogOrigin() { Function = logOriginMethod, File = originFile } : null;
+
 			var log = new Log
 			{
 				Level = logEventInfo.Level.ToString(),
 				Logger = logEventInfo.LoggerName,
-				Original = logEventInfo.Message
+				Original = logEventInfo.Message,
+				Origin = origin,
 			};
 
 			return log;
+		}
+
+		private int? ParseLogOriginCallSiteLineNo(string logOriginSourceLine)
+		{
+			if (string.IsNullOrEmpty(logOriginSourceLine))
+				return null;
+
+			if (int.TryParse(logOriginSourceLine, out var logOriginSourceLineNo))
+				return logOriginSourceLineNo;
+
+			return 0;
 		}
 
 		private string[] GetTags(LogEventInfo e)

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -274,7 +274,7 @@ namespace Elastic.CommonSchema.Serilog
 
 		private static Error GetError(IReadOnlyList<Exception> exceptions) =>
 			exceptions != null && exceptions.Count > 0
-				? new Error { Message = exceptions[0].Message, StackTrace = CatchErrors(exceptions), Code = exceptions[0].GetType().ToString() }
+				? new Error { Message = exceptions[0].Message, StackTrace = CatchErrors(exceptions), Type = exceptions[0].GetType().ToString() }
 				: null;
 
 		private static Event GetEvent(LogEvent e)

--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="FluentAssertions" Version="5.9.0" />
         <PackageReference Include="JunitXml.TestLogger" Version="2.1.15" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-        <PackageReference Include="NLog" Version="4.5.4" />
+        <PackageReference Include="NLog" Version="4.5.11" />
         <PackageReference Include="NLog.Config" Version="4.5.4" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.NLog" Version="1.1.1" />


### PR DESCRIPTION
So you can do this:

```xml
<layout type="EcsLayout"
    logOriginCallSiteMethod="${callsite}"
    logOriginCallSiteFile="${callsite-filename}"
    logOriginCallSiteLine="${callsite-linenumber}"
 />
```

See also: https://github.com/NLog/NLog/wiki/Callsite-Layout-Renderer

Trying to fix one item from #77