### PR TITLE
Ensure APM service name gets exposed to Serilog/NLog ECS export"

### DIFF
--- a/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
@@ -1,0 +1,24 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Text;
+using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace Elastic.Apm.NLog
+{
+	[LayoutRenderer(Name)]
+	[ThreadSafe]
+	public class ApmServiceNameLayoutRenderer : LayoutRenderer
+	{
+		public const string Name = "ElasticApmServiceName";
+
+		protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+		{
+			if (!Agent.IsConfigured) return;
+			builder.Append(Agent.Config.ServiceName);
+		}
+	}
+}

--- a/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
@@ -10,7 +10,7 @@ using NLog.LayoutRenderers;
 namespace Elastic.Apm.NLog
 {
 	[LayoutRenderer(Name)]
-	[ThreadSafe]
+	[ThreadSafe, ThreadAgnostic]
 	public class ApmServiceNameLayoutRenderer : LayoutRenderer
 	{
 		public const string Name = "ElasticApmServiceName";

--- a/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
@@ -6,7 +6,7 @@ using NLog.LayoutRenderers;
 namespace Elastic.Apm.NLog;
 
 [LayoutRenderer(Name)]
-[ThreadSafe]
+[ThreadSafe, ThreadAgnostic]
 public class ApmServiceNodeNameLayoutRenderer : LayoutRenderer
 {
 	public const string Name = "ElasticApmServiceNodeName";

--- a/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
@@ -1,0 +1,19 @@
+using System.Text;
+using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace Elastic.Apm.NLog;
+
+[LayoutRenderer(Name)]
+[ThreadSafe]
+public class ApmServiceNodeNameLayoutRenderer : LayoutRenderer
+{
+	public const string Name = "ElasticApmServiceNodeName";
+
+	protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+	{
+		if (!Agent.IsConfigured) return;
+		builder.Append(Agent.Config.ServiceNodeName);
+	}
+}

--- a/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
@@ -1,0 +1,19 @@
+using System.Text;
+using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace Elastic.Apm.NLog;
+
+[LayoutRenderer(Name)]
+[ThreadSafe]
+public class ApmServiceVersionLayoutRenderer : LayoutRenderer
+{
+	public const string Name = "ElasticApmServiceVersion";
+
+	protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+	{
+		if (!Agent.IsConfigured) return;
+		builder.Append(Agent.Config.ServiceVersion);
+	}
+}

--- a/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
@@ -6,7 +6,7 @@ using NLog.LayoutRenderers;
 namespace Elastic.Apm.NLog;
 
 [LayoutRenderer(Name)]
-[ThreadSafe]
+[ThreadSafe, ThreadAgnostic]
 public class ApmServiceVersionLayoutRenderer : LayoutRenderer
 {
 	public const string Name = "ElasticApmServiceVersion";

--- a/src/Elastic.Apm.NLog/readme.md
+++ b/src/Elastic.Apm.NLog/readme.md
@@ -5,6 +5,9 @@ Allows you to add the following place holders in your NLog templates:
 * `ElasticApmTraceId`
 * `ElasticApmTransactionId`
 * `ElasticApmSpanId`
+* `ElasticApmServiceName`
+* `ElasticApmServiceNodeName`
+* `ElasticApmServiceVersion`
 
 Which will be replaced with the appropriate Elastic APM variables if available
 
@@ -19,7 +22,7 @@ The .NET assemblies are published to NuGet under the package name [Elastic.Apm.N
 // or `|||InTransaction` if the place holders are not available
 var consoleTarget = new ConsoleTarget("console");
 consoleTarget.Layout = 
-    "${ElasticApmTraceId}|${ElasticApmTransactionId}|${ElasticApmSpanId}|${message}";
+    "${ElasticApmServiceName}|${ElasticApmTraceId}|${ElasticApmTransactionId}|${ElasticApmSpanId}|${message}";
 config.AddRule(LogLevel.Debug, LogLevel.Fatal, consoleTarget);
 LogManager.Configuration = config;
 var logger = LogManager.GetCurrentClassLogger();

--- a/src/Elastic.Apm.SerilogEnricher/ElasticApmEnricher.cs
+++ b/src/Elastic.Apm.SerilogEnricher/ElasticApmEnricher.cs
@@ -17,6 +17,14 @@ namespace Elastic.Apm.SerilogEnricher
 		public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
 		{
 			if (!Agent.IsConfigured) return;
+
+			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ElasticApmServiceName", Agent.Config.ServiceName));
+			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ElasticApmServiceVersion", Agent.Config.ServiceVersion));
+			logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ElasticApmServiceNodeName", Agent.Config.ServiceNodeName));
+
+			if (Agent.Config.GlobalLabels != null)
+				logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("ElasticApmGlobalLabels", Agent.Config.GlobalLabels));
+
 			if (Agent.Tracer is null) return;
 			if (Agent.Tracer.CurrentTransaction is null) return;
 

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -56,6 +56,10 @@ namespace Elastic.CommonSchema.NLog
 				ApmTraceId = "${ElasticApmTraceId}";
 				ApmTransactionId = "${ElasticApmTransactionId}";
 				ApmSpanId = "${ElasticApmSpanId}";
+
+				ApmServiceName = "${ElasticApmServiceName}";
+				ApmServiceNodeName = "${ElasticApmServiceNodeName}";
+				ApmServiceVersion = "${ElasticApmServiceVersion}";
 			}
 		}
 
@@ -66,8 +70,11 @@ namespace Elastic.CommonSchema.NLog
 
 		public Layout ApmTraceId { get; set; }
 		public Layout ApmTransactionId { get; set; }
-
 		public Layout ApmSpanId { get; set; }
+
+		public Layout ApmServiceName { get; set; }
+		public Layout ApmServiceNodeName { get; set; }
+		public Layout ApmServiceVersion { get; set; }
 
 		/// <summary>
 		/// Allow dynamically disabling <see cref="ThreadAgnosticAttribute" /> to
@@ -137,6 +144,7 @@ namespace Elastic.CommonSchema.NLog
 				Message = logEvent.FormattedMessage,
 				Ecs = new Ecs { Version = EcsDocument.Version },
 				Log = GetLog(logEvent),
+				Service = GetService(logEvent),
 				Event = GetEvent(logEvent),
 				Metadata = GetMetadata(logEvent),
 				Process = GetProcess(logEvent),
@@ -157,6 +165,16 @@ namespace Elastic.CommonSchema.NLog
 			EnrichAction?.Invoke(ecsEvent, logEvent);
 
 			ecsEvent.Serialize(target);
+		}
+
+		private Service GetService(LogEventInfo logEventInfo)
+		{
+			var serviceName = ApmServiceName?.Render(logEventInfo);
+			if (string.IsNullOrEmpty(serviceName)) return null;
+
+			var serviceNodeName = ApmServiceNodeName?.Render(logEventInfo);
+			var serviceVersion = ApmServiceVersion?.Render(logEventInfo);
+			return new Service { Name = serviceName, Version = serviceVersion, NodeName = serviceNodeName };
 		}
 
 		/// <summary>

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -54,6 +54,7 @@ namespace Elastic.CommonSchema.Serilog
 				Message = logEvent.RenderMessage(),
 				Ecs = new Ecs { Version = EcsDocument.Version },
 				Log = GetLog(logEvent, exceptions, configuration),
+				Service = GetService(logEvent),
 				Agent = GetAgent(logEvent),
 				Event = GetEvent(logEvent),
 				Metadata = GetMetadata(logEvent, configuration.LogEventPropertiesToFilter),
@@ -81,6 +82,19 @@ namespace Elastic.CommonSchema.Serilog
 				ecsEvent = configuration.MapCustom(ecsEvent, logEvent);
 
 			return ecsEvent;
+		}
+
+		private static Service GetService(LogEvent logEvent)
+		{
+			if (!logEvent.TryGetScalarPropertyValue("ElasticApmServiceName", out var serviceName))
+				return null;
+
+			return new Service
+			{
+				Name = serviceName.Value.ToString(),
+				Version = logEvent.TryGetScalarPropertyValue("ElasticApmServiceVersion", out var version) ? version.Value.ToString() : null,
+				NodeName = logEvent.TryGetScalarPropertyValue("ElasticApmServiceNodeName", out var name) ? name.Value.ToString() : null,
+			};
 		}
 
 		private static string GetTrace(LogEvent logEvent) => !logEvent.TryGetScalarPropertyValue("ElasticApmTraceId", out var traceId)

--- a/tests/Elastic.Apm.NLog.Test/NLogTests.cs
+++ b/tests/Elastic.Apm.NLog.Test/NLogTests.cs
@@ -12,6 +12,17 @@ namespace Elastic.Apm.NLog.Test
 {
 	public class NLogTests
 	{
+		public NLogTests()
+		{
+			var assembly = typeof(ApmTraceIdLayoutRenderer).Assembly;
+			global::NLog.Config.ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
+
+			var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
+			if (!Agent.IsConfigured)
+				Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender(), configurationReader: configuration));
+		}
+
+
 		/// <summary>
 		/// Creates 1 simple transaction and span and makes sure that the log line created within the transaction and span have
 		/// the transaction, trace and span ids, and logs prior to and after the transaction do not have those.
@@ -19,10 +30,6 @@ namespace Elastic.Apm.NLog.Test
 		[Fact]
 		public void NLogWithTransaction()
 		{
-			var assembly = typeof(ApmTraceIdLayoutRenderer).Assembly;
-			global::NLog.Config.ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
-			Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender()));
-
 			var target = new MemoryTarget();
 			target.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${ElasticApmSpanId}|${message}";
 
