### PR TITLE
Refactor Elasticsearch.Extensions.Logging

### DIFF
--- a/src/Elastic.Ingest/ChannelBuffer.cs
+++ b/src/Elastic.Ingest/ChannelBuffer.cs
@@ -23,6 +23,7 @@ namespace Elastic.Ingest
 	internal class ChannelBuffer<TEvent> : IChannelBuffer, IDisposable
 	{
 		private readonly int _maxBufferSize;
+		private CancellationTokenSource _breaker = new CancellationTokenSource();
 
 		public TimeSpan ForceFlushAfter { get; }
 		public List<TEvent> Buffer { get; }
@@ -64,9 +65,6 @@ namespace Elastic.Ingest
 				return d < ForceFlushAfter ? ForceFlushAfter - d : ForceFlushAfter;
 			}
 		}
-
-		private CancellationTokenSource _breaker = new CancellationTokenSource();
-
 
 		/// <summary>
 		/// Call <see cref="ChannelReader{T}.WaitToReadAsync"/> with a timeout to force a flush to happen every

--- a/src/Elastic.Ingest/Elastic.Ingest.csproj
+++ b/src/Elastic.Ingest/Elastic.Ingest.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Title>Elasticsearch Buffer backed data shipper</Title>
-    <Description>TODO</Description>
-    <PackageTags>TODO</PackageTags>
+    <Title>A buffer-backed channel for indexing documents into Elasticsearch</Title>
+    <Description>Provides components to build a buffer-backed channel for indexing documents into Elasticsearch</Description>
+    <PackageTags>elastic, elasticsearch, ingest, search</PackageTags>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Elastic.Ingest/ElasticsearchChannel.cs
+++ b/src/Elastic.Ingest/ElasticsearchChannel.cs
@@ -221,11 +221,7 @@ namespace Elastic.Ingest
 				config = new TransportConfiguration(connectionPool);
 			}
 
-			config = config.Proxy(new Uri("http://localhost:8080"), "", "");
-			config = config.EnableDebugMode();
-
 			var transport = new Transport<TransportConfiguration>(config);
-
 			_ = Interlocked.Exchange(ref _transport, transport);
 		}
 

--- a/src/Elastic.Ingest/Serialization/Model.cs
+++ b/src/Elastic.Ingest/Serialization/Model.cs
@@ -93,16 +93,16 @@ namespace Elastic.Ingest.Serialization
 						break;
 				}
 			}
-			BulkResponseItem r = (status == 200)
+			BulkResponseItem r = status == 200
 				? OkayBulkResponseItem
 				: new BulkResponseItem { Action = action!, Status = status, Error = error };
-			return r;
 
+			return r;
 		}
 
 		public override void Write(Utf8JsonWriter writer, BulkResponseItem value, JsonSerializerOptions options)
 		{
-			if (value == null)
+			if (value is null)
 			{
 				writer.WriteNullValue();
 				return;
@@ -118,9 +118,7 @@ namespace Elastic.Ingest.Serialization
 				JsonSerializer.Serialize(writer, value.Error, options);
 			}
 
-			writer.WritePropertyName("status");
 			writer.WriteNumber("status", value.Status);
-
 			writer.WriteEndObject();
 			writer.WriteEndObject();
 		}

--- a/src/Elastic.Ingest/ShipTo.cs
+++ b/src/Elastic.Ingest/ShipTo.cs
@@ -23,10 +23,10 @@ namespace Elastic.Ingest
 		public ShipTo(string cloudId, string apiKey)
 		{
 			if (string.IsNullOrEmpty(cloudId))
-				throw new ArgumentException("cloudId may not be null.", nameof(cloudId));
+				throw new ArgumentException("cloudId may not be null or empty.", nameof(cloudId));
 
 			if (string.IsNullOrEmpty(apiKey))
-				throw new ArgumentException("apiKey may not be null.", nameof(apiKey));
+				throw new ArgumentException("apiKey may not be null or empty.", nameof(apiKey));
 
 			CloudId = cloudId;
 			ApiKey = apiKey;
@@ -36,13 +36,13 @@ namespace Elastic.Ingest
 		public ShipTo(string cloudId, string username, string password)
 		{
 			if (string.IsNullOrEmpty(cloudId))
-				throw new ArgumentException("cloudId may not be null.", nameof(cloudId));
+				throw new ArgumentException("cloudId may not be null or empty.", nameof(cloudId));
 
 			if (string.IsNullOrEmpty(username))
-				throw new ArgumentException("username may not be null.", nameof(username));
+				throw new ArgumentException("username may not be null or empty.", nameof(username));
 
 			if (string.IsNullOrEmpty(password))
-				throw new ArgumentException("password may not be null.", nameof(password));
+				throw new ArgumentException("password may not be null or empty.", nameof(password));
 
 			CloudId = cloudId;
 			Username = username;

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLogger.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLogger.cs
@@ -309,7 +309,7 @@ namespace Elasticsearch.Extensions.Logging
 			}
 		}
 
