### PR TITLE
Add span id to APM Logging integrations

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -27,7 +27,7 @@ include::./tab-widgets/ecs-integration-widget.asciidoc[]
 === Step 2: Enable APM log correlation (optional)
 If you are using the Elastic APM .NET agent,
 {apm-dotnet-ref}/log-correlation.html[log correlation can be configured] to
-inject trace id fields into log events.
+inject trace, transaction and span id fields into log events.
 
 [float]
 [[setup-step-3]]

--- a/src/Elastic.Apm.NLog/ApmSpanIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmSpanIdLayoutRenderer.cs
@@ -1,0 +1,22 @@
+using System.Text;
+using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace Elastic.Apm.NLog
+{
+	[LayoutRenderer(Name)]
+	[ThreadSafe]
+	public class ApmSpanIdLayoutRenderer : LayoutRenderer
+	{
+		public const string Name = "ElasticApmSpanId";
+
+		protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+		{
+			if (!Agent.IsConfigured) return;
+			if (Agent.Tracer?.CurrentSpan is null) return;
+
+			builder.Append(Agent.Tracer.CurrentSpan.Id);
+		}
+	}
+}

--- a/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.NLog
 		protected override void Append(StringBuilder builder, LogEventInfo logEvent)
 		{
 			if (!Agent.IsConfigured) return;
-			if (Agent.Tracer?.CurrentTransaction == null) return;
+			if (Agent.Tracer?.CurrentTransaction is null) return;
 
 			builder.Append(Agent.Tracer.CurrentTransaction.TraceId);
 		}

--- a/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.NLog
 		protected override void Append(StringBuilder builder, LogEventInfo logEvent)
 		{
 			if (!Agent.IsConfigured) return;
-			if (Agent.Tracer?.CurrentTransaction == null) return;
+			if (Agent.Tracer?.CurrentTransaction is null) return;
 
 			builder.Append(Agent.Tracer.CurrentTransaction.Id);
 		}

--- a/src/Elastic.Apm.NLog/readme.md
+++ b/src/Elastic.Apm.NLog/readme.md
@@ -4,6 +4,7 @@ Allows you to add the following place holders in your NLog templates:
 
 * `ElasticApmTraceId`
 * `ElasticApmTransactionId`
+* `ElasticApmSpanId`
 
 Which will be replaced with the appropriate Elastic APM variables if available
 