@@ -56,6 +63,22 @@ namespace Elastic.Apm.NLog.Test
 			target.Logs[1].Should().Be($"{traceId}|{transactionId}||InTransaction");
 			target.Logs[2].Should().Be($"{traceId}|{transactionId}|{spanId}|InSpan");
 			target.Logs[3].Should().Be("|||PostTransaction");
+		}
+
+		[Fact]
+		public void NLogWithServiceName()
+		{
+			var target = new MemoryTarget();
+			target.Layout = "${ElasticApmServiceName}|${ElasticApmServiceNodeName}|${ElasticApmServiceVersion}|${message}";
+
+			global::NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Debug);
+
+			var logger = LogManager.GetLogger("Example");
+
+			logger.Debug("Some log");
+
+			target.Logs.Count.Should().Be(1);
+			target.Logs[0].Should().Be("my-service|my-service-node-name|0.2.1|Some log");
 		}
 	}
 }

--- a/tests/Elastic.Apm.SerilogEnricher.Test/ServiceInformationTests.cs
+++ b/tests/Elastic.Apm.SerilogEnricher.Test/ServiceInformationTests.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Test.Common;
+using FluentAssertions;
+using Serilog;
+using Serilog.Sinks.InMemory;
+using Xunit;
+
+namespace Elastic.Apm.SerilogEnricher.Test
+{
+	public class ServiceInformationTests : IDisposable
+	{
+		public ServiceInformationTests()
+		{
+			var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
+			if (!Agent.IsConfigured)
+				Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender(), configurationReader: configuration));
+		}
+
+		[Fact]
+		public void ServiceIsExposedToSerilog()
+		{
+			var logger = new LoggerConfiguration()
+				.Enrich.WithElasticApmCorrelationInfo()
+				.WriteTo.InMemory()
+				.CreateLogger();
+
+			logger.Information("Line1");
+
+			Agent.Tracer.CaptureTransaction("Test", "Test", (t) =>
+			{
+				t.CaptureSpan("Span", "Test", s =>
+				{
+					logger.Information("Line2");
+				});
+			});
+
+			// service information should always be available because the agent IsConfigured
+			var logEvent0 = InMemorySink.Instance.LogEvents.ElementAt(0);
+			logEvent0.Properties["ElasticApmServiceName"].ToString().Should().Be("\"my-service\"");
+			logEvent0.Properties["ElasticApmServiceNodeName"].ToString().Should().Be("\"my-service-node-name\"");
+			logEvent0.Properties["ElasticApmServiceVersion"].ToString().Should().Be("\"0.2.1\"");
+
+
+			var logEvent1 = InMemorySink.Instance.LogEvents.ElementAt(1);
+			logEvent1.Properties["ElasticApmServiceName"].ToString().Should().Be("\"my-service\"");
+			logEvent1.Properties["ElasticApmServiceNodeName"].ToString().Should().Be("\"my-service-node-name\"");
+			logEvent1.Properties["ElasticApmServiceVersion"].ToString().Should().Be("\"0.2.1\"");
+		}
+
+		public void Dispose() => InMemorySink.Instance.Dispose();
+	}
+}

