### PR TITLE
Fix documentation for NLog EcsLayout to match Serilog

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ Formats an NLog event into a JSON representation that adheres to the Elastic Com
 
 ```csharp
 Layout.Register<EcsLayout>("EcsLayout"); // Register the ECS layout.
-var config = new Config.LoggingConfiguration();
-var memoryTarget = new EventInfoMemoryTarget { Layout = Layout.FromString("EcsLayout") }; // Use the layout.
-config.AddRule(LogLevel.Debug, LogLevel.Fatal, memoryTarget);
-var factory = new LogFactory(config);
-var logger = factory.GetCurrentClassLogger();
+var config = new LoggingConfiguration();
+var consoleTarget = new ConsoleTarget("console") { Layout = new EcsLayout() };  // Use the ECS layout.
+config.AddRule(LogLevel.Debug, LogLevel.Fatal, consoleTarget);
+LogManager.Configuration = config;
+var logger = LogManager.GetCurrentClassLogger();
 ```
 
 ## APM
@@ -114,17 +114,16 @@ Introduce two special place holder variables (`ElasticApmTraceId`, `ElasticApmTr
 [Learn more...](https://github.com/elastic/ecs-dotnet/tree/master/src/Elastic.Apm.NLog)
 
 ```csharp
-var target = new MemoryTarget();
-target.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}";
-Agent.Tracer.CaptureTransaction("TestTransaction", "Test", t =>
-{
-	traceId = "trace-id";
-	transactionId = "transaction-id";
-	logger.Debug("InTransaction");
-});
 // Logged message will be in format of `trace-id|transation-id|InTransaction`
 // or `||InTransaction` if the place holders are not available
+var consoleTarget = new ConsoleTarget("console");
+consoleTarget.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}";
+config.AddRule(LogLevel.Debug, LogLevel.Fatal, consoleTarget);
+LogManager.Configuration = config;
+var logger = LogManager.GetCurrentClassLogger();
 ```
+
+When using EcsLayout from `Elastic.CommonSchema.NLog` then trace and transaction id will automatically appear in ECS.
 
 ## Benchmarking
 

--- a/src/Elastic.Apm.NLog/readme.md
+++ b/src/Elastic.Apm.NLog/readme.md
@@ -11,19 +11,32 @@ Which will be replaced with the appropriate Elastic APM variables if available
 
 The .NET assemblies are published to NuGet under the package name [Elastic.Apm.NLog](http://nuget.org/packages/Elastic.Apm.NLog)
 
-## How to Enable
+## How to use from API
 
 ```csharp
-var target = new MemoryTarget();
-target.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}";
-Agent.Tracer.CaptureTransaction("TestTransaction", "Test", t =>
-{
-	traceId = "trace-id";
-	transactionId = "transaction-id";
-	logger.Debug("InTransaction");
-});
 // Logged message will be in format of `trace-id|transation-id|InTransaction`
 // or `||InTransaction` if the place holders are not available
+var consoleTarget = new ConsoleTarget("console");
+consoleTarget.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}";
+config.AddRule(LogLevel.Debug, LogLevel.Fatal, consoleTarget);
+LogManager.Configuration = config;
+var logger = LogManager.GetCurrentClassLogger();
+```
+
+## How to use from NLog.config
+
+```xml
+<nlog>
+  <extensions>
+    <add assembly="Elastic.Apm.NLog"/>
+  </extensions>
+  <targets>
+    <target name="console" type="console" layout="${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}" />
+  </targets>
+  <rules>
+    <logger name="*" minLevel="Debug" writeTo="Console" />
+  </rules>
+</nlog>
 ```
 
 ## Prerequisite

--- a/src/Elastic.CommonSchema.NLog/README.md
+++ b/src/Elastic.CommonSchema.NLog/README.md
@@ -6,22 +6,42 @@ This Layout implementation formats an NLog event into a JSON representation that
 
 The .NET assemblies are published to NuGet under the package name [Elastic.CommonSchema.NLog](http://nuget.org/packages/Elastic.CommonSchema.NLog)
 
-## How to Enable
+## How to use from API
 
 ```csharp
 Layout.Register<EcsLayout>("EcsLayout"); // Register the ECS layout.
-var config = new Config.LoggingConfiguration();
-var memoryTarget = new EventInfoMemoryTarget { Layout = Layout.FromString("EcsLayout") }; // Use the layout.
-config.AddRule(LogLevel.Debug, LogLevel.Fatal, memoryTarget);
-var factory = new LogFactory(config);
-var logger = factory.GetCurrentClassLogger();
+var config = new LoggingConfiguration();
+var consoleTarget = new ConsoleTarget("console") { Layout = new EcsLayout() };  // Use the ECS layout.
+config.AddRule(LogLevel.Debug, LogLevel.Fatal, consoleTarget);
+LogManager.Configuration = config;
+var logger = LogManager.GetCurrentClassLogger();
 ```
 
 In the code snippet above `Layout.Register<EcsLayout>("EcsLayout")` registers the `EcsLayout` with NLog.
-The `Layout = Layout.FromString("EcsLayout")` line then instructs NLog to use the registered layout.
-The sample above uses the memory target, but you are free to use any target of your choice, perhaps consider using a
+The `Layout = new EcsLayout()` line then instructs NLog to use the registered layout.
+The sample above uses the console target, but you are free to use any target of your choice, perhaps consider using a
 filesystem target and [Elastic Filebeat](https://www.elastic.co/downloads/beats/filebeat) for durable and reliable ingestion.
 
+## How to use from NLog.config
+
+```xml
+<nlog>
+  <extensions>
+    <add assembly="Elastic.Apm.NLog"/>
+    <add assembly="Elastic.CommonSchema.NLog"/>
+  </extensions>
+  <targets>
+    <target name="console" type="console">
+      <layout xsi:type="EcsLayout" />
+    </target>
+  </targets>
+  <rules>
+    <logger name="*" minLevel="Debug" writeTo="Console" />
+  </rules>
+</nlog>
+```
+
+## Example output from EcsLayout
 An example of the output is given below:
 
 ```json


### PR DESCRIPTION
Generate output to the console-target, instead of in-memory-target.

Make use of the actual EcsLayout, instead of just printing the static string `"EcsLayout"`.