### PR TITLE
Initial documentation for elastic.co

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,14 @@
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/ecs-logging/dotnet[elastic.co]
+endif::[]
+
+= ECS Logging .NET Reference
+
+ifndef::env-github[]
+include::./intro.asciidoc[Introduction]
+include::./setup.asciidoc[Set up]
+endif::[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,0 +1,87 @@
+[[intro]]
+== Introduction
+
+Centralized logging for .NET applications with the Elastic stack made easy.
+
+[role="screenshot"]
+image:https://user-images.githubusercontent.com/2163464/62682932-9cac3600-b9bd-11e9-9cc3-39e907280f8e.png[]
+
+[float]
+=== What is ECS?
+
+Elastic Common Schema (ECS) defines a common set of fields for ingesting data into Elasticsearch.
+For more information about ECS, visit the {ecs-ref}/ecs-reference.html[ECS Reference Documentation].
+
+[float]
+=== What is ECS logging?
+
+ECS integrations allow the use of Elastic Common Schema with your favorite logging library.
+They make it easy to format your logs into ECS-compatible JSON.
+
+[float]
+=== Why ECS logging?
+
+*No parsing of the log file required*::
++
+--
+ECS-compatible JSON doesn't require the use of Logstash or grok parsing via an ingest node pipeline.
+--
+
+*Decently human-readable JSON structure*::
++
+--
+The first three fields are always `@timestamp`, `log.level` and `message`.
+It's also possible to format stack traces so that each element is rendered in a new line.
+--
+
+*Enjoy the benefits of a common schema*::
++
+--
+Use the Kibana {observability-guide}/monitor-logs.html[Logs app] without additional configuration.
+
+Using a common schema across different services and teams makes it possible create reusable dashboards and avoids {ref}/mapping.html#mapping-limit-settings[mapping explosions].
+--
+
+*APM Log correlation*::
++
+--
+If you are using the {apm-dotnet-ref}/index.html[Elastic APM .NET agent],
+you can leverage the {apm-dotnet-ref}/log-correlation.html[log correlation feature] without any additional configuration.
+This lets you jump from the {kibana-ref}/spans.html[Span timeline in the APM UI] to the {observability-guide}/monitor-logs.html[Logs app],
+showing only the logs which belong to the corresponding request.
+Vice versa, you can also jump from a log line in the Logs UI to the Span Timeline of the APM UI.
+--
+
+[float]
+==== Additional advantages when using in combination with Filebeat
+
+We recommend using this library to log into a JSON log file and using Filebeat to send the logs to Elasticsearch. Here are a few benefits to this approach.
+
+*Resilient in case of outages*::
++
+--
+{filebeat-ref}/how-filebeat-works.html#at-least-once-delivery[Guaranteed at-least-once delivery]
+without buffering within the application, thus no risk of `OutOfMemoryError` s or lost events.
+There's also the option to use either the JSON logs or plain-text logs as a fallback.
+--
+
+*Loose coupling*::
++
+--
+The application does not need to know the details of the logging backend (URI, credentials, etc.).
+You can also leverage alternative {filebeat-ref}/configuring-output.html[Filebeat outputs],
+like Logstash, Kafka or Redis.
+--
+
+*Index Lifecycle management*::
++
+--
+Leverage Filebeat's default {filebeat-ref}/ilm.html[index lifecycle management settings].
+This is much more efficient than using daily indices.
+--
+
+*Efficient Elasticsearch mappings*::
++
+--
+Leverage Filebeat's default ECS-compatible {filebeat-ref}/configuration-template.html[index template]
+--

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,0 +1,55 @@
+[[setup]]
+== Get Started
+
+include::./tab-widgets/code.asciidoc[]
+
+[float]
+[[setup-step-1]]
+=== Step 1: Configure application logging
+
+The following logging frameworks are supported:
+
+* Serilog
+* NLog
+
+[float]
+==== Add the dependency
+
+include::./tab-widgets/add-dependency-widget.asciidoc[]
+
+[float]
+==== Use the ECS integration
+
+include::./tab-widgets/ecs-integration-widget.asciidoc[]
+
+[float]
+[[setup-step-2]]
+=== Step 2: Enable APM log correlation (optional)
+If you are using the Elastic APM .NET agent,
+{apm-dotnet-ref}/log-correlation.html[log correlation can be configured] to 
+inject trace id fields into log events.
+
+[float]
+[[setup-step-3]]
+=== Step 3: Configure Filebeat
+
+Configure your `filebeat.inputs` as follows:
+
+[source,yml]
+----
+filebeat.inputs:
+- type: log
+  paths: /path/to/log.txt
+  json.keys_under_root: true
+  json.overwrite_keys: true
+
+# no further processing required, logs can directly be sent to Elastic Cloud
+cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+cloud.auth: "elastic:YOUR_PASSWORD"
+
+# Or to your local Elasticsearch cluster
+#output.elasticsearch:
+#  hosts: ["https://localhost:9200"]
+----
+
+For more information, check the {filebeat-ref}/configuring-howto-filebeat.html[Filebeat documentation].

--- a/docs/tab-widgets/add-dependency-widget.asciidoc
+++ b/docs/tab-widgets/add-dependency-widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="dependency">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="serilog-tab-install"
+            id="serilog-install">
+      Serilog
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="nlog-tab-install"
+            id="nlog-install"
+            tabindex="-1">
+      NLog
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="serilog-tab-install"
+       aria-labelledby="serilog-install">
+++++
+
+include::add-dependency.asciidoc[tag=serilog]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="nlog-tab-install"
+       aria-labelledby="nlog-install"
+       hidden="">
+++++
+
+include::add-dependency.asciidoc[tag=nlog]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/tab-widgets/add-dependency.asciidoc
+++ b/docs/tab-widgets/add-dependency.asciidoc
@@ -1,0 +1,84 @@
+// tag::serilog[]
+The following target frameworks are supported
+
+|===
+| Name | Target Framework Moniker (TFM)
+
+| .NET Framework 4.6.1
+| `net461`
+
+| .NET Standard 2.0
+| `netstandard2.0`
+
+| .NET Standard 2.1
+| `netstandard2.1`
+|===
+
+The minimum required Serilog version is 2.9.0.
+
+Add a dependency to your application project file:
+[source,xml]
+----
+<Project Sdk="Microsoft.NET.Sdk">
+    <!-- other details excluded for brevity... -->
+    <ItemGroup>
+        <PackageReference Include="Elastic.CommonSchema.Serilog" Version="${ecs-logging-dotnet.version}" />
+    </ItemGroup>
+</Project>
+----
+
+or install with the .NET CLI
+[source,sh]
+----
+dotnet add package Elastic.CommonSchema.Serilog --version ${ecs-logging-dotnet.version}
+----
+
+or nuget CLI
+[source,sh]
+----
+Install-Package Elastic.CommonSchema.Serilog -Version ${ecs-logging-dotnet.version}
+----
+
+// end::serilog[]
+
+// tag::nlog[]
+The following target frameworks are supported
+
+|===
+| Name | Target Framework Moniker (TFM)
+
+| .NET Framework 4.6.1
+| `net461`
+
+| .NET Standard 2.0
+| `netstandard2.0`
+
+| .NET Standard 2.1
+| `netstandard2.1`
+|===
+
+The minimum required NLog version is 4.5.4.
+
+Add a dependency to your application project file:
+[source,xml]
+----
+<Project Sdk="Microsoft.NET.Sdk">
+    <!-- other details excluded for brevity... -->
+    <ItemGroup>
+        <PackageReference Include="Elastic.CommonSchema.NLog" Version="${ecs-logging-dotnet.version}" />
+    </ItemGroup>
+</Project>
+----
+
+or install with the .NET CLI
+[source,sh]
+----
+dotnet add package Elastic.CommonSchema.NLog --version ${ecs-logging-dotnet.version}
+----
+
+or nuget CLI
+[source,sh]
+----
+Install-Package Elastic.CommonSchema.NLog -Version ${ecs-logging-dotnet.version}
+----
+// end::nlog[]

--- a/docs/tab-widgets/code.asciidoc
+++ b/docs/tab-widgets/code.asciidoc
@@ -1,0 +1,166 @@
+// Defining styles and script here for simplicity.
+++++
+<style>
+.tabs {
+  width: 100%;
+}
+[role="tablist"] {
+  margin: 0 0 -0.1em;
+  overflow: visible;
+}
+[role="tab"] {
+  position: relative;
+  padding: 0.3em 0.5em 0.4em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0.2em 0.2em 0 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  background: hsl(220, 20%, 94%);
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before,
+[role="tab"][aria-selected="true"]::before {
+  position: absolute;
+  bottom: 100%;
+  right: -1px;
+  left: -1px;
+  border-radius: 0.2em 0.2em 0 0;
+  border-top: 3px solid hsl(219, 1%, 72%);
+  content: '';
+}
+[role="tab"][aria-selected="true"] {
+  border-radius: 0;
+  background: hsl(220, 43%, 99%);
+  outline: 0;
+}
+[role="tab"][aria-selected="true"]:not(:focus):not(:hover)::before {
+  border-top: 5px solid hsl(218, 96%, 48%);
+}
+[role="tab"][aria-selected="true"]::after {
+  position: absolute;
+  z-index: 3;
+  bottom: -1px;
+  right: 0;
+  left: 0;
+  height: 0.3em;
+  background: hsl(220, 43%, 99%);
+  box-shadow: none;
+  content: '';
+}
+[role="tab"]:hover,
+[role="tab"]:focus,
+[role="tab"]:active {
+  outline: 0;
+  border-radius: 0;
+  color: inherit;
+}
+[role="tab"]:hover::before,
+[role="tab"]:focus::before {
+  border-color: hsl(218, 96%, 48%);
+}
+[role="tabpanel"] {
+  position: relative;
+  z-index: 2;
+  padding: 1em;
+  border: 1px solid hsl(219, 1%, 72%);
+  border-radius: 0 0.2em 0.2em 0.2em;
+  box-shadow: 0 0 0.2em hsl(219, 1%, 72%);
+  background: hsl(220, 43%, 99%);
+  margin-bottom: 1em;
+}
+[role="tabpanel"] p {
+  margin: 0;
+}
+[role="tabpanel"] * + p {
+  margin-top: 1em;
+}
+</style>
+
+<script>
+window.addEventListener("DOMContentLoaded", () => {
+  const tabs = document.querySelectorAll('[role="tab"]');
+  const tabList = document.querySelector('[role="tablist"]');
+  // Add a click event handler to each tab
+  tabs.forEach(tab => {
+    tab.addEventListener("click", changeTabs);
+  });
+  // Enable arrow navigation between tabs in the tab list
+  let tabFocus = 0;
+  tabList.addEventListener("keydown", e => {
+    // Move right
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      tabs[tabFocus].setAttribute("tabindex", -1);
+      if (e.keyCode === 39) {
+        tabFocus++;
+        // If we're at the end, go to the start
+        if (tabFocus >= tabs.length) {
+          tabFocus = 0;
+        }
+        // Move left
+      } else if (e.keyCode === 37) {
+        tabFocus--;
+        // If we're at the start, move to the end
+        if (tabFocus < 0) {
+          tabFocus = tabs.length - 1;
+        }
+      }
+      tabs[tabFocus].setAttribute("tabindex", 0);
+      tabs[tabFocus].focus();
+    }
+  });
+});
+
+function setActiveTab(target) {
+  const parent = target.parentNode;
+  const grandparent = parent.parentNode;
+  // console.log(grandparent);
+  // Remove all current selected tabs
+  parent
+    .querySelectorAll('[aria-selected="true"]')
+    .forEach(t => t.setAttribute("aria-selected", false));
+  // Set this tab as selected
+  target.setAttribute("aria-selected", true);
+  // Hide all tab panels
+  grandparent
+    .querySelectorAll('[role="tabpanel"]')
+    .forEach(p => p.setAttribute("hidden", true));
+  // Show the selected panel
+  grandparent.parentNode
+    .querySelector(`#${target.getAttribute("aria-controls")}`)
+    .removeAttribute("hidden");
+}
+
+function changeTabs(e) {
+  // get the containing list of the tab that was just clicked
+  const tabList = e.target.parentNode;
+
+  // get all of the sibling tabs
+  const buttons = Array.apply(null, tabList.querySelectorAll('button'));
+
+  // loop over the siblings to discover which index thje clicked one was
+  const { index } = buttons.reduce(({ found, index }, button) => {
+    if (!found && buttons[index] === e.target) {
+      return { found: true, index };
+    } else if (!found) {
+      return { found, index: index + 1 };
+    } else {
+      return { found, index };
+    }
+  }, { found: false, index: 0 });
+
+  // get the tab container
+  const container = tabList.parentNode;
+  // read the data-tab-group value from the container, e.g. "os"
+  const { tabGroup } = container.dataset;
+  // get a list of all the tab groups that match this value on the page
+  const groups = document.querySelectorAll('[data-tab-group=' + tabGroup + ']');
+
+  // for each of the found tab groups, find the tab button at the previously discovered index and select it for each group
+  groups.forEach((group) => {
+    const target = group.querySelectorAll('button')[index];
+    setActiveTab(target);
+  });
+}
+</script>
+++++

--- a/docs/tab-widgets/ecs-integration-widget.asciidoc
+++ b/docs/tab-widgets/ecs-integration-widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="ecs-integration">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="serilog-tab-ecs-integration"
+            id="serilog-ecs-integration">
+      Serilog
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="nlog-tab-ecs-integration"
+            id="nlog-ecs-integration"
+            tabindex="-1">
+      NLog
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="serilog-tab-ecs-integration"
+       aria-labelledby="serilog-ecs-integration">
+++++
+
+include::ecs-integration.asciidoc[tag=serilog]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="nlog-tab-ecs-integration"
+       aria-labelledby="nlog-ecs-integration"
+       hidden="">
+++++
+
+include::ecs-integration.asciidoc[tag=nlog]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/tab-widgets/ecs-integration.asciidoc
+++ b/docs/tab-widgets/ecs-integration.asciidoc
@@ -1,0 +1,249 @@
+// tag::serilog[]
+**Serilog Text Formatter**
+
+`EcsTextFormatter` is an `ITextFormatter` implementation in 
+Elastic.CommonSchema.Serilog that formats Serilog events into 
+a JSON representation that adheres to the Elastic Common Schema specification.
+
+It can be configured in conjunction with a Serilog Sink. To configure
+with the file sink for example, first install 
+https://www.nuget.org/packages/Serilog.Sinks.File/[Serilog.Sinks.File] nuget
+package
+
+[source,sh]
+----
+Install-Package Serilog.Sinks.File
+----
+
+Then configure the file sink to use `EcsTextFormatter`:
+
+[source,csharp]
+----
+var logger = new LoggerConfiguration()
+    .WriteTo.File(new EcsTextFormatter(), "/path/to/log.txt")
+    .CreateLogger();
+----
+
+Now, when logging events
+
+[source,csharp]
+----
+logger.Information("Checkout contains {ItemCount} items", 12); <1>
+----
+<1> log a message with the information level
+
+Each Serilog log event will be formatted as single line JSON in the file
+`/path/to/log.txt`. 
+
+// end::serilog[]
+
+// tag::nlog[]
+**NLog Layout**
+
+`EcsLayout` is a `Layout` implementation in Elastic.CommonSchema.NLog that
+formats an NLog event into a JSON representation that adheres to the 
+Elastic Common Schema specification.
+
+It can be configured as the layout of an NLog Target. To configure
+with the file target for example, using code configuration:
+
+[source, csharp]
+----
+var config = new LoggingConfiguration();
+var fileTarget = new FileTarget() 
+{
+    Layout = new EcsLayout(), <1>
+    FileName = "/path/to/log.txt"
+};
+config.AddRule(LogLevel.Info, LogLevel.Fatal, fileTarget);
+LogManager.Configuration = config;
+var logger = LogManager.GetCurrentClassLogger();
+----
+<1> Create a new instance of ECS layout
+
+In addition to code configuration, `EcsLayout` can be configured using 
+XML configuration in https://github.com/nlog/NLog/wiki/Configuration-file[`NLog.config`]:
+
+[source,xml]
+----
+<nlog>
+  <extensions>
+    <add assembly="Elastic.CommonSchema.NLog"/>
+  </extensions>
+  <targets>
+    <target name="file" type="File">
+      <layout xsi:type="EcsLayout">
+      </layout>
+    </target>
+  </targets>
+  <rules>
+    <logger name="*" minLevel="Info" writeTo="File" />
+  </rules>
+</nlog>
+----
+
+Now, when logging events:
+
+[source,csharp]
+----
+logger.Info("Checkout contains {ItemCount} items", 12); <1>
+----
+<1> log a message with the information level
+
+Each NLog log event will be formatted as single line JSON in the file
+`/path/to/log.txt`.
+
+**EcsLayout Parameter Options**
+
+The following properties determine which properties should be included
+or excluded as metadata of an event
+
+|===
+| Parameter name | Type | Default | Description
+
+| `IncludeAllProperties`
+| bool
+| `true`
+| Include LogEvent properties as metadata
+
+| `IncludeMdlc`
+| bool
+| `false`
+| Include NLog Scope Context Properties as metadata
+
+| `ExcludeProperties`
+| string
+| 
+| Comma separated string of properties to exclude from metadata
+
+The following are NLog `Layout` properties used to capture
+information for an event
+
+|===
+| Parameter name | Type | Default | Description
+
+| `EventAction`
+| string 
+| 
+| The action captured by the event
+
+| `EventCategory`
+| string
+| 
+| The category of the event.
+
+| `EventId`
+| string
+|
+| The unique identifier for the event
+
+| `EventKind`
+| string
+|
+| The kind of event. High level information about what kind of information the event contains
+
+| `EventSeverity`
+| long
+| _NLog level_
+
+* Trace, Debug:: 7
+* Info:: 6
+* Warn:: 4
+* Error:: 3
+* Fatal:: 2
+
+| The severity of the event
+
+| `AgentId`
+| string
+| 
+| The id of the agent collecting events
+
+| `AgentName`
+| string
+| 
+| The name of the agent collecting events
+
+| `AgentType`
+| string
+| 
+| The type of the agent collecting events
+
+| `AgentVersion`
+| string
+| 
+| The version of the agent collecting events
+
+| `ProcessExecutable`
+| string
+| `${processname:FullName=true}`
+| Absolute path to the process executable
+
+| `ProcessId`
+| long
+| `${processid}`
+| The process id (pid)
+
+| `ProcessName`
+| string
+| `${processname:FullName=false}`
+| The name of the process
+
+| `ProcessThreadId`
+| long
+| `${threadid}`
+| The id of the process thread
+
+| `ProcessTitle`
+| string
+| `${processinfo:MainWindowTitle}`
+| The title of the process
+
+| `ServerAddress`
+| string
+| 
+| The address of the server
+
+| `ServerIp`
+| string
+| 
+| The IP address of the server
+
+| `ServerUser`
+| string
+| `${environment-user}`
+| Information about the user that is relevant to the event
+
+| `HostId`
+| string
+| 
+| Unique host id. Hostnames are not always unique, so use an id that is meaningful in your environment
+
+| `HostIp`
+|
+| `${local-ip:cachedSeconds=60}` _(requires NLog 4.6.8+)_
+| The IP address of the host
+
+| `HostName`
+| string
+| `${machinename}`
+| The name of the host
+
+| `LogOriginCallSiteMethod`
+| string
+| `${exception:format=method}`
+| The name of the function or method which originated the event
+
+| `LogOriginCallSiteFile`
+| string
+| `${exception:format=source}`
+| The file containing the source code which originated the event
+
+| `LogOriginCallSiteLine`
+| string
+|
+| The line number of the file containing the source code which originated the event
+
+|===
+
+// end::nlog[]


### PR DESCRIPTION
Relates: #119

This commit adds initial documentation for the elastic.co website. It follows a similar layout and structure to the ECS logging documentation for Java.