### PR TITLE
Expose Serialize(StringBuilder) overload

### DIFF
--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -33,7 +33,6 @@ namespace Elastic.CommonSchema.NLog
 		}
 
 		private readonly Layout _disableThreadAgnostic = "${threadid:cached=true}";
-		private readonly ReusableUtf8JsonWriter _jsonWriter = new ReusableUtf8JsonWriter();
 
 		public EcsLayout()
 		{
@@ -144,10 +143,7 @@ namespace Elastic.CommonSchema.NLog
 			//Allow programmatical actions to enrich before serializing
 			EnrichAction?.Invoke(ecsEvent, logEvent);
 
-			using (var reusableWriter = _jsonWriter.AllocateJsonWriter(target))
-			{
-				reusableWriter.Serialize(ecsEvent);
-			}
+			ecsEvent.Serialize(target);
 		}
 
 		/// <summary>

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -33,6 +33,7 @@ namespace Elastic.CommonSchema.NLog
 		}
 
 		private readonly Layout _disableThreadAgnostic = "${threadid:cached=true}";
+		private readonly ReusableUtf8JsonWriter _jsonWriter = new ReusableUtf8JsonWriter();
 
 		public EcsLayout()
 		{
@@ -117,42 +118,46 @@ namespace Elastic.CommonSchema.NLog
 		[ArrayParameter(typeof(TargetPropertyWithContext), "tag")]
 		public IList<TargetPropertyWithContext> Tags { get; } = new List<TargetPropertyWithContext>();
 
-		protected override void RenderFormattedMessage(LogEventInfo logEventInfo, StringBuilder target)
+		protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
 		{
 			var ecsEvent = new Base
 			{
-				Timestamp = logEventInfo.TimeStamp,
-				Message = logEventInfo.FormattedMessage,
+				Timestamp = logEvent.TimeStamp,
+				Message = logEvent.FormattedMessage,
 				Ecs = new Ecs { Version = Base.Version },
-				Log = GetLog(logEventInfo),
-				Event = GetEvent(logEventInfo),
-				Metadata = GetMetadata(logEventInfo),
-				Process = GetProcess(logEventInfo),
-				Trace = GetTrace(logEventInfo),
-				Transaction = GetTransaction(logEventInfo),
-				Error = GetError(logEventInfo.Exception),
-				Tags = GetTags(logEventInfo),
-				Labels = GetLabels(logEventInfo),
-				Agent = GetAgent(logEventInfo),
-				Server = GetServer(logEventInfo),
-				Host = GetHost(logEventInfo)
+				Log = GetLog(logEvent),
+				Event = GetEvent(logEvent),
+				Metadata = GetMetadata(logEvent),
+				Process = GetProcess(logEvent),
+				Trace = GetTrace(logEvent),
+				Transaction = GetTransaction(logEvent),
+				Error = GetError(logEvent.Exception),
+				Tags = GetTags(logEvent),
+				Labels = GetLabels(logEvent),
+				Agent = GetAgent(logEvent),
+				Server = GetServer(logEvent),
+				Host = GetHost(logEvent)
 			};
+
 			//Give any deriving classes a chance to enrich the event
-			EnrichEvent(logEventInfo,ref ecsEvent);
+			EnrichEvent(logEvent, ref ecsEvent);
 			//Allow programmatical actions to enrich before serializing
-			EnrichAction?.Invoke(ecsEvent, logEventInfo);
-			var output = ecsEvent.Serialize();
-			target.Append(output);
+			EnrichAction?.Invoke(ecsEvent, logEvent);
+
+			using (var reusableWriter = _jsonWriter.AllocateJsonWriter(target))
+			{
+				reusableWriter.Serialize(ecsEvent);
+			}
 		}
 
 		/// <summary>
 		/// Override to supplement the ECS event parsing
 		/// </summary>
-		/// <param name="logEventInfo">The original log event</param>
+		/// <param name="logEvent">The original log event</param>
 		/// <param name="ecsEvent">The EcsEvent to modify</param>
 		/// <returns>Enriched ECS Event</returns>
 		/// <remarks>Destructive for performance</remarks>
-		protected virtual void EnrichEvent(LogEventInfo logEventInfo,ref Base ecsEvent)
+		protected virtual void EnrichEvent(LogEventInfo logEvent, ref Base ecsEvent)
 		{
 		}
 

--- a/src/Elastic.CommonSchema.NLog/ReusableUtf8JsonWriter.cs
+++ b/src/Elastic.CommonSchema.NLog/ReusableUtf8JsonWriter.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace Elastic.CommonSchema.NLog
+{
+	internal sealed class ReusableUtf8JsonWriter
+	{
+		private Utf8JsonWriter _cachedJsonWriter;
+		private readonly System.IO.MemoryStream _cachedMemoryStream;
+		private readonly char[] _cachedEncodingBuffer;
+
+		public ReusableUtf8JsonWriter()
+		{
+			_cachedMemoryStream = new System.IO.MemoryStream(4 * 1024);
+			_cachedJsonWriter = new Utf8JsonWriter(_cachedMemoryStream);
+			_cachedEncodingBuffer = new char[1024];
+		}
+
+		public ReusableJsonWriter AllocateJsonWriter(StringBuilder text)
+		{
+			var writer = System.Threading.Interlocked.Exchange(ref _cachedJsonWriter, null);
+			return new ReusableJsonWriter(this, writer, text);
+		}
+
+		private void Return(Utf8JsonWriter writer, StringBuilder output)
+		{
+			writer.Flush();
+
+			if (_cachedMemoryStream.Length > 0)
+			{
+				if (!_cachedMemoryStream.TryGetBuffer(out var byteArray))
+					byteArray = new ArraySegment<byte>(_cachedMemoryStream.GetBuffer(), 0, (int)_cachedMemoryStream.Length);
+
+				CopyToStringBuilder(byteArray, _cachedEncodingBuffer, output);
+			}
+
+			writer.Reset();
+			_cachedMemoryStream.Position = 0;
+			_cachedMemoryStream.SetLength(0);
+			System.Threading.Interlocked.Exchange(ref _cachedJsonWriter, writer);
+		}
+
+		private static void CopyToStringBuilder(ArraySegment<byte> byteArray, char[] encodingBuffer, StringBuilder output)
+		{
+			var utf8encoder = Encoding.UTF8;
+			var byteCount = 0;
+			var charCount = 0;
+			for (int i = 0; i < byteArray.Count; i += encodingBuffer.Length)
+			{
+				byteCount = Math.Min(byteArray.Count - i, encodingBuffer.Length);
+				charCount = utf8encoder.GetChars(byteArray.Array, byteArray.Offset + i, byteCount, encodingBuffer, 0);
+				output.Append(encodingBuffer, 0, charCount);
+			}
+		}
+
+		internal struct ReusableJsonWriter : IDisposable
+		{
+			private readonly ReusableUtf8JsonWriter _owner;
+			private readonly Utf8JsonWriter _writer;
+			private readonly StringBuilder _output;
+
+			public ReusableJsonWriter(ReusableUtf8JsonWriter owner, Utf8JsonWriter writer, StringBuilder output)
+			{
+				_writer = writer;
+				_owner = writer != null ? owner : null;
+				_output = output;
+			}
+
+			public void Serialize(Base ecsEvent)
+			{
+				if (_writer != null)
+				{
+					ecsEvent.Serialize(_writer);
+				}
+				else
+				{
+					var result = ecsEvent.Serialize();
+					_output.Append(result);
+				}
+			}
+
+			public void Dispose()
+			{
+				if (_owner != null)
+				{
+					_owner.Return(_writer, _output);
+				}
+			}
+		}
+	}
+}

--- a/src/Elastic.CommonSchema/Base.Serialization.cs
+++ b/src/Elastic.CommonSchema/Base.Serialization.cs
@@ -106,6 +106,8 @@ namespace Elastic.CommonSchema
 			JsonSerializer.Serialize(writer, this, JsonConfiguration.SerializerOptions);
 		}
 