--- a/tests/Elastic.Apm.SerilogEnricher.Test/ServiceInformationTests.cs
+++ b/tests/Elastic.Apm.SerilogEnricher.Test/ServiceInformationTests.cs
@@ -16,12 +16,7 @@ namespace Elastic.Apm.SerilogEnricher.Test
 {
 	public class ServiceInformationTests : IDisposable
 	{
-		public ServiceInformationTests()
-		{
-			var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
-			if (!Agent.IsConfigured)
-				Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender(), configurationReader: configuration));
-		}
+		public ServiceInformationTests() => TestApmAgent.Configure();
 
 		[Fact]
 		public void ServiceIsExposedToSerilog()

--- a/tests/Elastic.Apm.SerilogEnricher.Test/TraceInformationTests.cs
+++ b/tests/Elastic.Apm.SerilogEnricher.Test/TraceInformationTests.cs
@@ -14,9 +14,11 @@ using Xunit;
 
 namespace Elastic.Apm.SerilogEnricher.Test
 {
-	public class SerilogTests : IDisposable
+	public class TraceInformationTests : IDisposable
 	{
-		public SerilogTests()
+		private readonly string[] _tracingKeys = { "ElasticApmSpanId", "ElasticApmTransactionId", "ElasticApmTraceId" };
+
+		public TraceInformationTests()
 		{
 			if (!Agent.IsConfigured)
 				Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender()));
@@ -61,8 +63,8 @@ namespace Elastic.Apm.SerilogEnricher.Test
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(0)
-				.Properties.Should()
-				.BeEmpty();
+				.Properties.Keys.Should()
+				.NotContain(_tracingKeys);
 
 			var logEvent1 = InMemorySink.Instance.LogEvents.ElementAt(1);
 
@@ -104,8 +106,8 @@ namespace Elastic.Apm.SerilogEnricher.Test
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(3)
-				.Properties.Should()
-				.BeEmpty();
+				.Properties.Keys.Should()
+				.NotContain(_tracingKeys);
 		}
 
 		/// <summary>
