### PR TITLE
Bulk support for extensions logging integration.

### DIFF
--- a/ecs-dotnet.sln
+++ b/ecs-dotnet.sln
@@ -75,6 +75,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elasticsearch.Extensions.Lo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elasticsearch.Extensions.Logging.IntegrationTests", "tests\Elasticsearch.Extensions.Logging.IntegrationTests\Elasticsearch.Extensions.Logging.IntegrationTests.csproj", "{0E7008E1-B215-4B9B-BC28-DC9D31415FB9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elasticsearch.Extensions.Logging.Example", "examples\Elasticsearch.Extensions.Logging.Example\Elasticsearch.Extensions.Logging.Example.csproj", "{F319AD28-A0A4-4012-8480-E2A4CFA755C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -163,6 +165,10 @@ Global
 		{0E7008E1-B215-4B9B-BC28-DC9D31415FB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E7008E1-B215-4B9B-BC28-DC9D31415FB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E7008E1-B215-4B9B-BC28-DC9D31415FB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F319AD28-A0A4-4012-8480-E2A4CFA755C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F319AD28-A0A4-4012-8480-E2A4CFA755C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F319AD28-A0A4-4012-8480-E2A4CFA755C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F319AD28-A0A4-4012-8480-E2A4CFA755C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -190,6 +196,7 @@ Global
 		{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 		{D88AAA7D-1AEE-4B4C-BE37-69BA85DA07DA} = {7610B796-BB3E-4CB2-8296-79BBFF6D23FC}
 		{0E7008E1-B215-4B9B-BC28-DC9D31415FB9} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
+		{F319AD28-A0A4-4012-8480-E2A4CFA755C2} = {05075402-8669-45BD-913A-BD40A29BBEAB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/examples/Elasticsearch.Extensions.Logging.Example/Elasticsearch.Extensions.Logging.Example.csproj
+++ b/examples/Elasticsearch.Extensions.Logging.Example/Elasticsearch.Extensions.Logging.Example.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
+    <PackageReference Include="Elastic.Elasticsearch.Ephemeral" Version="0.2.4" />
+    <PackageReference Include="NEST" Version="7.8.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elasticsearch.Extensions.Logging\Elasticsearch.Extensions.Logging.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/examples/Elasticsearch.Extensions.Logging.Example/HighVolumeWorkSimulation.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/HighVolumeWorkSimulation.cs
@@ -14,9 +14,9 @@ namespace Elasticsearch.Extensions.Logging.Example
 	/// <summary> Simulate work that logs in low volume with some time in between each log call </summary>
 	public class HighVolumeWorkSimulation : BackgroundService
 	{
-		private readonly ILogger<LowVolumeWorkSimulation> _logger;
+		private readonly ILogger<HighVolumeWorkSimulation> _logger;
 
-		public HighVolumeWorkSimulation(ILogger<LowVolumeWorkSimulation> logger) => _logger = logger;
+		public HighVolumeWorkSimulation(ILogger<HighVolumeWorkSimulation> logger) => _logger = logger;
 
 		protected override async Task ExecuteAsync(CancellationToken ctx)
 		{

--- a/examples/Elasticsearch.Extensions.Logging.Example/HighVolumeWorkSimulation.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/HighVolumeWorkSimulation.cs
@@ -23,7 +23,7 @@ namespace Elasticsearch.Extensions.Logging.Example
 			for (var i = 0; i < 100_000; i++)
 			{
 				_logger.LogWarning($"We are logging way too much: {i}");
-				if (i % 1_00 == 0) await Task.Delay(1, ctx);
+				if (i % 100 == 0) await Task.Delay(1, ctx);
 			}
 		}
 	}

--- a/examples/Elasticsearch.Extensions.Logging.Example/HighVolumeWorkSimulation.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/HighVolumeWorkSimulation.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Elasticsearch.Extensions.Logging.Example
+{
+
+	/// <summary> Simulate work that logs in low volume with some time in between each log call </summary>
+	public class HighVolumeWorkSimulation : BackgroundService
+	{
+		private readonly ILogger<LowVolumeWorkSimulation> _logger;
+
+		public HighVolumeWorkSimulation(ILogger<LowVolumeWorkSimulation> logger) => _logger = logger;
+
+		protected override async Task ExecuteAsync(CancellationToken ctx)
+		{
+			for (var i = 0; i < 100_000; i++)
+			{
+				_logger.LogWarning($"We are logging way too much: {i}");
+				if (i % 1_00 == 0) await Task.Delay(1, ctx);
+			}
+		}
+	}
+}

--- a/examples/Elasticsearch.Extensions.Logging.Example/Log.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/Log.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Elasticsearch.Extensions.Logging.Example
+{
+	public class Log
+	{
+		public static readonly Action<ILogger, Exception?> CriticalErrorExecuteFailed =
+			LoggerMessage.Define(LogLevel.Critical,
+				new EventId(9000, nameof(CriticalErrorExecuteFailed)),
+				"Critical error, execute failed.");
+
+		public static readonly Action<ILogger, int, Exception?> ErrorProcessingCustomer =
+			LoggerMessage.Define<int>(LogLevel.Error,
+				new EventId(5000, nameof(ErrorProcessingCustomer)),
+				"Unexpected error processing customer {CustomerId}.");
+
+		public static readonly Action<ILogger, Guid, Exception?> ProcessOrderItem =
+			LoggerMessage.Define<Guid>(LogLevel.Information,
+				new EventId(1000, nameof(ProcessOrderItem)),
+				"Processing order item {ItemId}.");
+
+		public static readonly Action<ILogger, byte, bool, Exception?> SignInToken =
+			LoggerMessage.Define<byte, bool>(LogLevel.Trace,
+				new EventId(1, nameof(SignInToken)),
+				"Sign in secret token checksum {Checksum}: {Success}.");
+
+		public static readonly Action<ILogger, int, Exception?> StartingProcessing =
+			LoggerMessage.Define<int>(LogLevel.Debug,
+				new EventId(6000, nameof(StartingProcessing)),
+				"Starting processing of {ItemCount} items.");
+
+		public static readonly Action<ILogger, DateTimeOffset, Exception?> WarningEndOfProcessing =
+			LoggerMessage.Define<DateTimeOffset>(LogLevel.Warning,
+				new EventId(4000, nameof(WarningEndOfProcessing)),
+				"End of processing reached at {EndTime}.");
+	}
+
+}

--- a/examples/Elasticsearch.Extensions.Logging.Example/LowVolumeWorkSimulation.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/LowVolumeWorkSimulation.cs
@@ -5,17 +5,18 @@ using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
-using Elastic.CommonSchema;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Elasticsearch.Extensions.Logging.Example
 {
-	public class Worker : BackgroundService
-	{
-		private readonly ILogger<Worker> _logger;
 
-		public Worker(ILogger<Worker> logger) => _logger = logger;
+	/// <summary> Simulate work that logs in low volume with some time in between each log call </summary>
+	public class LowVolumeWorkSimulation : BackgroundService
+	{
+		private readonly ILogger<LowVolumeWorkSimulation> _logger;
+
+		public LowVolumeWorkSimulation(ILogger<LowVolumeWorkSimulation> logger) => _logger = logger;
 
 		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 		{

--- a/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
@@ -30,9 +30,9 @@ namespace Elasticsearch.Extensions.Logging.Example
 					loggingBuilder.AddElasticsearch(c =>
 					{
 						if (highLoadUseCase)
-							c.Throttles = new DrainThrottles { ConcurrentConsumers = 4, PublishRejectionCallback = e => Console.Write("!") };
+							c.BufferOptions = new BufferOptions { ConcurrentConsumers = 4, PublishRejectionCallback = e => Console.Write("!") };
 
-						c.Throttles.ElasticsearchResponseCallback = (r, b) =>
+						c.BufferOptions.ElasticsearchResponseCallback = (r, b) =>
 							Console.WriteLine($"Indexed: {r.ApiCall.Success} items: {b.Count} time since first read: {b.DurationSinceFirstRead}");
 					});
 				})

--- a/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Ephemeral;
+using Elasticsearch.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Nest;
+
+namespace Elasticsearch.Extensions.Logging.Example
+{
+	internal static class Program
+	{
+		public static IHostBuilder CreateHostBuilder(string[] args) =>
+			Host.CreateDefaultBuilder(args)
+				.UseConsoleLifetime()
+				.ConfigureAppConfiguration((hostContext, configurationBuilder) =>
+				{
+					configurationBuilder.SetBasePath(AppDomain.CurrentDomain.BaseDirectory);
+				})
+				.ConfigureLogging((hostContext, loggingBuilder) =>
+				{
+					loggingBuilder.AddElasticsearch();
+					// The default configuration section is "Elasticsearch"; if you want
+					// a different section, you can manually configure:
+					// loggingBuilder.AddElasticsearch(options =>
+					//     hostContext.Configuration.Bind("Logging:CustomElasticsearch", options));
+				})
+				.ConfigureServices((hostContext, services) => { services.AddHostedService<Worker>(); });
+
+		public static async Task Main(string[] args)
+		{
+			using var cluster = new EphemeralCluster("7.8.0");
+			var client = CreateClient(cluster);
+			if (!(await client.RootNodeInfoAsync()).IsValid)
+				cluster.Start(TimeSpan.FromMinutes(1));
+			else Console.WriteLine("Using already running Elasticsearch instance");
+
+			await CreateHostBuilder(args).Build().RunAsync();
+		}
+
+		private static ElasticClient CreateClient(EphemeralCluster cluster)
+		{
+			var nodes = cluster.NodesUris();
+			var connectionPool = new StaticConnectionPool(nodes);
+			var settings = new ConnectionSettings(connectionPool)
+				.EnableDebugMode();
+			return new ElasticClient(settings);
+		}
+	}
+}

--- a/examples/Elasticsearch.Extensions.Logging.Example/Worker.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/Worker.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.CommonSchema;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Elasticsearch.Extensions.Logging.Example
+{
+	public class Worker : BackgroundService
+	{
+		private readonly ILogger<Worker> _logger;
+
+		public Worker(ILogger<Worker> logger) => _logger = logger;
+
+		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+		{
+			var ipAddress = IPAddress.Parse("2001:db8:85a3::8a2e:370:7334");
+			var customerId = 12345;
+			var orderId = "PO-56789";
+			var dueDate = new DateTime(2020, 1, 2);
+			var token = new byte[] { 0x12, 0x34, 0xbc, 0xde };
+			var checksum = (byte)0x9a;
+			var success = true;
+			var end = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(6));
+			var total = 100;
+			var rate = 0;
+
+			Thread.CurrentPrincipal = new ClaimsPrincipal(new GenericIdentity("user@example.com"));
+			//Trace.CorrelationManager.ActivityId = Guid.NewGuid();
+
+			using (_logger.BeginScope("IP address {ip}", ipAddress))
+			{
+				try
+				{
+					using (_logger.BeginScope(new Dictionary<string, object> { ["SecretToken"] = token }))
+					{
+						Log.SignInToken(_logger, checksum, success, null);
+					}
+
+					using (_logger.BeginScope("Customer {CustomerId}, Order {OrderId}, Due {DueDate:yyyy-MM-dd}",
+						customerId, orderId, dueDate))
+					{
+						Log.StartingProcessing(_logger, 10, null);
+						var items = new List<Guid>();
+						for (var i = 0; i < 10; i++)
+						{
+							await Task.Delay(TimeSpan.FromMilliseconds(1000), stoppingToken).ConfigureAwait(false);
+							var item = Guid.NewGuid();
+							Log.ProcessOrderItem(_logger, item, null);
+							items.Add(item);
+						}
+
+						using (_logger.BeginScope("{ItemsProcessed}", items))
+						{
+							_logger.LogWarning("End of processing reached at {EndTime}.", end);
+							Log.WarningEndOfProcessing(_logger, end, null);
+						}
+
+						try
+						{
+							var points = total / rate;
+						}
+						catch (Exception ex)
+						{
+							throw new Exception("Calculation error", ex);
+						}
+					}
+				}
+				catch (Exception ex)
+				{
+					using (_logger.BeginScope("PlainScope"))
+					{
+						Log.ErrorProcessingCustomer(_logger, customerId, ex);
+					}
+				}
+			}
+
+			Log.CriticalErrorExecuteFailed(_logger, null);
+		}
+	}
+}

--- a/examples/Elasticsearch.Extensions.Logging.Example/appsettings.json
+++ b/examples/Elasticsearch.Extensions.Logging.Example/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "Elasticsearch": {
+      "Tags": [ "Development", "Example" ],
+      "IndexOffset": "00:00",
+      "IsEnabled": true,
+      "IncludeScopes": true,
+      "IncludeHost": true,
+      "IncludeProcess": true,
+      "IncludeUser": true
+    },
+    "LogLevel" : {
+      "Default": "Trace",
+      "Microsoft": "Warning"
+    }
+  }
+}

--- a/src/Elasticsearch.Extensions.Logging/ConsumerBuffer.cs
+++ b/src/Elasticsearch.Extensions.Logging/ConsumerBuffer.cs
@@ -26,6 +26,7 @@ namespace Elasticsearch.Extensions.Logging
 
 		public TimeSpan ForceFlushAfter { get; }
 		public List<LogEvent> Buffer { get; }
+                /// <summary>The time that the first event is read from the channel and added to the buffer, from first read or after the buffer is reset.</summary>
 		private DateTimeOffset? TimeOfFirstRead { get; set; }
 
 		public int Count => Buffer.Count;

--- a/src/Elasticsearch.Extensions.Logging/ConsumerBuffer.cs
+++ b/src/Elasticsearch.Extensions.Logging/ConsumerBuffer.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Elasticsearch.Extensions.Logging
+{
+	/// <summary>
+	/// Information about the consumers local buffer, available to users in <see cref="DrainThrottles.ElasticsearchResponseCallback" />
+	/// </summary>
+	public interface IConsumerBuffer
+	{
+		int Count { get; }
+		TimeSpan? DurationSinceFirstRead { get; }
+	}
+
+	/// <summary>
+	/// Acts as a wrapper around the consumers buffer of messages. We want the buffer to flush
+	/// every N messages OR in the case messages do no flow fast enough or stop before N messages were received every
+	/// M timespan.
+	/// </summary>
+	internal class ConsumerBuffer : IConsumerBuffer, IDisposable
+	{
+		private readonly int _maxBufferSize;
+
+		public TimeSpan ForceFlushAfter { get; }
+		public List<LogEvent> Buffer { get; }
+		private DateTimeOffset? TimeOfFirstRead { get; set; }
+
+		public int Count => Buffer.Count;
+		public TimeSpan? DurationSinceFirstRead => DateTimeOffset.UtcNow - TimeOfFirstRead;
+		public bool NoThresholdsHit => Count == 0 || (Count < _maxBufferSize && DurationSinceFirstRead <= ForceFlushAfter);
+
+		public ConsumerBuffer(int maxBufferSize, TimeSpan forceFlushAfter)
+		{
+			_maxBufferSize = maxBufferSize;
+			ForceFlushAfter = forceFlushAfter;
+			Buffer = new List<LogEvent>(maxBufferSize);
+			TimeOfFirstRead = null;
+		}
+
+		public void Add(LogEvent item)
+		{
+			TimeOfFirstRead ??= DateTimeOffset.UtcNow;
+			Buffer.Add(item);
+		}
+
+		public void Reset()
+		{
+			Buffer.Clear();
+			TimeOfFirstRead = null;
+		}
+
+		private TimeSpan Wait
+		{
+			get
+			{
+				if (!DurationSinceFirstRead.HasValue) return ForceFlushAfter;
+				var d = DurationSinceFirstRead.Value;
+				return d < ForceFlushAfter ? ForceFlushAfter - d : ForceFlushAfter;
+			}
+		}
+
+		private CancellationTokenSource _breaker = new CancellationTokenSource();
+
+
+		/// <summary>
+		/// Call <see cref="ChannelReader{T}.WaitToReadAsync"/> with a timeout to force a flush to happen every
+		/// <see cref="ForceFlushAfter"/>. This tries to avoid allocation too many <see cref="CancellationTokenSource"/>'s
+		/// needlessly and reuses them if possible. If we know the buffer is empty we can wait indefinitely as well.
+		/// </summary>
+		public async Task<bool> WaitToReadAsync(ChannelReader<LogEvent> reader)
+		{
+			//if we have nothing in the buffer wait indefinitely for messages
+			if (_breaker.IsCancellationRequested)
+			{
+				_breaker.Dispose();
+				_breaker = new CancellationTokenSource();
+			}
+
+			try
+			{
+				//if we have nothing in the buffer wait indefinitely for messages
+				var w = Count == 0 ? TimeSpan.FromMilliseconds(-1) : Wait;
+				_breaker.CancelAfter(w);
+				var _ = await reader.WaitToReadAsync(_breaker.Token).ConfigureAwait(false);
+				_breaker.CancelAfter(ForceFlushAfter);
+				return true;
+			}
+			catch (Exception) when (_breaker.IsCancellationRequested)
+			{
+				_breaker.Dispose();
+				_breaker = new CancellationTokenSource();
+				return true;
+			}
+			catch (Exception)
+			{
+				_breaker.CancelAfter(ForceFlushAfter);
+				return true;
+			}
+		}
+
+		public void Dispose() => _breaker.Dispose();
+	}
+}

--- a/src/Elasticsearch.Extensions.Logging/ConsumerBuffer.cs
+++ b/src/Elasticsearch.Extensions.Logging/ConsumerBuffer.cs
@@ -73,7 +73,6 @@ namespace Elasticsearch.Extensions.Logging
 		/// </summary>
 		public async Task<bool> WaitToReadAsync(ChannelReader<LogEvent> reader)
 		{
-			//if we have nothing in the buffer wait indefinitely for messages
 			if (_breaker.IsCancellationRequested)
 			{
 				_breaker.Dispose();

--- a/src/Elasticsearch.Extensions.Logging/Elasticsearch.Extensions.Logging.csproj
+++ b/src/Elasticsearch.Extensions.Logging/Elasticsearch.Extensions.Logging.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="7.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
+    <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchDataShipper.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchDataShipper.cs
@@ -31,7 +31,7 @@ namespace Elasticsearch.Extensions.Logging
 				FullMode = BoundedChannelFullMode.Wait
 			});
 			async Task ConsumeMessages() =>
-				await Consume(options.Throttles.MaxConsumerBufferSize, options.Throttles.MaxConsumerBufferLifeTime).ConfigureAwait(false);
+				await Consume(options.Throttles.MaxConsumerBufferSize, options.Throttles.MaxConsumerBufferLifetime).ConfigureAwait(false);
 			for (var i = 0; i < maxConsumers; i++)
 				_backgroundTasks.Add(Task.Factory.StartNew(() => ConsumeMessages(), TaskCreationOptions.LongRunning));
 		}

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchDataShipper.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchDataShipper.cs
@@ -146,7 +146,6 @@ namespace Elasticsearch.Extensions.Logging
 			{
 				settings = new ConnectionConfiguration(connectionPool);
 			}
-			settings = settings.EnableDebugMode();
 			var lowlevelClient = new ElasticLowLevelClient(settings);
 
 			_ = Interlocked.Exchange(ref _lowLevelClient, lowlevelClient);

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchDataShipper.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchDataShipper.cs
@@ -49,7 +49,7 @@ namespace Elasticsearch.Extensions.Logging
 				Options.Throttles.PublishRejectionCallback?.Invoke(item);
 		}
 
-		private static readonly byte[] LineFeed = { 10 };
+		private static readonly byte[] LineFeed = { (byte)'\n' };
 
 
 		private async Task Consume(int maxQueuedMessages, TimeSpan maxInterval)

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLogger.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLogger.cs
@@ -55,7 +55,7 @@ namespace Elasticsearch.Extensions.Logging
 				var elasticsearchData =
 					BuildLogEvent(_categoryName, logLevel, eventId, state, exception, formatter);
 
-				_dataShipper.EnqueueMessage(elasticsearchData);
+				_dataShipper.Enqueue(elasticsearchData);
 			}
 			catch (Exception ex)
 			{

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
@@ -100,6 +100,8 @@ namespace Elasticsearch.Extensions.Logging
 		/// </summary>
 		public int ConcurrentConsumers { get; set; } = 1;
 
+		//TODO these should be events since it's unknown if there will be typically one listener or multiple
+
 		/// <summary>
 		/// If <see cref="MaxInFlightMessages"/> is reached, <see cref="LogEvent"/>'s will fail to be published to the channel. You can be notified of dropped
 		/// events with this callback

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
@@ -80,29 +80,29 @@ namespace Elasticsearch.Extensions.Logging
 	public class DrainThrottles
 	{
 		/// <summary>
-		/// The maximum number of `<see cref="LogEvent"/> that can queued in memory. If this threshold is reached messages will be dropped
+		/// The maximum number of <see cref="LogEvent"/> that can be queued in memory. If this threshold is reached, events will be dropped
 		/// </summary>
 		public int MaxInFlightMessages { get; set; } = 100_000;
 
 		/// <summary>
-		/// The number of messages a local buffer should reach before sending the messages in a single call to `Elasticsearch`.
+		/// The number of events a local buffer should reach before sending the events in a single call to Elasticsearch.
 		/// </summary>
 		public int MaxConsumerBufferSize { get; set; } = 1_000;
 
 		/// <summary>
-		/// A consumer builds up a local buffer until <see cref="MaxConsumerBufferSize"/> is reached. If messages come in too slow however these
-		/// messages could end up taking forever to be sent to Elasticsearch. This controls how long a buffer may exists before a flush is triggered.
+		/// A consumer builds up a local buffer until <see cref="MaxConsumerBufferSize"/> is reached. If events come in too slow, these
+		/// events could end up taking forever to be sent to Elasticsearch. This controls how long a buffer may exist before a flush is triggered.
 		/// </summary>
-		public TimeSpan MaxConsumerBufferLifeTime { get; set; } = TimeSpan.FromSeconds(5);
+		public TimeSpan MaxConsumerBufferLifetime { get; set; } = TimeSpan.FromSeconds(5);
 
 		/// <summary>
-		/// The maximum number of consumers allowed to poll for new messages on the channel. Defaults to 1, increase to introduce concurrency.
+		/// The maximum number of consumers allowed to poll for new events on the channel. Defaults to 1, increase to introduce concurrency.
 		/// </summary>
 		public int ConcurrentConsumers { get; set; } = 1;
 
 		/// <summary>
-		/// If <see cref="MaxInFlightMessages"/> is reached, <see cref="LogEvent"/>'s will fail to be published. You can be notified of dropped
-		/// messages with this callback
+		/// If <see cref="MaxInFlightMessages"/> is reached, <see cref="LogEvent"/>'s will fail to be published to the channel. You can be notified of dropped
+		/// events with this callback
 		/// </summary>
 		public Action<LogEvent> PublishRejectionCallback { get; set; } = e => { };
 

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
@@ -70,14 +70,14 @@ namespace Elasticsearch.Extensions.Logging
 		/// </summary>
 		public string[] Tags { get; set; } = new string[0];
 
-		public DrainThrottles Throttles { get; set; } = new DrainThrottles();
+		public BufferOptions BufferOptions { get; set; } = new BufferOptions();
 
 	}
 
 	/// <summary>
 	/// Controls how <see cref="LogEvent"/>'s are batched and send to Elasticsearch. These can not be dynamically updated.
 	/// </summary>
-	public class DrainThrottles
+	public class BufferOptions
 	{
 		/// <summary>
 		/// The maximum number of <see cref="LogEvent"/> that can be queued in memory. If this threshold is reached, events will be dropped

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerProvider.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerProvider.cs
@@ -21,7 +21,7 @@ namespace Elasticsearch.Extensions.Logging
 		public ElasticsearchLoggerProvider(IOptionsMonitor<ElasticsearchLoggerOptions> options)
 		{
 			_options = options;
-			_shipper = new ElasticsearchDataShipper();
+			_shipper = new ElasticsearchDataShipper(options.CurrentValue);
 			_loggers = new ConcurrentDictionary<string, ElasticsearchLogger>();
 			ReloadLoggerOptions(options.CurrentValue);
 			_optionsReloadToken = _options.OnChange(ReloadLoggerOptions);

--- a/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingTests.cs
+++ b/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingTests.cs
@@ -59,7 +59,7 @@ namespace Elasticsearch.Extensions.Logging.IntegrationTests
 			logger.LogError("an error occured");
 
 			// TODO make sure we can await something here on ElasticsearchDataShipper
-			await Task.Delay(TimeSpan.FromSeconds(5));
+			await Task.Delay(TimeSpan.FromSeconds(10));
 
 			var response = Client.Search<LogEvent>(new SearchRequest($"{indexPrefix}-*"));
 

--- a/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingTests.cs
+++ b/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingTests.cs
@@ -37,7 +37,7 @@ namespace Elasticsearch.Extensions.Logging.IntegrationTests
 					o.Index = $"{pre}-{{0:yyyy.MM.dd}}";
 					var nodes = Client.ConnectionSettings.ConnectionPool.Nodes.Select(n => n.Uri).ToArray();
 					o.ShipTo = new ShipTo(nodes, ConnectionPoolType.Static);
-					
+
 				});
 
 			var optionsFactory = new OptionsFactory<ElasticsearchLoggerOptions>(


### PR DESCRIPTION
Continuation of #97

Introduces batching of log events before indexing into Elasticsearch. Powered by `System.Threading.Channels`. It supports sending every N items or every M interval after the first item was added. 

This also introduces the ability to have multiple consumers drain the channel concurrently. 

A callback now exists when items are being dropped because the channel is full and when a `_bulk` request has occurred. 

We still need to add 

- _bulk failure handling
- _bulk retry handling (exponential backoff)
- _bulk rejection callback for `LogEvent` 

Since this PR and #97 are big enough already will tackle the remained when we pull in the flight PR's. 


This also includes a modified version of the example project from @sgryphon 's PR: #69 

It also includes a high volume worker that can be started with `dotnet run -- high`.


