### PR TITLE
Downgrade Microsoft.Extensions.* packages to 2.1.0.

### DIFF
--- a/src/Elasticsearch.Extensions.Logging/Elasticsearch.Extensions.Logging.csproj
+++ b/src/Elasticsearch.Extensions.Logging/Elasticsearch.Extensions.Logging.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="7.6.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.1.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
As per the GA plan, use lower level package for wider usability.