+		public void Serialize(Utf8JsonWriter writer) => JsonSerializer.Serialize(writer, this, JsonConfiguration.SerializerOptions);
+
 		public Task SerializeAsync(Stream stream, CancellationToken ctx = default) =>
 			JsonSerializer.SerializeAsync(stream, this, GetType(), SerializerOptions, ctx);
 	}

--- a/src/Elastic.CommonSchema/Base.Serialization.cs
+++ b/src/Elastic.CommonSchema/Base.Serialization.cs
@@ -98,8 +98,9 @@ namespace Elastic.CommonSchema
 		public byte[] SerializeToUtf8Bytes() => JsonSerializer.SerializeToUtf8Bytes(this, GetType(), SerializerOptions);
 
 		[ThreadStatic]
-		private static readonly ReusableUtf8JsonWriter ReusableJsonWriter = new ReusableUtf8JsonWriter();
-		
+		private static ReusableUtf8JsonWriter _reusableJsonWriter;
+		private static ReusableUtf8JsonWriter ReusableJsonWriter => _reusableJsonWriter ??= new ReusableUtf8JsonWriter();
+
 		public StringBuilder Serialize(StringBuilder stringBuilder)
 		{
 			using var reusableWriter = ReusableJsonWriter.AllocateJsonWriter(stringBuilder);

--- a/src/Elastic.CommonSchema/Base.Serialization.cs
+++ b/src/Elastic.CommonSchema/Base.Serialization.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Buffers;
 using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -12,45 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elastic.CommonSchema.Serialization;
 using static Elastic.CommonSchema.Serialization.JsonConfiguration;
-
-namespace Elastic.CommonSchema.Serialization
-{
-	/// <summary>
-	/// This static class allows you to deserialize subclasses of <see cref="Base"/>
-	/// If you are dealing with <see cref="Base"/> directly you do not need to use this class,
-	/// use <see cref="Base.Deserialize(string)"/> and the overloads instead.
-	/// </summary>
-	/// <remarks>
-	/// This class should only be used for advanced use cases, for simpler use cases you can utilise the <see cref="Base.Metadata"/> property.
-	/// </remarks>
-	/// <typeparam name="TBase">Type of the <see cref="Base"/> subclass</typeparam>
-	public static class EcsSerializerFactory<TBase> where TBase : Base, new()
-	{
-		public static ValueTask<TBase> DeserializeAsync(Stream stream, CancellationToken ctx = default) =>
-			JsonSerializer.DeserializeAsync<TBase>(stream, SerializerOptions, ctx);
-
-		public static TBase Deserialize(string json) => JsonSerializer.Deserialize<TBase>(json, SerializerOptions);
-
-		public static TBase Deserialize(ReadOnlySpan<byte> json) => JsonSerializer.Deserialize<TBase>(json, SerializerOptions);
-
-		public static TBase Deserialize(Stream stream)
-		{
-			using var ms = new MemoryStream();
-			var buffer = ArrayPool<byte>.Shared.Rent(1024);
-			var total = 0;
-			int read;
-			while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-			{
-				ms.Write(buffer, 0, read);
-				total += read;
-			}
-			var span = ms.TryGetBuffer(out var segment)
-				? new ReadOnlyMemory<byte>(segment.Array, segment.Offset, total).Span
-				: new ReadOnlyMemory<byte>(ms.ToArray()).Span;
-			return Deserialize(span);
-		}
-	}
-}
 
 namespace Elastic.CommonSchema
 {
@@ -97,7 +57,6 @@ namespace Elastic.CommonSchema
 
 		public byte[] SerializeToUtf8Bytes() => JsonSerializer.SerializeToUtf8Bytes(this, GetType(), SerializerOptions);
 
-		[ThreadStatic]
 		private static ReusableUtf8JsonWriter _reusableJsonWriter;
 		private static ReusableUtf8JsonWriter ReusableJsonWriter => _reusableJsonWriter ??= new ReusableUtf8JsonWriter();
 

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props"/>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <Title>Elastic Common Schema (ECS) Types</Title>

--- a/src/Elastic.CommonSchema/Serialization/EcsSerializerFactory.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsSerializerFactory.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elastic.CommonSchema.Serialization
+{
+	/// <summary>
+	/// This static class allows you to deserialize subclasses of <see cref="Base"/>
+	/// If you are dealing with <see cref="Base"/> directly you do not need to use this class,
+	/// use <see cref="Base.Deserialize(string)"/> and the overloads instead.
+	/// </summary>
+	/// <remarks>
+	/// This class should only be used for advanced use cases, for simpler use cases you can utilise the <see cref="Base.Metadata"/> property.
+	/// </remarks>
+	/// <typeparam name="TBase">Type of the <see cref="Base"/> subclass</typeparam>
+	public static class EcsSerializerFactory<TBase> where TBase : Base, new()
+	{
+		public static ValueTask<TBase> DeserializeAsync(Stream stream, CancellationToken ctx = default) =>
+			JsonSerializer.DeserializeAsync<TBase>(stream, JsonConfiguration.SerializerOptions, ctx);
+
+		public static TBase Deserialize(string json) => JsonSerializer.Deserialize<TBase>(json, JsonConfiguration.SerializerOptions);
+
+		public static TBase Deserialize(ReadOnlySpan<byte> json) => JsonSerializer.Deserialize<TBase>(json, JsonConfiguration.SerializerOptions);
+
+		public static TBase Deserialize(Stream stream)
+		{
+			using var ms = new MemoryStream();
+			var buffer = ArrayPool<byte>.Shared.Rent(1024);
+			var total = 0;
+			int read;
+			while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+			{
+				ms.Write(buffer, 0, read);
+				total += read;
+			}
+			var span = ms.TryGetBuffer(out var segment)
+				? new ReadOnlyMemory<byte>(segment.Array, segment.Offset, total).Span
+				: new ReadOnlyMemory<byte>(ms.ToArray()).Span;
+			return Deserialize(span);
+		}
+	}
+}

--- a/src/Elastic.CommonSchema/Serialization/ReusableUtf8JsonWriter.cs
+++ b/src/Elastic.CommonSchema/Serialization/ReusableUtf8JsonWriter.cs
@@ -51,13 +51,10 @@ namespace Elastic.CommonSchema.Serialization
 
 		private static void CopyToStringBuilder(ArraySegment<byte> byteArray, char[] encodingBuffer, StringBuilder output)
 		{
-			var utf8Encoder = Encoding.UTF8;
-			var byteCount = 0;
-			var charCount = 0;
 			for (var i = 0; i < byteArray.Count; i += encodingBuffer.Length)
 			{
-				byteCount = Math.Min(byteArray.Count - i, encodingBuffer.Length);
-				charCount = utf8Encoder.GetChars(byteArray.Array, byteArray.Offset + i, byteCount, encodingBuffer, 0);
+				var byteCount = Math.Min(byteArray.Count - i, encodingBuffer.Length);
+				var charCount = Encoding.UTF8.GetChars(byteArray.Array, byteArray.Offset + i, byteCount, encodingBuffer, 0);
 				output.Append(encodingBuffer, 0, charCount);
 			}
 		}

--- a/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
+++ b/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props"/>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\Library.build.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoBogus" Version="2.8.2"/>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1"/>
-    <PackageReference Include="Bogus" Version="29.0.2"/>
+    <PackageReference Include="AutoBogus" Version="2.8.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Bogus" Version="29.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.CommonSchema\Elastic.CommonSchema.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Elastic.CommonSchema.Benchmarks/SerializingStringBuilderBase.cs
+++ b/tests/Elastic.CommonSchema.Benchmarks/SerializingStringBuilderBase.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text;
+using AutoBogus;
+using BenchmarkDotNet.Attributes;
+
+namespace Elastic.CommonSchema.Benchmarks
+{
+	[UnicodeConsoleLogger, MemoryDiagnoser, ThreadingDiagnoser]
+	public class SerializingStringBuilderBase
+	{
+		[Benchmark]
+		public StringBuilder Empty()
+		{
+			var ecs = new Base();
+			return ecs.Serialize(new StringBuilder());
+		}
+		[Benchmark]
+		public StringBuilder Minimal()
+		{
+			var ecs = new Base
+			{
+				Timestamp =  DateTimeOffset.UtcNow,
+				Log = new Log
+				{
+					Level = "Debug"
+				},
+				Message = "hello world!"
+			};
+			return ecs.Serialize(new StringBuilder());
+		}
+		[Benchmark]
+		public StringBuilder Complex()
+		{
+			var ecs = new Base
+			{
+				Timestamp =  DateTimeOffset.UtcNow,
+				Log = new Log
+				{
+					Level = "Debug", Logger = "Logger",
+					Origin = new LogOrigin
+					{
+						File = new OriginFile { Line = 12, Name = "file.cs"}, Function = "Complex"
+					},
+					Original = "new log line",
+					Syslog = new LogSyslog {
+						Facility = new SyslogFacility
+						{
+							Code = 12, Name = "syslog"
+						}, Priority = 12, Severity = new SyslogSeverity()
+						{
+							Code = 12, Name =  "asd"
+						},
+					}
+				},
+				Message = "hello world!",
+				Agent = new Agent
+				{
+					Name = "test"
+				}
+
+			};
+			return ecs.Serialize(new StringBuilder());
+		}
+
+		public static readonly Base FullInstance = new AutoFaker<Base>().Generate();
+
+		[Benchmark]
+		public StringBuilder Full() => FullInstance.Serialize(new StringBuilder());
+	}
+}

--- a/tests/Elastic.CommonSchema.NLog.Tests/OutputTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/OutputTests.cs
@@ -17,7 +17,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 		{
 			logger.Info("My log message!");
 			logger.Info("Test output to NLog!");
-			Action sketchy = () => throw new Exception("I threw up.");
+			void sketchy() => throw new Exception("I threw up.");
 			var exception = Record.Exception(sketchy);
 			logger.Error(exception, "Here is an error.");
 			Assert.NotNull(exception);


### PR DESCRIPTION
Continuation of #75 

* NLog EcsLayout - Write directly to StringBuilder instead of string allocation

This continuation:

- Move internal ReusableUtf8JsonWriter down to Elastic.CommonSchema
- Expose an overload on `Base` that serializes on a `StringBuilder` directly.
- Add benchmarks for the `StringBuilder` overload
- `ReusableUtf8JsonWriter` is now a `ThreadStatic` instance on `Base`

Reusing the text writer in the `StringBuilder` overload:

|  Method |       Mean |      Error |      StdDev | Completed Work Items | Lock Contentions |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |-----------:|-----------:|------------:|---------------------:|-----------------:|-------:|------:|------:|----------:|
|   Empty |   1.064 μs |  0.0047 μs |   0.0042 μs |               0.0000 |                - | 0.1068 |     - |     - |     680 B |
| Minimal |   1.740 μs |  0.0067 μs |   0.0059 μs |               0.0000 |                - | 0.1431 |     - |     - |     903 B |
| Complex |   4.732 μs |  0.0219 μs |   0.0183 μs |               0.0000 |                - | 0.3357 |     - |     - |    2120 B |
|    Full | 484.817 μs | 39.2360 μs | 112.5753 μs |                    - |                - |      - |     - |     - |   58208 B |


vs newing one up every time in the `StringBuilder` overload.

|  Method |       Mean |      Error |     StdDev | Completed Work Items | Lock Contentions |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |-----------:|-----------:|-----------:|---------------------:|-----------------:|-------:|------:|------:|----------:|
|   Empty |   1.112 μs |  0.0047 μs |  0.0044 μs |               0.0000 |                - | 0.2098 |     - |     - |   1.29 KB |
| Minimal |   1.808 μs |  0.0032 μs |  0.0028 μs |               0.0000 |                - | 0.2193 |     - |     - |   1.34 KB |
| Complex |   4.803 μs |  0.0267 μs |  0.0236 μs |               0.0000 |                - | 0.4272 |     - |     - |   2.66 KB |
|    Full | 492.265 μs | 32.6823 μs | 93.7718 μs |                    - |                - |      - |     - |     - |  45.94 KB |



For reference this is the unmodified `ecs.Serialize()` path which returns a string

|  Method |       Mean |      Error |     StdDev |     Median | Completed Work Items | Lock Contentions |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |-----------:|-----------:|-----------:|-----------:|---------------------:|-----------------:|-------:|------:|------:|----------:|
|   Empty |   1.092 μs |  0.0096 μs |  0.0090 μs |   1.090 μs |               0.0000 |                - | 0.1125 |     - |     - |     712 B |
| Minimal |   1.766 μs |  0.0049 μs |  0.0044 μs |   1.765 μs |               0.0000 |                - | 0.1469 |     - |     - |     928 B |
| Complex |   4.805 μs |  0.0342 μs |  0.0320 μs |   4.805 μs |               0.0000 |                - | 0.3357 |     - |     - |    2152 B |
|    Full | 480.523 μs | 34.5599 μs | 99.7134 μs | 445.317 μs |                    - |                - |      - |     - |     - |   41872 B |

Which seems to have on par performance with the stringbuilder overload that reuses.


