### PR TITLE
fix #87 hostname shouldn't be written in server.IP field

### DIFF
--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -194,7 +194,6 @@ namespace Elastic.CommonSchema.Serilog
 
 			var hasHost = e.TryGetScalarPropertyValue(SpecialKeys.Host, out var host);
 			server.Address = hasHost ? host.Value.ToString() : null;
-			server.Ip = hasHost ? host.Value.ToString() : null;
 			return server;
 		}
 


### PR DESCRIPTION
Writing hostname to the IP field creates logs like the one below:

{"@timestamp":"2020-10-21T14:02:51.7698395+03:00","log.level":"Information","message":"Request starting HTTP/1.1 GET http://10.132.4.163:5111/readiness ","_metadata":{"message_template":"{HostingRequestStartingLog:l}","protocol":"HTTP/1.1","method":"GET","content_type":null,"content_length":null,"scheme":"http","path_base":"","path":"/readiness","query_string":"","hosting_request_starting_log":"Request starting HTTP/1.1 GET http://10.132.4.163:5111/readiness ","event_id":{"id":1},"request_id":"0HM3LHKKTLRML:00000001","request_path":"/readiness","span_id":"|3d1c3928-4b1f17b80024b28b.","trace_id":"3d1c3928-4b1f17b80024b28b","parent_id":"","connection_id":"0HM3LHKKTLRML"},"ecs":{"version":"1.5.0"},"event":{"severity":2,"timezone":"GMT+03:00","created":"2020-10-21T14:02:51.7698395+03:00"},"log":{"logger":"Microsoft.AspNetCore.Hosting.Diagnostics","original":null},"process":{"thread":{"id":25},"pid":1,"name":"dotnet","executable":"dotnet"},"server":{"address":"10.132.4.163:5111",**"ip":"10.132.4.163:5111"**}}

which is not parsable as IP
"failed to parse field [server.ip] of type [ip] in document with id '3TwkS3UBbmzuC991IrD5'. Preview of field's value: '10.132.4.163:5111'","caused_by":{"type":"illegal_argument_exception","reason":"'10.132.4.163:5111' is not an IP string literal."}