### PR TITLE
docs: Use shared ecs-logging content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ project.lock.json
 /src/.vs/restore.dg
 src/packages/
 BenchmarkDotNet.Artifacts
+
+html_docs

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,3 +1,5 @@
+:ecs-repo-dir:  {ecs-logging-root}/docs/
+
 include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,7 +1,7 @@
 [[intro]]
 == Introduction
 
-ECS loggers are formatter/encoder plugins for your favorite logging libraries.
+ECS logging are integrations for your favorite .NET logging libraries.
 They make it easy to format your logs into ECS-compatible JSON.
 
 TIP: Want to learn more about ECS, ECS logging, and other available language plugins?

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,87 +1,10 @@
 [[intro]]
 == Introduction
 
-Centralized logging for .NET applications with the Elastic stack made easy.
-
-[role="screenshot"]
-image:https://user-images.githubusercontent.com/2163464/62682932-9cac3600-b9bd-11e9-9cc3-39e907280f8e.png[]
-
-[float]
-=== What is ECS?
-
-Elastic Common Schema (ECS) defines a common set of fields for ingesting data into Elasticsearch.
-For more information about ECS, visit the {ecs-ref}/ecs-reference.html[ECS Reference Documentation].
-
-[float]
-=== What is ECS logging?
-
-ECS integrations allow the use of Elastic Common Schema with your favorite logging library.
+ECS loggers are formatter/encoder plugins for your favorite logging libraries.
 They make it easy to format your logs into ECS-compatible JSON.
 
-[float]
-=== Why ECS logging?
+TIP: Want to learn more about ECS, ECS logging, and other available language plugins?
+See the {ecs-logging-ref}/intro.html[ECS logging overview].
 
-*No parsing of the log file required*::
-+
---
-ECS-compatible JSON doesn't require the use of Logstash or grok parsing via an ingest node pipeline.
---
-
-*Decently human-readable JSON structure*::
-+
---
-The first three fields are always `@timestamp`, `log.level` and `message`.
-It's also possible to format stack traces so that each element is rendered in a new line.
---
-
-*Enjoy the benefits of a common schema*::
-+
---
-Use the Kibana {observability-guide}/monitor-logs.html[Logs app] without additional configuration.
-
-Using a common schema across different services and teams makes it possible create reusable dashboards and avoids {ref}/mapping.html#mapping-limit-settings[mapping explosions].
---
-
-*APM Log correlation*::
-+
---
-If you are using the {apm-dotnet-ref}/index.html[Elastic APM .NET agent],
-you can leverage the {apm-dotnet-ref}/log-correlation.html[log correlation feature] without any additional configuration.
-This lets you jump from the {kibana-ref}/spans.html[Span timeline in the APM UI] to the {observability-guide}/monitor-logs.html[Logs app],
-showing only the logs which belong to the corresponding request.
-Vice versa, you can also jump from a log line in the Logs UI to the Span Timeline of the APM UI.
---
-
-[float]
-==== Additional advantages when using in combination with Filebeat
-
-We recommend using this library to log into a JSON log file and using Filebeat to send the logs to Elasticsearch. Here are a few benefits to this approach.
-
-*Resilient in case of outages*::
-+
---
-{filebeat-ref}/how-filebeat-works.html#at-least-once-delivery[Guaranteed at-least-once delivery]
-without buffering within the application, thus no risk of `OutOfMemoryError` s or lost events.
-There's also the option to use either the JSON logs or plain-text logs as a fallback.
---
-
-*Loose coupling*::
-+
---
-The application does not need to know the details of the logging backend (URI, credentials, etc.).
-You can also leverage alternative {filebeat-ref}/configuring-output.html[Filebeat outputs],
-like Logstash, Kafka or Redis.
---
-
-*Index Lifecycle management*::
-+
---
-Leverage Filebeat's default {filebeat-ref}/ilm.html[index lifecycle management settings].
-This is much more efficient than using daily indices.
---
-
-*Efficient Elasticsearch mappings*::
-+
---
-Leverage Filebeat's default ECS-compatible {filebeat-ref}/configuration-template.html[index template]
---
+Ready to jump into `ecs-logging-dotnet`? <<setup,Get started>>.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -26,30 +26,11 @@ include::./tab-widgets/ecs-integration-widget.asciidoc[]
 [[setup-step-2]]
 === Step 2: Enable APM log correlation (optional)
 If you are using the Elastic APM .NET agent,
-{apm-dotnet-ref}/log-correlation.html[log correlation can be configured] to 
+{apm-dotnet-ref}/log-correlation.html[log correlation can be configured] to
 inject trace id fields into log events.
 
 [float]
 [[setup-step-3]]
 === Step 3: Configure Filebeat
 
