### PR TITLE
Added ElasticCloud logging

### DIFF
--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchDataProcessor.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchDataProcessor.cs
@@ -220,38 +220,21 @@ namespace Elasticsearch.Extensions.Logging
 		{
 			// TODO: Check if Uri has changed before recreating
 			// TODO: Injectable factory? Or some way of testing.
+			var connectionPool = _options.ShipTo.CreateConnectionPool();
+			var nodes = _options.ShipTo.NodeUris.ToArray();
 
 			ConnectionConfiguration settings;
-			if (_options.NodeUris.Length == 0)
+
+			if (nodes.Length == 0 && _options.ShipTo.ConnectionPoolType != ConnectionPoolType.Cloud)
 			{
 				// This is SingleNode with "http://localhost:9200"
 				settings = new ConnectionConfiguration();
 			}
 			else if (_options.ConnectionPoolType == ConnectionPoolType.SingleNode
-				|| _options.ConnectionPoolType == ConnectionPoolType.Unknown && _options.NodeUris.Length == 1)
-				settings = new ConnectionConfiguration(_options.NodeUris[0]);
+				|| _options.ConnectionPoolType == ConnectionPoolType.Unknown && nodes.Length == 1)
+				settings = new ConnectionConfiguration(nodes[0]);
 			else
 			{
-				IConnectionPool connectionPool;
-				switch (_options.ConnectionPoolType)
-				{
-					// TODO: Add option to randomize pool
-					case ConnectionPoolType.Unknown:
-					case ConnectionPoolType.Sniffing:
-						connectionPool = new SniffingConnectionPool(_options.NodeUris);
-						break;
-					case ConnectionPoolType.Static:
-						connectionPool = new StaticConnectionPool(_options.NodeUris);
-						break;
-					case ConnectionPoolType.Sticky:
-						connectionPool = new StickyConnectionPool(_options.NodeUris);
-						break;
-					// case ConnectionPoolType.StickySniffing:
-					// case ConnectionPoolType.Cloud:
-					default:
-						throw new NotSupportedException($"Unknown connection pool type {_options.ConnectionPoolType}");
-				}
-
 				settings = new ConnectionConfiguration(connectionPool);
 			}
 

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
@@ -57,10 +57,11 @@ namespace Elasticsearch.Extensions.Logging
 		public string ListSeparator { get; set; } = ", ";
 
 		/// <summary>
-		/// Gets or sets the URIs of the Elasticsearch nodes in the connection pool. If not specified the default single node
+		/// Gets or sets the ShipTo property of the Elasticsearch.
+		/// If not specified the default single node is being used.
 		/// "http://localhost:9200" is used.
 		/// </summary>
-		public Uri[] NodeUris { get; set; } = new Uri[0];
+		public ShipTo ShipTo { get; set; } = new ShipTo();
 
 		/// <summary>
 		/// Gets or sets additional tags to pass in the message, for example you can tag with the environment name ('Development',
@@ -68,4 +69,5 @@ namespace Elasticsearch.Extensions.Logging
 		/// </summary>
 		public string[] Tags { get; set; } = new string[0];
 	}
+
 }

--- a/src/Elasticsearch.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/Elasticsearch.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -35,5 +35,50 @@ namespace Elasticsearch.Extensions.Logging
 			builder.Services.Configure(configure);
 			return builder;
 		}
+
+		public static ILoggingBuilder AddElasticCloud(this ILoggingBuilder builder,
+			string cloudId, string apiKey
+		)
+		{
+			if (string.IsNullOrEmpty(cloudId))
+				throw new ArgumentException("cloudId may not be empty.", nameof(cloudId));
+
+			if (string.IsNullOrEmpty(apiKey))
+				throw new ArgumentException("apiKey may not be empty.", nameof(apiKey));
+
+			builder.AddElasticsearch();
+
+			void configure(ElasticsearchLoggerOptions options)
+			{
+				options.ShipTo = new ShipTo(cloudId, apiKey);
+			}
+
+			builder.Services.Configure((Action<ElasticsearchLoggerOptions>)configure);
+			return builder;
+		}
+
+		public static ILoggingBuilder AddElasticCloud(this ILoggingBuilder builder,
+			string cloudId, string username, string password
+		)
+		{
+			if (string.IsNullOrEmpty(cloudId))
+				throw new ArgumentException("cloudId may not be empty.", nameof(cloudId));
+
+			if (string.IsNullOrEmpty(username))
+				throw new ArgumentException("username may not be empty.", nameof(username));
+
+			if (string.IsNullOrEmpty(password))
+				throw new ArgumentException("password may not be empty.", nameof(password));
+
+			builder.AddElasticsearch();
+
+			void configure(ElasticsearchLoggerOptions options)
+			{
+				options.ShipTo = new ShipTo(cloudId, username, password);
+			}
+
+			builder.Services.Configure((Action<ElasticsearchLoggerOptions>)configure);
+			return builder;
+		}
 	}
 }

