### PR TITLE
Switch to serviced dotnet/sdk tag

### DIFF
--- a/.ci/docker/sdk-linux/Dockerfile
+++ b/.ci/docker/sdk-linux/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
+FROM mcr.microsoft.com/dotnet/sdk:5.0


### PR DESCRIPTION
This `5.0.102-ca-patch-buster-slim` tag is no longer needed and is no longer serviced.

Context: https://github.com/dotnet/dotnet-docker/issues/2742

As an aside, do you have any feedback on how .NET container images can be improved? Do they meet your expectations?