### PR TITLE
Move actual shipper into own project

### DIFF
--- a/ecs-dotnet.sln
+++ b/ecs-dotnet.sln
@@ -77,6 +77,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elasticsearch.Extensions.Lo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elasticsearch.Extensions.Logging.Example", "examples\Elasticsearch.Extensions.Logging.Example\Elasticsearch.Extensions.Logging.Example.csproj", "{F319AD28-A0A4-4012-8480-E2A4CFA755C2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Ingest", "src\Elastic.Ingest\Elastic.Ingest.csproj", "{741E050B-EF53-4531-8406-6FBEB1A5E2D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -169,6 +171,10 @@ Global
 		{F319AD28-A0A4-4012-8480-E2A4CFA755C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F319AD28-A0A4-4012-8480-E2A4CFA755C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F319AD28-A0A4-4012-8480-E2A4CFA755C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{741E050B-EF53-4531-8406-6FBEB1A5E2D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{741E050B-EF53-4531-8406-6FBEB1A5E2D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{741E050B-EF53-4531-8406-6FBEB1A5E2D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{741E050B-EF53-4531-8406-6FBEB1A5E2D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -197,6 +203,7 @@ Global
 		{D88AAA7D-1AEE-4B4C-BE37-69BA85DA07DA} = {7610B796-BB3E-4CB2-8296-79BBFF6D23FC}
 		{0E7008E1-B215-4B9B-BC28-DC9D31415FB9} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 		{F319AD28-A0A4-4012-8480-E2A4CFA755C2} = {05075402-8669-45BD-913A-BD40A29BBEAB}
+		{741E050B-EF53-4531-8406-6FBEB1A5E2D4} = {7610B796-BB3E-4CB2-8296-79BBFF6D23FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Elastic.Elasticsearch.Ephemeral;
+using Elastic.Ingest;
 using Elasticsearch.Net;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,7 +31,7 @@ namespace Elasticsearch.Extensions.Logging.Example
 					loggingBuilder.AddElasticsearch(c =>
 					{
 						if (highLoadUseCase)
-							c.BufferOptions = new BufferOptions { ConcurrentConsumers = 4, PublishRejectionCallback = e => Console.Write("!") };
+							c.BufferOptions = new BufferOptions<LogEvent> { ConcurrentConsumers = 4, PublishRejectionCallback = e => Console.Write("!") };
 
 						c.BufferOptions.ElasticsearchResponseCallback = (r, b) =>
 							Console.WriteLine($"Indexed: {r.ApiCall.Success} items: {b.Count} time since first read: {b.DurationSinceFirstRead}");

--- a/src/Elastic.Ingest/BufferOptions.cs
+++ b/src/Elastic.Ingest/BufferOptions.cs
@@ -3,49 +3,10 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using Elasticsearch.Net;
 
 namespace Elastic.Ingest
 {
-	public class ElasticsearchChannelOptions<TEvent>
-	{
-		//TODO index patters are more complex then this, ILM, write alias, buffer tier, datastreams
-
-		/// <summary>
-		/// Gets or sets the format string for the Elastic search index. The current <c>DateTimeOffset</c> is passed as parameter
-		/// 0.
-		/// </summary>
-		public string Index { get; set; } = "dotnet-{0:yyyy.MM.dd}";
-
-		/// <summary>
-		/// Gets or sets the offset to use for the index <c>DateTimeOffset</c>. Default value is null, which uses the system local
-		/// offset. Use "00:00" for UTC.
-		/// </summary>
-		public TimeSpan? IndexOffset { get; set; }
-
-		/// <summary>
-		/// Gets or sets the connection pool type. Default for multiple nodes is <c>Sniffing</c>; other supported values are
-		/// <c>Static</c>, <c>Sticky</c>, or force to <c>SingleNode</c>.
-		/// </summary>
-		public ConnectionPoolType ConnectionPoolType { get; set; }
-
-		/// <summary>
-		/// Gets or sets the ShipTo property of the Elasticsearch.
-		/// If not specified the default single node is being used.
-		/// "http://localhost:9200" is used.
-		/// </summary>
-		public ShipTo ShipTo { get; set; } = new ShipTo();
-
-		public BufferOptions<TEvent> BufferOptions { get; set; } = new BufferOptions<TEvent>();
-
-		public Func<TEvent, DateTimeOffset?> TimestampLookup { get; set; } = null!;
-
-		public Func<Stream, CancellationToken, TEvent, Task> WriteEvent { get; set; } = null!;
-	}
-
 	/// <summary>
 	/// Controls how <see cref="LogEvent"/>'s are batched and send to Elasticsearch. These can not be dynamically updated.
 	/// </summary>

--- a/src/Elastic.Ingest/ConnectionPoolType.cs
+++ b/src/Elastic.Ingest/ConnectionPoolType.cs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-namespace Elasticsearch.Extensions.Logging
+namespace Elastic.Ingest
 {
 	public enum ConnectionPoolType
 	{

--- a/src/Elastic.Ingest/Elastic.Ingest.csproj
+++ b/src/Elastic.Ingest/Elastic.Ingest.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Title>Elasticsearch Buffer backed data shipper</Title>
+    <Description>TODO</Description>
+    <PackageTags>TODO</PackageTags>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elasticsearch.Net" Version="7.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
+    <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Elastic.Ingest/Elastic.Ingest.csproj
+++ b/src/Elastic.Ingest/Elastic.Ingest.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="7.6.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>
 

--- a/src/Elastic.Ingest/ElasticsearchChannelOptions.cs
+++ b/src/Elastic.Ingest/ElasticsearchChannelOptions.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elastic.Ingest
+{
+	public class ElasticsearchChannelOptions<TEvent>
+	{
+		//TODO index patters are more complex then this, ILM, write alias, buffer tier, datastreams
+
+		/// <summary>
+		/// Gets or sets the format string for the Elastic search index. The current <c>DateTimeOffset</c> is passed as parameter
+		/// 0.
+		/// </summary>
+		public string Index { get; set; } = "dotnet-{0:yyyy.MM.dd}";
+
+		/// <summary>
+		/// Gets or sets the offset to use for the index <c>DateTimeOffset</c>. Default value is null, which uses the system local
+		/// offset. Use "00:00" for UTC.
+		/// </summary>
+		public TimeSpan? IndexOffset { get; set; }
+
+		/// <summary>
+		/// Gets or sets the connection pool type. Default for multiple nodes is <c>Sniffing</c>; other supported values are
+		/// <c>Static</c>, <c>Sticky</c>, or force to <c>SingleNode</c>.
+		/// </summary>
+		public ConnectionPoolType ConnectionPoolType { get; set; }
+
+		/// <summary>
+		/// Gets or sets the ShipTo property of the Elasticsearch.
+		/// If not specified the default single node is being used.
+		/// "http://localhost:9200" is used.
+		/// </summary>
+		public ShipTo ShipTo { get; set; } = new ShipTo();
+
+		public BufferOptions<TEvent> BufferOptions { get; set; } = new BufferOptions<TEvent>();
+
+		public Func<TEvent, DateTimeOffset?> TimestampLookup { get; set; } = null!;
+
+		public Func<Stream, CancellationToken, TEvent, Task> WriteEvent { get; set; } = null!;
+	}
+}

--- a/src/Elastic.Ingest/ElasticsearchLoggerOptions.cs
+++ b/src/Elastic.Ingest/ElasticsearchLoggerOptions.cs
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+
+namespace Elastic.Ingest
+{
+	public class ElasticsearchChannelOptions<TEvent>
+	{
+		//TODO index patters are more complex then this, ILM, write alias, buffer tier, datastreams
+
+		/// <summary>
+		/// Gets or sets the format string for the Elastic search index. The current <c>DateTimeOffset</c> is passed as parameter
+		/// 0.
+		/// </summary>
+		public string Index { get; set; } = "dotnet-{0:yyyy.MM.dd}";
+
+		/// <summary>
+		/// Gets or sets the offset to use for the index <c>DateTimeOffset</c>. Default value is null, which uses the system local
+		/// offset. Use "00:00" for UTC.
+		/// </summary>
+		public TimeSpan? IndexOffset { get; set; }
+
+		/// <summary>
+		/// Gets or sets the connection pool type. Default for multiple nodes is <c>Sniffing</c>; other supported values are
+		/// <c>Static</c>, <c>Sticky</c>, or force to <c>SingleNode</c>.
+		/// </summary>
+		public ConnectionPoolType ConnectionPoolType { get; set; }
+
+		/// <summary>
+		/// Gets or sets the ShipTo property of the Elasticsearch.
+		/// If not specified the default single node is being used.
+		/// "http://localhost:9200" is used.
+		/// </summary>
+		public ShipTo ShipTo { get; set; } = new ShipTo();
+
+		public BufferOptions<TEvent> BufferOptions { get; set; } = new BufferOptions<TEvent>();
+
+		public Func<TEvent, DateTimeOffset?> TimestampLookup { get; set; } = null!;
+
+		public Func<Stream, CancellationToken, TEvent, Task> WriteEvent { get; set; } = null!;
+	}
+
+	/// <summary>
+	/// Controls how <see cref="LogEvent"/>'s are batched and send to Elasticsearch. These can not be dynamically updated.
+	/// </summary>
+	public class BufferOptions<TEvent>
+	{
+		/// <summary>
+		/// The maximum number of <see cref="LogEvent"/> that can be queued in memory. If this threshold is reached, events will be dropped
+		/// </summary>
+		public int MaxInFlightMessages { get; set; } = 100_000;
+
+		/// <summary>
+		/// The number of events a local buffer should reach before sending the events in a single call to Elasticsearch.
+		/// </summary>
+		public int MaxConsumerBufferSize { get; set; } = 1_000;
+
+		/// <summary>
+		/// A consumer builds up a local buffer until <see cref="MaxConsumerBufferSize"/> is reached. If events come in too slow, these
+		/// events could end up taking forever to be sent to Elasticsearch. This controls how long a buffer may exist before a flush is triggered.
+		/// </summary>
+		public TimeSpan MaxConsumerBufferLifetime { get; set; } = TimeSpan.FromSeconds(5);
+
+		/// <summary>
+		/// The maximum number of consumers allowed to poll for new events on the channel. Defaults to 1, increase to introduce concurrency.
+		/// </summary>
+		public int ConcurrentConsumers { get; set; } = 1;
+
+		//TODO these should be events since it's unknown if there will be typically one listener or multiple
+
+		/// <summary>
+		/// If <see cref="MaxInFlightMessages"/> is reached, <see cref="LogEvent"/>'s will fail to be published to the channel. You can be notified of dropped
+		/// events with this callback
+		/// </summary>
+		public Action<TEvent> PublishRejectionCallback { get; set; } = e => { };
+
+		public Action<IElasticsearchResponse, IChannelBuffer> ElasticsearchResponseCallback { get; set; } = (r, b) => { };
+
+	}
+
+}

--- a/src/Elastic.Ingest/ShipTo.cs
+++ b/src/Elastic.Ingest/ShipTo.cs
@@ -6,12 +6,12 @@ using System;
 using System.Collections.Generic;
 using Elasticsearch.Net;
 
-namespace Elasticsearch.Extensions.Logging
+namespace Elastic.Ingest
 {
 	public class ShipTo
 	{
 		public IEnumerable<Uri> NodeUris { get; } = new Uri[0];
-		public ConnectionPoolType? ConnectionPoolType { get; }
+		public ConnectionPoolType? ConnectionPool{ get; }
 		public string CloudId { get; } = string.Empty;
 
 		public string ApiKey { get; } = string.Empty;
@@ -19,12 +19,12 @@ namespace Elasticsearch.Extensions.Logging
 		public string Username { get; } = string.Empty;
 		public string Password { get; } = string.Empty;
 
-		public ShipTo() => ConnectionPoolType = Logging.ConnectionPoolType.SingleNode;
+		public ShipTo() => ConnectionPool = ConnectionPoolType.SingleNode;
 
 		public ShipTo(IEnumerable<Uri> nodeUris, ConnectionPoolType connectionPoolType)
 		{
 			NodeUris = nodeUris;
-			ConnectionPoolType = connectionPoolType;
+			ConnectionPool = connectionPoolType;
 		}
 
 		public ShipTo(string cloudId, string apiKey)
@@ -37,7 +37,7 @@ namespace Elasticsearch.Extensions.Logging
 
 			CloudId = cloudId;
 			ApiKey = apiKey;
-			ConnectionPoolType = Logging.ConnectionPoolType.Cloud;
+			ConnectionPool = ConnectionPoolType.Cloud;
 		}
 
 		public ShipTo(string cloudId, string username, string password)
@@ -55,23 +55,23 @@ namespace Elasticsearch.Extensions.Logging
 			Username = username;
 			Password = password;
 
-			ConnectionPoolType = Logging.ConnectionPoolType.Cloud;
+			ConnectionPool = ConnectionPoolType.Cloud;
 		}
 
 		internal IConnectionPool? CreateConnectionPool()
 		{
-			switch (ConnectionPoolType)
+			switch (ConnectionPool)
 			{
 				// TODO: Add option to randomize pool
-				case Logging.ConnectionPoolType.Unknown:
-				case Logging.ConnectionPoolType.Sniffing:
+				case ConnectionPoolType.Unknown:
+				case ConnectionPoolType.Sniffing:
 					return new SniffingConnectionPool(NodeUris);
-				case Logging.ConnectionPoolType.Static:
+				case ConnectionPoolType.Static:
 					return new StaticConnectionPool(NodeUris);
-				case Logging.ConnectionPoolType.Sticky:
+				case ConnectionPoolType.Sticky:
 					return new StickyConnectionPool(NodeUris);
 				// case ConnectionPoolType.StickySniffing:
-				case Logging.ConnectionPoolType.Cloud:
+				case ConnectionPoolType.Cloud:
 					if (!string.IsNullOrEmpty(ApiKey))
 					{
 						var apiKeyCredentials = new ApiKeyAuthenticationCredentials(ApiKey);
@@ -89,7 +89,7 @@ namespace Elasticsearch.Extensions.Logging
 		{
 			var hashCode = 352033288;
 
-			hashCode = hashCode * -1521134295 + ConnectionPoolType.GetHashCode();
+			hashCode = hashCode * -1521134295 + ConnectionPool.GetHashCode();
 			hashCode = hashCode * -1521134295 + CloudId.GetHashCode();
 			hashCode = hashCode * -1521134295 + Username.GetHashCode();
 			hashCode = hashCode * -1521134295 + Password.GetHashCode();

--- a/src/Elasticsearch.Extensions.Logging/Elasticsearch.Extensions.Logging.csproj
+++ b/src/Elasticsearch.Extensions.Logging/Elasticsearch.Extensions.Logging.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
+    <ProjectReference Include="..\Elastic.Ingest\Elastic.Ingest.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
@@ -1,19 +1,18 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
-// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
-// See the LICENSE file in the project root for more information
-
 using System;
-using Elasticsearch.Net;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Ingest;
 
 namespace Elasticsearch.Extensions.Logging
 {
-	public class ElasticsearchLoggerOptions
+	public class ElasticsearchLoggerOptions : ElasticsearchChannelOptions<LogEvent>
 	{
-		/// <summary>
-		/// Gets or sets the connection pool type. Default for multiple nodes is <c>Sniffing</c>; other supported values are
-		/// <c>Static</c>, <c>Sticky</c>, or force to <c>SingleNode</c>.
-		/// </summary>
-		public ConnectionPoolType ConnectionPoolType { get; set; }
+		public ElasticsearchLoggerOptions()
+		{
+			WriteEvent = async (stream, ctx, l) => await l.SerializeAsync(stream, ctx).ConfigureAwait(false);
+			TimestampLookup = l => l.Timestamp;
+		}
 
 		/// <summary>
 		/// Gets or sets a flag indicating whether host details should be included in the message. Defaults to <c>true</c>.
@@ -36,18 +35,6 @@ namespace Elasticsearch.Extensions.Logging
 		public bool IncludeUser { get; set; } = true;
 
 		/// <summary>
-		/// Gets or sets the format string for the Elastic search index. The current <c>DateTimeOffset</c> is passed as parameter
-		/// 0.
-		/// </summary>
-		public string Index { get; set; } = "dotnet-{0:yyyy.MM.dd}";
-
-		/// <summary>
-		/// Gets or sets the offset to use for the index <c>DateTimeOffset</c>. Default value is null, which uses the system local
-		/// offset. Use "00:00" for UTC.
-		/// </summary>
-		public TimeSpan? IndexOffset { get; set; }
-
-		/// <summary>
 		/// Gets or sets flag indicating if the logger is enabled. Default is <c>true</c>.
 		/// </summary>
 		public bool IsEnabled { get; set; } = true;
@@ -58,58 +45,9 @@ namespace Elasticsearch.Extensions.Logging
 		public string ListSeparator { get; set; } = ", ";
 
 		/// <summary>
-		/// Gets or sets the ShipTo property of the Elasticsearch.
-		/// If not specified the default single node is being used.
-		/// "http://localhost:9200" is used.
-		/// </summary>
-		public ShipTo ShipTo { get; set; } = new ShipTo();
-
-		/// <summary>
 		/// Gets or sets additional tags to pass in the message, for example you can tag with the environment name ('Development',
 		/// 'Production', etc).
 		/// </summary>
 		public string[] Tags { get; set; } = new string[0];
-
-		public BufferOptions BufferOptions { get; set; } = new BufferOptions();
-
 	}
-
-	/// <summary>
-	/// Controls how <see cref="LogEvent"/>'s are batched and send to Elasticsearch. These can not be dynamically updated.
-	/// </summary>
-	public class BufferOptions
-	{
-		/// <summary>
-		/// The maximum number of <see cref="LogEvent"/> that can be queued in memory. If this threshold is reached, events will be dropped
-		/// </summary>
-		public int MaxInFlightMessages { get; set; } = 100_000;
-
-		/// <summary>
-		/// The number of events a local buffer should reach before sending the events in a single call to Elasticsearch.
-		/// </summary>
-		public int MaxConsumerBufferSize { get; set; } = 1_000;
-
-		/// <summary>
-		/// A consumer builds up a local buffer until <see cref="MaxConsumerBufferSize"/> is reached. If events come in too slow, these
-		/// events could end up taking forever to be sent to Elasticsearch. This controls how long a buffer may exist before a flush is triggered.
-		/// </summary>
-		public TimeSpan MaxConsumerBufferLifetime { get; set; } = TimeSpan.FromSeconds(5);
-
-		/// <summary>
-		/// The maximum number of consumers allowed to poll for new events on the channel. Defaults to 1, increase to introduce concurrency.
-		/// </summary>
-		public int ConcurrentConsumers { get; set; } = 1;
-
-		//TODO these should be events since it's unknown if there will be typically one listener or multiple
-
-		/// <summary>
-		/// If <see cref="MaxInFlightMessages"/> is reached, <see cref="LogEvent"/>'s will fail to be published to the channel. You can be notified of dropped
-		/// events with this callback
-		/// </summary>
-		public Action<LogEvent> PublishRejectionCallback { get; set; } = e => { };
-
-		public Action<IElasticsearchResponse, IConsumerBuffer> ElasticsearchResponseCallback { get; set; } = (r, b) => { };
-
-	}
-
 }

--- a/src/Elasticsearch.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/Elasticsearch.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
+using Elastic.Ingest;
 
 namespace Elasticsearch.Extensions.Logging
 {
@@ -25,9 +26,7 @@ namespace Elasticsearch.Extensions.Logging
 			return builder;
 		}
 
-		public static ILoggingBuilder AddElasticsearch(this ILoggingBuilder builder,
-			Action<ElasticsearchLoggerOptions> configure
-		)
+		public static ILoggingBuilder AddElasticsearch(this ILoggingBuilder builder, Action<ElasticsearchLoggerOptions> configure)
 		{
 			if (configure == null) throw new ArgumentNullException(nameof(configure));
 
@@ -36,9 +35,7 @@ namespace Elasticsearch.Extensions.Logging
 			return builder;
 		}
 
-		public static ILoggingBuilder AddElasticCloud(this ILoggingBuilder builder,
-			string cloudId, string apiKey
-		)
+		public static ILoggingBuilder AddElasticCloud(this ILoggingBuilder builder, string cloudId, string apiKey)
 		{
 			if (string.IsNullOrEmpty(cloudId))
 				throw new ArgumentException("cloudId may not be empty.", nameof(cloudId));
@@ -57,9 +54,7 @@ namespace Elasticsearch.Extensions.Logging
 			return builder;
 		}
 
-		public static ILoggingBuilder AddElasticCloud(this ILoggingBuilder builder,
-			string cloudId, string username, string password
-		)
+		public static ILoggingBuilder AddElasticCloud(this ILoggingBuilder builder, string cloudId, string username, string password)
 		{
 			if (string.IsNullOrEmpty(cloudId))
 				throw new ArgumentException("cloudId may not be empty.", nameof(cloudId));

--- a/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingTests.cs
+++ b/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Elastic.CommonSchema;
 using Elastic.Elasticsearch.Xunit;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elastic.Ingest;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
This moves the shipping component from `Elasticsearch.Extensions.Logging` into its own package.

This allows any application to new an `ElasticsearchChannel<TEvent>` and
use it to push data into through  `TryWrite()` . The channel will then take care of
buffering and retrying etc.