### PR TITLE
add benchmarks for simple serialization cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ project.lock.json
 *.sln.iml
 /src/.vs/restore.dg
 src/packages/
+BenchmarkDotNet.Artifacts

--- a/src/ecs-dotnet.sln
+++ b/src/ecs-dotnet.sln
@@ -64,6 +64,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspnetCoreExample", "..\exa
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "aspnetcore-with-serilog", "aspnetcore-with-serilog", "{9F103D76-F7FA-4D10-8214-6E79C28D5AEC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.CommonSchema.Benchmarks", "..\tests\Elastic.CommonSchema.Benchmarks\Elastic.CommonSchema.Benchmarks.csproj", "{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -140,6 +142,10 @@ Global
 		{03FD4BFA-F9A5-4C16-ACA1-30FD060DFAEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{03FD4BFA-F9A5-4C16-ACA1-30FD060DFAEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{03FD4BFA-F9A5-4C16-ACA1-30FD060DFAEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -164,6 +170,7 @@ Global
 		{89ADA999-1A1D-4B51-8CEE-39A553F669D1} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 		{9F103D76-F7FA-4D10-8214-6E79C28D5AEC} = {05075402-8669-45BD-913A-BD40A29BBEAB}
 		{03FD4BFA-F9A5-4C16-ACA1-30FD060DFAEA} = {9F103D76-F7FA-4D10-8214-6E79C28D5AEC}
+		{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
+++ b/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="AutoBogus" Version="2.8.2" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+      <PackageReference Include="Bogus" Version="29.0.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
+++ b/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
@@ -1,18 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props"/>
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="AutoBogus" Version="2.8.2" />
-      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-      <PackageReference Include="Bogus" Version="29.0.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoBogus" Version="2.8.2"/>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1"/>
+    <PackageReference Include="Bogus" Version="29.0.2"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.CommonSchema\Elastic.CommonSchema.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/tests/Elastic.CommonSchema.Benchmarks/Program.cs
+++ b/tests/Elastic.CommonSchema.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Elastic.CommonSchema.Benchmarks
+{
+	internal class Program
+	{
+		public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+	}
+}

--- a/tests/Elastic.CommonSchema.Benchmarks/SerializingBase.cs
+++ b/tests/Elastic.CommonSchema.Benchmarks/SerializingBase.cs
@@ -1,0 +1,69 @@
+using System;
+using AutoBogus;
+using BenchmarkDotNet.Attributes;
+
+namespace Elastic.CommonSchema.Benchmarks
+{
+	[UnicodeConsoleLogger, MemoryDiagnoser, ThreadingDiagnoser]
+	public class SerializingBase
+	{
+		[Benchmark]
+		public string Empty()
+		{
+			var ecs = new Base();
+			return ecs.Serialize();
+		}
+		[Benchmark]
+		public string Minimal()
+		{
+			var ecs = new Base
+			{
+				Timestamp =  DateTimeOffset.UtcNow,
+				Log = new Log
+				{
+					Level = "Debug"
+				},
+				Message = "hello world!"
+			};
+			return ecs.Serialize();
+		}
+		[Benchmark]
+		public string Complex()
+		{
+			var ecs = new Base
+			{
+				Timestamp =  DateTimeOffset.UtcNow,
+				Log = new Log
+				{
+					Level = "Debug", Logger = "Logger",
+					Origin = new LogOrigin
+					{
+						File = new OriginFile { Line = 12, Name = "file.cs"}, Function = "Complex"
+					},
+					Original = "new log line",
+					Syslog = new LogSyslog {
+						Facility = new SyslogFacility
+						{
+							Code = 12, Name = "syslog"
+						}, Priority = 12, Severity = new SyslogSeverity()
+						{
+							Code = 12, Name =  "asd"
+						},
+					}
+				},
+				Message = "hello world!",
+				Agent = new Agent
+				{
+					Name = "test"
+				}
+
+			};
+			return ecs.Serialize();
+		}
+
+		public static readonly Base FullInstance = new AutoFaker<Base>().Generate();
+
+		[Benchmark]
+		public string Full() => FullInstance.Serialize();
+	}
+}


### PR DESCRIPTION
Every library needs a BenchmarkDotNet project so this was long overdue.


Looking to get this in so we can set a base line for the changes in #75 cc @snakefoot 


|  Method |         Mean |       Error |      StdDev | Completed Work Items | Lock Contentions |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |-------------:|------------:|------------:|---------------------:|-----------------:|-------:|-------:|------:|----------:|
|   Empty |     849.1 ns |     3.22 ns |     2.51 ns |               0.0000 |                - | 0.1135 |      - |     - |     712 B |
| Minimal |   1,441.0 ns |    13.18 ns |    11.69 ns |               0.0000 |                - | 0.1469 |      - |     - |     928 B |
| Complex |   3,913.2 ns |    50.75 ns |    44.99 ns |               0.0000 |                - | 0.3357 |      - |     - |    2152 B |
|    Full | 167,661.3 ns | 1,491.39 ns | 1,322.08 ns |               0.0005 |                - | 6.5918 | 0.7324 |     - |   42194 B |
