### PR TITLE
Update BenchmarkDotNet and allow more client configuration

### DIFF
--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Domain/BenchmarkGcStats.cs
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Domain/BenchmarkGcStats.cs
@@ -4,18 +4,19 @@
 
 using System.Runtime.Serialization;
 using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Running;
 
 namespace Elastic.CommonSchema.BenchmarkDotNetExporter.Domain
 {
 	public class BenchmarkGcStats
 	{
-		public BenchmarkGcStats(GcStats statistics)
+		public BenchmarkGcStats(GcStats statistics, BenchmarkCase benchmarkCase)
 		{
 			Gen0Collections = statistics.Gen0Collections;
 			Gen1Collections = statistics.Gen1Collections;
 			Gen2Collections = statistics.Gen2Collections;
 			TotalOperations = statistics.TotalOperations;
-			BytesAllocatedPerOperation = statistics.BytesAllocatedPerOperation;
+			BytesAllocatedPerOperation = statistics.GetBytesAllocatedPerOperation(benchmarkCase);
 		}
 
 		[DataMember(Name = "bytes_allocated_per_operation")]

--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Elastic.CommonSchema.BenchmarkDotNetExporter.csproj
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Elastic.CommonSchema.BenchmarkDotNetExporter.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="Elasticsearch.Net" Version="7.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporter.cs
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -26,6 +26,12 @@ namespace Elastic.CommonSchema.BenchmarkDotNetExporter
 		{
 			Options = options;
 			Client = new ElasticLowLevelClient(Options.CreateConnectionSettings());
+		}
+
+		public ElasticsearchBenchmarkExporter(ElasticsearchBenchmarkExporterOptions options, Func<ElasticsearchBenchmarkExporterOptions, IConnectionConfigurationValues> configure)
+		{
+			Options = options;
+			Client = new ElasticLowLevelClient(configure(Options));
 		}
 
 		private ElasticsearchBenchmarkExporterOptions Options { get; }
@@ -199,7 +205,7 @@ namespace Elastic.CommonSchema.BenchmarkDotNetExporter
 					};
 
 					if (summary.BenchmarksCases.Any(c => c.Config.HasMemoryDiagnoser()))
-						data.Benchmark.Memory = new BenchmarkGcStats(r.GcStats);
+						data.Benchmark.Memory = new BenchmarkGcStats(r.GcStats, r.BenchmarkCase);
 
 					var grouped = r.AllMeasurements
 						.GroupBy(m => $"{m.IterationStage.ToString()}-{m.IterationMode.ToString()}")

--- a/tests/Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests/Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests.csproj
+++ b/tests/Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests/Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-        <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.12.1" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+        <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.13.1" />
         <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.2.4" />
         <PackageReference Include="JunitXml.TestLogger" Version="2.1.15" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />

--- a/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
+++ b/tests/Elastic.CommonSchema.Benchmarks/Elastic.CommonSchema.Benchmarks.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoBogus" Version="2.8.2" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="Bogus" Version="29.0.2" />
   </ItemGroup>
 

--- a/tests/Elasticsearch.Extensions.Logging.IntegrationTests/Elasticsearch.Extensions.Logging.IntegrationTests.csproj
+++ b/tests/Elasticsearch.Extensions.Logging.IntegrationTests/Elasticsearch.Extensions.Logging.IntegrationTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.13.1" />
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.2.4" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />


### PR DESCRIPTION
Needed a newer version of BenchmarkDotNet and also needed to be able to configure the elasticsearch client more than what ElasticsearchBenchmarkExporterOptions allows.