@@ -149,8 +151,8 @@ namespace Elastic.Apm.SerilogEnricher.Test
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(0)
-				.Properties.Should()
-				.BeEmpty();
+				.Properties.Keys.Should()
+				.NotContain(_tracingKeys);
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(1)
@@ -182,8 +184,8 @@ namespace Elastic.Apm.SerilogEnricher.Test
 
 			InMemorySink.Instance
 				.LogEvents.ElementAt(3)
-				.Properties.Should()
-				.BeEmpty();
+				.Properties.Keys.Should()
+				.NotContain(_tracingKeys);
 		}
 
 		public void Dispose() => InMemorySink.Instance.Dispose();

--- a/tests/Elastic.Apm.SerilogEnricher.Test/TraceInformationTests.cs
+++ b/tests/Elastic.Apm.SerilogEnricher.Test/TraceInformationTests.cs
@@ -18,11 +18,7 @@ namespace Elastic.Apm.SerilogEnricher.Test
 	{
 		private readonly string[] _tracingKeys = { "ElasticApmSpanId", "ElasticApmTransactionId", "ElasticApmTraceId" };
 
-		public TraceInformationTests()
-		{
-			if (!Agent.IsConfigured)
-				Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender()));
-		}
+		public TraceInformationTests() => TestApmAgent.Configure();
 
 		/// <summary>
 		/// Creates 1 simple transaction and span and makes sure that the log line created within the transaction has