-Configure your `filebeat.inputs` as follows:
-
-[source,yml]
-----
-filebeat.inputs:
-- type: log
-  paths: /path/to/log.txt
-  json.keys_under_root: true
-  json.overwrite_keys: true
-
-# no further processing required, logs can directly be sent to Elastic Cloud
-cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
-cloud.auth: "elastic:YOUR_PASSWORD"
-
-# Or to your local Elasticsearch cluster
-#output.elasticsearch:
-#  hosts: ["https://localhost:9200"]
-----
-
-For more information, check the {filebeat-ref}/configuring-howto-filebeat.html[Filebeat documentation].
+include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]

--- a/docs/tab-widgets/ecs-integration.asciidoc
+++ b/docs/tab-widgets/ecs-integration.asciidoc
@@ -1,12 +1,12 @@
 // tag::serilog[]
 **Serilog Text Formatter**
 
-`EcsTextFormatter` is an `ITextFormatter` implementation in 
-Elastic.CommonSchema.Serilog that formats Serilog events into 
+`EcsTextFormatter` is an `ITextFormatter` implementation in
+Elastic.CommonSchema.Serilog that formats Serilog events into
 a JSON representation that adheres to the Elastic Common Schema specification.
 
 It can be configured in conjunction with a Serilog Sink. To configure
-with the file sink for example, first install 
+with the file sink for example, first install
 https://www.nuget.org/packages/Serilog.Sinks.File/[Serilog.Sinks.File] nuget
 package
 
@@ -33,7 +33,7 @@ logger.Information("Checkout contains {ItemCount} items", 12); <1>
 <1> log a message with the information level
 
 Each Serilog log event will be formatted as single line JSON in the file
-`/path/to/log.txt`. 
+`/path/to/log.txt`.
 
 // end::serilog[]
 
@@ -41,7 +41,7 @@ Each Serilog log event will be formatted as single line JSON in the file
 **NLog Layout**
 
 `EcsLayout` is a `Layout` implementation in Elastic.CommonSchema.NLog that
-formats an NLog event into a JSON representation that adheres to the 
+formats an NLog event into a JSON representation that adheres to the
 Elastic Common Schema specification.
 
 It can be configured as the layout of an NLog Target. To configure
@@ -50,7 +50,7 @@ with the file target for example, using code configuration:
 [source, csharp]
 ----
 var config = new LoggingConfiguration();
-var fileTarget = new FileTarget() 
+var fileTarget = new FileTarget()
 {
     Layout = new EcsLayout(), <1>
     FileName = "/path/to/log.txt"
@@ -61,7 +61,7 @@ var logger = LogManager.GetCurrentClassLogger();
 ----
 <1> Create a new instance of ECS layout
 
-In addition to code configuration, `EcsLayout` can be configured using 
+In addition to code configuration, `EcsLayout` can be configured using
 XML configuration in https://github.com/nlog/NLog/wiki/Configuration-file[`NLog.config`]:
 
 [source,xml]
@@ -98,7 +98,7 @@ Each NLog log event will be formatted as single line JSON in the file
 The following properties determine which properties should be included
 or excluded as metadata of an event
 
-|===
+|====
 | Parameter name | Type | Default | Description
 
 | `IncludeAllProperties`
@@ -113,23 +113,24 @@ or excluded as metadata of an event
 
 | `ExcludeProperties`
 | string
-| 
+|
 | Comma separated string of properties to exclude from metadata
+|====
 
 The following are NLog `Layout` properties used to capture
 information for an event
 
-|===
+|====
 | Parameter name | Type | Default | Description
 
 | `EventAction`
-| string 
-| 
+| string
+|
 | The action captured by the event
 
 | `EventCategory`
 | string
-| 
+|
 | The category of the event.
 
 | `EventId`
@@ -156,22 +157,22 @@ information for an event
 
 | `AgentId`
 | string
-| 
+|
 | The id of the agent collecting events
 
 | `AgentName`
 | string
-| 
+|
 | The name of the agent collecting events
 
 | `AgentType`
 | string
-| 
+|
 | The type of the agent collecting events
 
 | `AgentVersion`
 | string
-| 
+|
 | The version of the agent collecting events
 
 | `ProcessExecutable`
@@ -201,12 +202,12 @@ information for an event
 
 | `ServerAddress`
 | string
-| 
+|
 | The address of the server
 
 | `ServerIp`
 | string
-| 
+|
 | The IP address of the server
 
 | `ServerUser`
@@ -216,7 +217,7 @@ information for an event
 
 | `HostId`
 | string
-| 
+|
 | Unique host id. Hostnames are not always unique, so use an id that is meaningful in your environment
 
 | `HostIp`
@@ -244,6 +245,6 @@ information for an event
 |
 | The line number of the file containing the source code which originated the event
 
-|===
+|====
 
 // end::nlog[]


### PR DESCRIPTION
This PR updates the `ecs-dotnet` docs to use shared content from the `ecs-logging` docs. It also fixes some asciidoc errors in `ecs-integration.asciidoc` that were preventing the docs from building.

To test this PR, you'll need an up-to-date copy of both [`elastic/docs`](https://github.com/elastic/docs) and [`elastic/ecs-logging`](https://github.com/elastic/ecs-logging). Then run:

```
$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1 --open
```

For https://github.com/elastic/docs/pull/2018.