### PR TITLE
test: synchronizing spec

### DIFF
--- a/tests/Elastic.CommonSchema.Tests/Specs/spec.json
+++ b/tests/Elastic.CommonSchema.Tests/Specs/spec.json
@@ -9,7 +9,11 @@
             "type": "datetime",
             "required": true,
             "index": 0,
-            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "comment": [
+                "Field order, as specified by 'index', is RECOMMENDED.",
+                "ECS loggers must implement field order unless the logging framework makes that impossible."
+            ]
         },
         "log.level": {
             "type": "string",


### PR DESCRIPTION
### What
  ECS logging specs automatic sync

  ### Why
  *Manually forced with the CI automation job.*