--- a/tests/Elastic.Apm.Test.Common/MockConfiguration.cs
+++ b/tests/Elastic.Apm.Test.Common/MockConfiguration.cs
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using Elastic.Apm.Config;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.Test.Common
+{
+	public class MockConfiguration : IConfigurationReader
+	{
+		public MockConfiguration(
+			string serviceName,
+			string serviceNodeName,
+			string serviceVersion,
+			IReadOnlyDictionary<string, string> globalLabels = null
+		)
+		{
+			GlobalLabels = globalLabels;
+			ServiceName = serviceName;
+			ServiceNodeName = serviceNodeName;
+			ServiceVersion = serviceVersion;
+		}
+		public IReadOnlyDictionary<string, string> GlobalLabels { get; }
+		public string ServiceName { get; }
+		public string ServiceNodeName { get; }
+		public string ServiceVersion { get; }
+
+		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames { get; } = Array.Empty<WildcardMatcher>();
+		public IReadOnlyList<Uri> ServerUrls { get; } = Array.Empty<Uri>();
+		public IReadOnlyList<WildcardMatcher> DisableMetrics { get; } = Array.Empty<WildcardMatcher>();
+		public List<string> CaptureBodyContentTypes { get; } = new();
+		public LogLevel LogLevel { get; } = LogLevel.Information;
+
+		// ReSharper disable UnassignedGetOnlyAutoProperty
+		public string CaptureBody { get; }
+		public bool CaptureHeaders { get; }
+		public bool CentralConfig { get; }
+		public string Environment { get; }
+		public TimeSpan FlushInterval { get; }
+		public int MaxBatchEventCount { get; }
+		public int MaxQueueEventCount { get; }
+		public double MetricsIntervalInMilliseconds { get; }
+		public string SecretToken { get; }
+		public string ApiKey { get; }
+		public double SpanFramesMinDurationInMilliseconds { get; }
+		public int StackTraceLimit { get; }
+		public int TransactionMaxSpans { get; }
+		public double TransactionSampleRate { get; }
+		public bool UseElasticTraceparentHeader { get; }
+		public bool VerifyServerCert { get; }
+		// ReSharper restore UnassignedGetOnlyAutoProperty
+	}
+}

--- a/tests/Elastic.Apm.Test.Common/TestApmAgent.cs
+++ b/tests/Elastic.Apm.Test.Common/TestApmAgent.cs
@@ -1,0 +1,13 @@
+namespace Elastic.Apm.Test.Common;
+
+public static class TestApmAgent
+{
+	static TestApmAgent()
+	{
+		var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
+		if (!Agent.IsConfigured)
+			Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender(), configurationReader: configuration));
+	}
+
+	public static void Configure() { }
+}

--- a/tests/Elastic.CommonSchema.NLog.Tests/ApmTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/ApmTests.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Linq;
 using Elastic.Apm;
+using Elastic.Apm.Test.Common;
 using FluentAssertions;
 using Xunit;
 
@@ -15,8 +16,9 @@ namespace Elastic.CommonSchema.NLog.Tests
 		[Fact]
 		public void ElasticApmEndUpOnEcsLog() => TestLogger((logger, getLogEvents) =>
 		{
+			var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
 			if (!Apm.Agent.IsConfigured)
-				Apm.Agent.Setup(new AgentComponents());
+				Apm.Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender(), configurationReader: configuration));
 
 			string traceId = null;
 			string transactionId = null;
@@ -44,6 +46,10 @@ namespace Elastic.CommonSchema.NLog.Tests
 			info.TraceId.Should().Be(traceId);
 			info.TransactionId.Should().Be(transactionId);
 			info.SpanId.Should().Be(spanId);
