### PR TITLE
fix: deserialize nested json

### DIFF
--- a/src/Elastic.CommonSchema/Serialization/BaseJsonConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/BaseJsonConverter.cs
@@ -23,10 +23,14 @@ namespace Elastic.CommonSchema.Serialization
 
 			string loglevel = null;
 			DateTimeOffset? timestamp = default;
+			var originalDepth = reader.CurrentDepth;
 			while (reader.Read())
 			{
 				if (reader.TokenType == JsonTokenType.EndObject)
-					break;
+					if (reader.CurrentDepth == originalDepth)
+						break;
+					else
+						continue;
 
 				if (reader.TokenType != JsonTokenType.PropertyName)
 					throw new JsonException();


### PR DESCRIPTION
BaseJsonConverter was throwing an error "Error: Exception occurred while processing event The converter 'Elastic.CommonSchema.Serialization.BaseJsonConverter' read too much or not enough." when trying to deserialize a nested json.

So adding in code fix to handle reading nested json.