@@ -14,10 +15,11 @@ The .NET assemblies are published to NuGet under the package name [Elastic.Apm.N
 ## How to use from API
 
 ```csharp
-// Logged message will be in format of `trace-id|transation-id|InTransaction`
-// or `||InTransaction` if the place holders are not available
+// Logged message will be in format of `trace-id|transation-id|span-id|InTransaction`
+// or `|||InTransaction` if the place holders are not available
 var consoleTarget = new ConsoleTarget("console");
-consoleTarget.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}";
+consoleTarget.Layout = 
+    "${ElasticApmTraceId}|${ElasticApmTransactionId}|${ElasticApmSpanId}|${message}";
 config.AddRule(LogLevel.Debug, LogLevel.Fatal, consoleTarget);
 LogManager.Configuration = config;
 var logger = LogManager.GetCurrentClassLogger();
@@ -31,7 +33,9 @@ var logger = LogManager.GetCurrentClassLogger();
     <add assembly="Elastic.Apm.NLog"/>
   </extensions>
   <targets>
-    <target name="console" type="console" layout="${ElasticApmTraceId}|${ElasticApmTransactionId}|${message}" />
+    <target name="console" 
+        type="console" 
+        layout="${ElasticApmTraceId}|${ElasticApmTransactionId}|${ElasticApmSpanId}|${message}" />
   </targets>
   <rules>
     <logger name="*" minLevel="Debug" writeTo="Console" />

--- a/src/Elastic.Apm.SerilogEnricher/ElasticApmEnricher.cs
+++ b/src/Elastic.Apm.SerilogEnricher/ElasticApmEnricher.cs
@@ -8,20 +8,28 @@ using Serilog.Events;
 namespace Elastic.Apm.SerilogEnricher
 {
 	/// <summary>
-	/// This enricher adds trace id and the transaction id for every log that is created during a transaction in case
-	/// the Elastic APM Agent is active in your application.
+	/// This enricher adds trace id and transaction id for every log that is created during a
+	/// transaction in case the Elastic APM Agent is active in your application. If there is
+	/// an active span, the span id is also added.
 	/// </summary>
 	public sealed class ElasticApmEnricher : ILogEventEnricher
 	{
 		public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
 		{
 			if (!Agent.IsConfigured) return;
-			if (Agent.Tracer?.CurrentTransaction == null) return;
+			if (Agent.Tracer is null) return;
+			if (Agent.Tracer.CurrentTransaction is null) return;
 
 			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
 				"ElasticApmTransactionId", Agent.Tracer.CurrentTransaction.Id));
 			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
 				"ElasticApmTraceId", Agent.Tracer.CurrentTransaction.TraceId));
+
+			if (Agent.Tracer.CurrentSpan != null)
+			{
+				logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
+					"ElasticApmSpanId", Agent.Tracer.CurrentSpan.Id));
+			}
 		}
 	}
 }

--- a/src/Elastic.Apm.SerilogEnricher/readme.md
+++ b/src/Elastic.Apm.SerilogEnricher/readme.md
@@ -11,20 +11,27 @@ The .NET assemblies are published to NuGet under the package name [Elastic.Apm.S
 ```csharp
 var logger = new LoggerConfiguration()
    .Enrich.WithElasticApmCorrelationInfo()
-   .WriteTo.Console(outputTemplate: "[{ElasticApmTraceId} {ElasticApmTransactionId} {Message:lj} {NewLine}{Exception}")
+   .WriteTo.Console(outputTemplate: "[{ElasticApmTraceId} {ElasticApmTransactionId} {ElasticApmSpanId} {Message:lj} {NewLine}{Exception}")
    .CreateLogger();
 ```
 
-In the code snippet above `Enrich.WithElasticApmCorrelationInfo()` enables the enricher from this project, which will set 2 properties for log lines that are created during a transaction:
+In the code snippet above `Enrich.WithElasticApmCorrelationInfo()` enables the enricher from this project, 
+which will set 3 properties for log lines that are created during a transaction:
 
-- `ElasticApmTransactionId`
 - `ElasticApmTraceId`
+- `ElasticApmTransactionId`
+- `ElasticApmSpanId`
 
-These two properties are printed to the Console using the `outputTemplate` parameter, of course they can be used with any sink, you could consider using a filesystem sink and [Elastic Filebeat](https://www.elastic.co/downloads/beats/filebeat) for durable and reliable ingestion. This enricher is also compatible with the [Elastic.CommonSchema.Serilog](https://www.nuget.org/packages/Elastic.CommonSchema.Serilog) package.
+These two properties are printed to the Console using the `outputTemplate` parameter, of course they can 
+be used with any sink, you could consider using a filesystem sink and 
+[Elastic Filebeat](https://www.elastic.co/downloads/beats/filebeat) for durable and reliable ingestion. 
+This enricher is also compatible with the 
+[Elastic.CommonSchema.Serilog](https://www.nuget.org/packages/Elastic.CommonSchema.Serilog) package.
 
 ## Prerequisite
 
-The prerequisite for this to work is a configured [Elastic APM Agent](https://github.com/elastic/apm-agent-dotnet). If the agent is not configured the enricher won't add anything to the logs.
+The prerequisite for this to work is a configured [Elastic APM Agent](https://github.com/elastic/apm-agent-dotnet). 
+If the agent is not configured the enricher won't add anything to the logs.
 
 ## Copyright and License
 

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -55,6 +55,7 @@ namespace Elastic.CommonSchema.NLog
 			{
 				ApmTraceId = "${ElasticApmTraceId}";
 				ApmTransactionId = "${ElasticApmTransactionId}";
+				ApmSpanId = "${ElasticApmSpanId}";
 			}
 		}
 
@@ -65,6 +66,8 @@ namespace Elastic.CommonSchema.NLog
 
 		public Layout ApmTraceId { get; set; }
 		public Layout ApmTransactionId { get; set; }
+
+		public Layout ApmSpanId { get; set; }
 
 		/// <summary>
 		/// Allow dynamically disabling <see cref="ThreadAgnosticAttribute" /> to
@@ -133,6 +136,7 @@ namespace Elastic.CommonSchema.NLog
 				Process = GetProcess(logEvent),
 				Trace = GetTrace(logEvent),
 				Transaction = GetTransaction(logEvent),
+				Span = GetSpan(logEvent),
 				Error = GetError(logEvent.Exception),
 				Tags = GetTags(logEvent),
 				Labels = GetLabels(logEvent),
@@ -450,6 +454,18 @@ namespace Elastic.CommonSchema.NLog
 			return new Transaction
 			{
 				Id = transactionId
+			};
+		}
+
+		private Span GetSpan(LogEventInfo logEventInfo)
+		{
+			var spanId = ApmSpanId?.Render(logEventInfo);
+			if (string.IsNullOrEmpty(spanId))
+				return null;
+
+			return new Span
+			{
+				Id = spanId
 			};
 		}
 

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -60,7 +60,8 @@ namespace Elastic.CommonSchema.Serilog
 				Process = GetProcess(logEvent, configuration.MapCurrentThread),
 				Host = GetHost(logEvent),
 				Trace = GetTrace(logEvent),
-				Transaction = GetTransaction(logEvent)
+				Transaction = GetTransaction(logEvent),
+				Span = GetSpan(logEvent)
 			};
 
 			if (configuration.MapHttpAdapter != null)
@@ -90,6 +91,11 @@ namespace Elastic.CommonSchema.Serilog
 			!logEvent.TryGetScalarPropertyValue("ElasticApmTransactionId", out var transactionId)
 				? null
 				: new Transaction { Id = transactionId.Value.ToString() };
+
+		private static Span GetSpan(LogEvent logEvent) =>
+			!logEvent.TryGetScalarPropertyValue("ElasticApmSpanId", out var spanId)
+				? null
+				: new Span { Id = spanId.Value.ToString() };
 
 		private static IDictionary<string, object> GetMetadata(LogEvent logEvent, ISet<string> logEventPropertiesToFilter)
 		{

--- a/tests/Elastic.CommonSchema.NLog.Tests/LogTestsBase.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/LogTestsBase.cs
@@ -25,6 +25,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 			// These layout renderers need to registered statically as ultimately ConfigurationItemFactory.Default is called in the call stack.
 			LayoutRenderer.Register<ApmTraceIdLayoutRenderer>(ApmTraceIdLayoutRenderer.Name); //generic
 			LayoutRenderer.Register<ApmTransactionIdLayoutRenderer>(ApmTransactionIdLayoutRenderer.Name); //generic
+			LayoutRenderer.Register<ApmSpanIdLayoutRenderer>(ApmSpanIdLayoutRenderer.Name); //generic
 
 			var logFactory = new LogFactory();
 			var logConfig = new Config.LoggingConfiguration(logFactory);

--- a/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
@@ -53,16 +53,20 @@ namespace Elastic.CommonSchema.Serilog.Tests
 
 			string traceId = null;
 			string transactionId = null;
+			string spanId = null;
 
 			// Start a new activity to make sure it does not override Tracing.Trace.Id
 			Activity.Current = new Activity("test").Start();
 
-			Apm.Agent.Tracer.CaptureTransaction("test", "test", (t)
-				=>
+			Apm.Agent.Tracer.CaptureTransaction("test", "test", t =>
 			{
-				traceId = t.TraceId;
-				transactionId = t.Id;
-				logger.Information("My log message!");
+				t.CaptureSpan("span", "test", s =>
+				{
+					traceId = t.TraceId;
+					transactionId = t.Id;
+					spanId = s.Id;
+					logger.Information("My log message!");
+				});
 			});
 
 			var logEvents = getLogEvents();
@@ -73,6 +77,7 @@ namespace Elastic.CommonSchema.Serilog.Tests
 
 			info.Trace.Id.Should().Be(traceId);
 			info.Transaction.Id.Should().Be(transactionId);
+			info.Span.Id.Should().Be(spanId);
 		});
 	}
 }


### PR DESCRIPTION
With the introduction of span id into ECS schema 1.6, this commit adds the span id to APM logging integrations when there is an active span.