+			info.Service.Should().NotBeNull();
+			info.Service.Name.Should().Be("my-service");
+			info.Service.NodeName.Should().Be("my-service-node-name");
+			info.Service.Version.Should().Be("0.2.1");
 		});
 	}
 }

--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -25,6 +25,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\Elastic.Apm.NLog\Elastic.Apm.NLog.csproj" />
       <ProjectReference Include="..\..\src\Elastic.CommonSchema.NLog\Elastic.CommonSchema.NLog.csproj" />
+      <ProjectReference Include="..\Elastic.Apm.Test.Common\Elastic.Apm.Test.Common.csproj" />
       <ProjectReference Include="..\Elastic.CommonSchema.Tests\Elastic.CommonSchema.Tests.csproj" />
     </ItemGroup>
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/LogTestsBase.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/LogTestsBase.cs
@@ -27,6 +27,9 @@ namespace Elastic.CommonSchema.NLog.Tests
 			LayoutRenderer.Register<ApmTraceIdLayoutRenderer>(ApmTraceIdLayoutRenderer.Name); //generic
 			LayoutRenderer.Register<ApmTransactionIdLayoutRenderer>(ApmTransactionIdLayoutRenderer.Name); //generic
 			LayoutRenderer.Register<ApmSpanIdLayoutRenderer>(ApmSpanIdLayoutRenderer.Name); //generic
+			LayoutRenderer.Register<ApmServiceNameLayoutRenderer>(ApmServiceNameLayoutRenderer.Name); //generic
+			LayoutRenderer.Register<ApmServiceVersionLayoutRenderer>(ApmServiceVersionLayoutRenderer.Name); //generic
+			LayoutRenderer.Register<ApmServiceNodeNameLayoutRenderer>(ApmServiceNodeNameLayoutRenderer.Name); //generic
 
 			var logFactory = new LogFactory();
 			var logConfig = new Config.LoggingConfiguration(logFactory);

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
@@ -28,6 +28,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\Elastic.Apm.SerilogEnricher\Elastic.Apm.SerilogEnricher.csproj" />
       <ProjectReference Include="..\..\src\Elastic.CommonSchema.Serilog\Elastic.CommonSchema.Serilog.csproj" />
+      <ProjectReference Include="..\Elastic.Apm.Test.Common\Elastic.Apm.Test.Common.csproj" />
       <ProjectReference Include="..\Elastic.CommonSchema.Tests\Elastic.CommonSchema.Tests.csproj" />
     </ItemGroup>
 

--- a/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Elastic.Apm;
 using Elastic.Apm.SerilogEnricher;
+using Elastic.Apm.Test.Common;
 using FluentAssertions;
 using Serilog;
 using Xunit;
@@ -55,8 +56,9 @@ namespace Elastic.CommonSchema.Serilog.Tests
 		[Fact]
 		public void ElasticApmEnrichmentsEndUpOnEcsLog() => TestLogger((logger, getLogEvents) =>
 		{
+			var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
 			if (!Apm.Agent.IsConfigured)
-				Apm.Agent.Setup(new AgentComponents());
+				Apm.Agent.Setup(new AgentComponents(payloadSender: new NoopPayloadSender(),configurationReader:configuration));
 
 			string traceId = null;
 			string transactionId = null;
@@ -85,6 +87,11 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			info.TraceId.Should().Be(traceId);
 			info.TransactionId.Should().Be(transactionId);
 			info.SpanId.Should().Be(spanId);
+			info.Service.Name.Should().Be("my-service");
+			info.Service.NodeName.Should().Be("my-service-node-name");
+			info.Service.Version.Should().Be("0.2.1");
+
+
 		});
 	}
 }


### PR DESCRIPTION
- Expose service information to serilog and expose it to EcsTextJsonFormatter
- Expose service information to NLog and ensure Elastic.CommonSchema.NLog sets Service information

Fixes: #134 