--- a/src/Elasticsearch.Extensions.Logging/ShipTo.cs
+++ b/src/Elasticsearch.Extensions.Logging/ShipTo.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using Elasticsearch.Net;
+
+namespace Elasticsearch.Extensions.Logging
+{
+	public class ShipTo
+	{
+		public IEnumerable<Uri> NodeUris { get; } = new Uri[0];
+		public ConnectionPoolType? ConnectionPoolType { get; }
+		public string CloudId { get; } = string.Empty;
+
+		public string ApiKey { get; } = string.Empty;
+
+		public string Username { get; } = string.Empty;
+		public string Password { get; } = string.Empty;
+
+		public ShipTo() => ConnectionPoolType = Logging.ConnectionPoolType.SingleNode;
+
+		public ShipTo(IEnumerable<Uri> nodeUris, ConnectionPoolType connectionPoolType)
+		{
+			NodeUris = nodeUris;
+			ConnectionPoolType = connectionPoolType;
+		}
+
+		public ShipTo(string cloudId, string apiKey)
+		{
+			if (string.IsNullOrEmpty(cloudId))
+				throw new ArgumentException("cloudId may not be null.", nameof(cloudId));
+
+			if (string.IsNullOrEmpty(apiKey))
+				throw new ArgumentException("apiKey may not be null.", nameof(apiKey));
+
+			CloudId = cloudId;
+			ApiKey = apiKey;
+			ConnectionPoolType = Logging.ConnectionPoolType.Cloud;
+		}
+
+		public ShipTo(string cloudId, string username, string password)
+		{
+			if (string.IsNullOrEmpty(cloudId))
+				throw new ArgumentException("cloudId may not be null.", nameof(cloudId));
+
+			if (string.IsNullOrEmpty(username))
+				throw new ArgumentException("username may not be null.", nameof(username));
+
+			if (string.IsNullOrEmpty(password))
+				throw new ArgumentException("password may not be null.", nameof(password));
+
+			CloudId = cloudId;
+			Username = username;
+			Password = password;
+
+			ConnectionPoolType = Logging.ConnectionPoolType.Cloud;
+		}
+
+		internal IConnectionPool? CreateConnectionPool()
+		{
+			switch (ConnectionPoolType)
+			{
+				// TODO: Add option to randomize pool
+				case Logging.ConnectionPoolType.Unknown:
+				case Logging.ConnectionPoolType.Sniffing:
+					return new SniffingConnectionPool(NodeUris);
+				case Logging.ConnectionPoolType.Static:
+					return new StaticConnectionPool(NodeUris);
+				case Logging.ConnectionPoolType.Sticky:
+					return new StickyConnectionPool(NodeUris);
+				// case ConnectionPoolType.StickySniffing:
+				case Logging.ConnectionPoolType.Cloud:
+					if (!string.IsNullOrEmpty(ApiKey))
+					{
+						var apiKeyCredentials = new ApiKeyAuthenticationCredentials(ApiKey);
+						return new CloudConnectionPool(CloudId, apiKeyCredentials);
+					}
+
+					var basicAuthCredentials = new BasicAuthenticationCredentials(Username, Password);
+					return new CloudConnectionPool(CloudId, basicAuthCredentials);
+				default:
+					return null;
+			}
+		}
+
+		public override int GetHashCode()
+		{
+			var hashCode = 352033288;
+
+			hashCode = hashCode * -1521134295 + ConnectionPoolType.GetHashCode();
+			hashCode = hashCode * -1521134295 + CloudId.GetHashCode();
+			hashCode = hashCode * -1521134295 + Username.GetHashCode();
+			hashCode = hashCode * -1521134295 + Password.GetHashCode();
+			hashCode = hashCode * -1521134295 + NodeUris.GetHashCode();
+
+			return hashCode;
+		}
+	}
+
+}


### PR DESCRIPTION
This introduces two new extension methods:

- UseElasticCloud(string cloudId, string apiKey)
- UseElasticCloud(string cloudId, string username, string password)

Breaking change:
- Removed NodeUris from the ElasticsearchLoggerOptions
- Added new ShipTo class which encloses the previous NodeUris

I am not 100% sure if this is what you want/need, but it works fine for me.

Tested on a local ElasticSearch instance using `.AddElasticsearch()`.
Tested on elastic cloud using `.AddElasticCloud(cloudId, username, password)`
Tested on elastic cloud using `.AddElasticCloud(cloudId, apiKey)`

The ApiKey has to come in correctly. So the base64'd "ApiKey.Id + colon + ApiKey.Key".

Please let me know if you need anything to be changed.