-		private void WriteName(StringBuilder stringBuilder, string name)
+		private static void WriteName(StringBuilder stringBuilder, string name)
 		{
 			foreach (var c in name)
 			{
@@ -322,7 +322,7 @@ namespace Elasticsearch.Extensions.Logging
 			}
 		}
 
-		private void WriteValue(StringBuilder stringBuilder, string value)
+		private static void WriteValue(StringBuilder stringBuilder, string value)
 		{
 			foreach (var c in value)
 			{

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerOptions.cs
@@ -24,7 +24,7 @@ namespace Elasticsearch.Extensions.Logging
 		/// </summary>
 		public bool IncludeUser { get; set; } = true;
 
-		//TODO index patters are more complex then this, ILM, write alias, buffer tier, datastreams
+		//TODO index patterns are more complex then this, ILM, write alias, buffer tier, datastreams
 		/// <summary>
 		/// Gets or sets the format string for the Elastic search index. The current <c>DateTimeOffset</c> is passed as parameter
 		/// 0.

--- a/src/Elasticsearch.Extensions.Logging/LogEventToEcsHelper.cs
+++ b/src/Elasticsearch.Extensions.Logging/LogEventToEcsHelper.cs
@@ -64,22 +64,16 @@ namespace Elasticsearch.Extensions.Logging
 		{
 			if (!(_host is null)) return _host;
 
-			// Architecture osArchitecture = RuntimeInformation.OSArchitecture;
-			// if (osDescription.Contains('#'))
-			// {
-			//     int indexOfHash = osDescription.IndexOf('#');
-			//     osDescription = osDescription.Substring(0, Math.Max(0, indexOfHash - 1));
-			// }
-
-			var operatingSystem = new Os
-			{
-				Full = RuntimeInformation.OSDescription,
-				Platform = Environment.OSVersion.Platform.ToString(),
-				Version = Environment.OSVersion.Version.ToString()
-			};
 			_host = new Host
 			{
-				Hostname = Environment.MachineName, Architecture = RuntimeInformation.OSArchitecture.ToString(), Os = operatingSystem
+				Hostname = Environment.MachineName,
+				Architecture = RuntimeInformation.OSArchitecture.ToString(),
+				Os = new Os
+				{
+					Full = RuntimeInformation.OSDescription,
+					Platform = Environment.OSVersion.Platform.ToString(),
+					Version = Environment.OSVersion.Version.ToString()
+				}
 			};
 
 			return _host;
@@ -87,7 +81,7 @@ namespace Elasticsearch.Extensions.Logging
 
 		public static Process GetProcess()
 		{
-			if (_processName == null)
+			if (_processName is null)
 			{
 				using var process = System.Diagnostics.Process.GetCurrentProcess();
 				_processId = process.Id;

--- a/tests/Elastic.Ingest.Tests/SerializationTests.cs
+++ b/tests/Elastic.Ingest.Tests/SerializationTests.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using Elastic.Ingest.Serialization;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Ingest.Tests
+{
+	public class SerializationTests
+	{
+		[Fact]
+		public void CanSerializeBulkResponseItem()
+		{
+			var json = "{\"index\":{\"status\":200}}";
+			var item = JsonSerializer.Deserialize<BulkResponseItem>(json);
+
+			item.Should().NotBeNull();
+
+			var actual = JsonSerializer.Serialize(item);
+
+			actual.Should().Be(json);
+		}
+	}
+}


### PR DESCRIPTION
This PR refactors Elasticsearch.Extensions.Logging in preparation for an initial release

- Remove caching loggers in a concurrent dictionary in `ElasticsearchLoggerProvider`

   Can evaluate later if the performance improvements in doing this would justify the added complexity. Most notably, there is no mechanism to remove loggers from the dictionary, which for an unknown logger naming convention, could allow it to grow unbounded.

- Move `ElasticsearchLogger` required properties into the ctor
- Fix bulk item response serialization
- Add package details to Elastic.Ingest