### PR TITLE
Fixes #86 only write log level once

### DIFF
--- a/src/Elastic.CommonSchema.Generator/CodeConfiguration.cs
+++ b/src/Elastic.CommonSchema.Generator/CodeConfiguration.cs
@@ -10,9 +10,6 @@ namespace Generator
 	{
 		private static string _root;
 		public static string ElasticCommonSchemaGeneratedFolder { get; } = $@"{Root}Elastic.CommonSchema/";
-		public static string ElasticCommonSchemaNESTGeneratedFolder { get; } = $@"{Root}Elastic.CommonSchemaNEST/";
-
-		public static string ElasticNLogGeneratedFolder { get; } = $@"{Root}Elastic.CommonSchema.NLog/";
 
 		private static string Root
 		{

--- a/src/Elastic.CommonSchema.Generator/FileGenerator.cs
+++ b/src/Elastic.CommonSchema.Generator/FileGenerator.cs
@@ -25,10 +25,13 @@ namespace Elastic.CommonSchema.Generator
 			var actions = new Dictionary<Action<CommonSchemaTypesProjection>, string>
 			{
 				{ m => Generate(m, "EcsDocument"), "Base ECS Document" },
-				{ m => Generate(m, "EcsDocumentJsonConverter"), "Base ECS Document Json Converter" },
+
+				{ m => Generate(m, "EcsDocumentJsonConverter", "Serialization"), "Base ECS Document Json Converter" },
+				{ m => Generate(m, "EcsLogJsonConverter", "Serialization"), "Log fieldset needs a custom converter to omit level on write" },
+				{ m => Generate(m, "EcsJsonContext", "Serialization"), "Ecs System Text Json Source Generators" },
+
 				{ m => Generate(m, "LogTemplateProperties"), "Strongly types ECS fields supported in log templates" },
 				{ m => Generate(m, "PropDispatch"), "ECS key value setter generation" },
-				{ m => Generate(m, "EcsJsonContext"), "Ecs System Text Json Source Generators" },
 				{ m => Generate(m, "FieldSets"), "Field Sets" },
 				{ m => Generate(m, "Entities"), "Entities" },
 				{ m => Generate(m, "InlineObjects"), "Inline Objects" },
@@ -53,10 +56,10 @@ namespace Elastic.CommonSchema.Generator
 		private static string DoRazor(string name, string template, CommonSchemaTypesProjection model) =>
 			Razor.CompileRenderStringAsync(name, template, model).GetAwaiter().GetResult();
 
-		private static void Generate(CommonSchemaTypesProjection model, string what)
+		private static void Generate(CommonSchemaTypesProjection model, string what, string subFolder = "")
 		{
 			var targetDir = Path.GetFullPath(CodeConfiguration.ElasticCommonSchemaGeneratedFolder);
-			var outputFile = Path.Combine(targetDir, $"{what}.Generated.cs");
+			var outputFile = Path.Combine(targetDir, subFolder, $"{what}.Generated.cs");
 			var path = Path.Combine(CodeConfiguration.ViewFolder, $"{what}.Generated.cshtml");
 			var template = File.ReadAllText(path);
 			var source = DoRazor(nameof(Generate) + what, template, model);

--- a/src/Elastic.CommonSchema.Generator/Projection/ProjectionTypeExtensions.cs
+++ b/src/Elastic.CommonSchema.Generator/Projection/ProjectionTypeExtensions.cs
@@ -11,6 +11,7 @@ namespace Elastic.CommonSchema.Generator.Projection
 		public static string PascalCase(this string s) => new CultureInfo("en-US")
 			.TextInfo
 			.ToTitleCase(s.ToLowerInvariant())
+			.Replace("?", string.Empty)
 			.Replace("@", string.Empty)
 			.Replace("_", string.Empty)
 			.Replace(".", string.Empty);

--- a/src/Elastic.CommonSchema.Generator/Projection/PropertyReference.cs
+++ b/src/Elastic.CommonSchema.Generator/Projection/PropertyReference.cs
@@ -80,12 +80,14 @@ namespace Elastic.CommonSchema.Generator.Projection
 		public ValueTypePropertyReference(string parentPath, string fullPath, Field field) : base(parentPath, fullPath)
 		{
 			ClrType = field.GetClrType();
+			ReadJsonType = ClrType.PascalCase();
 			CastFromObject = field.GetCastFromObject();
 			Description = GetFieldDescription(field);
 			Example = field.Example?.ToString() ?? string.Empty;
 		}
 
 		public string CastFromObject { get; }
+		public string ReadJsonType { get; }
 		public string ClrType { get; }
 		public override string Description { get; }
 		public override string Example { get; }

--- a/src/Elastic.CommonSchema.Generator/Projection/TypeProjector.cs
+++ b/src/Elastic.CommonSchema.Generator/Projection/TypeProjector.cs
@@ -19,6 +19,7 @@ namespace Elastic.CommonSchema.Generator.Projection
 		public IReadOnlyCollection<FieldSetBaseClass> FieldSets { get; set; }
 		public IReadOnlyCollection<EntityClass> EntityClasses { get; set; }
 		public EntityClass Base { get; set; }
+		public EntityClass Log => EntityClasses.First(e => e.Name == "Log");
 		public IReadOnlyCollection<EntityClass> NestedEntityClasses { get; set; }
 		public IReadOnlyCollection<InlineObject> InlineObjects { get; set; }
 		public ReadOnlyCollection<string> Warnings { get; set; }

--- a/src/Elastic.CommonSchema.Generator/Views/EcsDocumentJsonConverter.Generated.cshtml
+++ b/src/Elastic.CommonSchema.Generator/Views/EcsDocumentJsonConverter.Generated.cshtml
@@ -63,6 +63,31 @@ namespace Elastic.CommonSchema.Serialization
 							: false
 			};
 		}
+@{
+	var manualLogFields = new List<string>() { "level" };
+}
+		public void WriteLogEntity(Utf8JsonWriter writer, Log value) {
+			if (value == null) return;
+			// only write the log object if it has values other then log.level
+			if (
+@foreach (var field in Model.Log.BaseFieldSet.ValueProperties)
+{
+	if (manualLogFields.Contains(field.JsonProperty)) 
+	{
+		continue;
+	}
+	<text>			value.@field.Name == null &&
+	</text>
+}
+@foreach (var property in Model.Log.BaseFieldSet.InlineObjectProperties)
+{
+<text>		value.@(property.Name) == null &&
+</text>
+}
+			true) return;
+
+			WriteProp(writer, "log", value, EcsJsonContext.Default.Log);
+		}
 
 		public override void Write(Utf8JsonWriter writer, TBase value, JsonSerializerOptions options)
 		{
@@ -76,18 +101,17 @@ namespace Elastic.CommonSchema.Serialization
 			WriteTimestamp(writer, value);
 			WriteLogLevel(writer, value);
 			WriteMessage(writer, value);
-			WriteProp(writer, "metadata", value.Metadata);
+			WriteLogEntity(writer, value.Log);
 
 			// Base fields
 @{
-	var manualFields = new List<string>() { "@timestamp", "message" };
+	var manualFields = new List<string>() { "@timestamp", "message", "log" };
 }
 @foreach (var field in Model.Base.BaseFieldSet.ValueProperties)
 {
 	if (manualFields.Contains(field.JsonProperty))
 	{
 		continue;
-		
 	}
 	<text>			WriteProp(writer, "@field.JsonProperty", value.@field.Name);
 	</text>
@@ -102,9 +126,14 @@ namespace Elastic.CommonSchema.Serialization
 @foreach (var entity in Model.EntityClasses)
 {
 	var entityName = entity.BaseFieldSet.FieldSet.Name;
+	if (manualFields.Contains(entityName))
+	{
+		continue;
+	}
 <text>			WriteProp(writer, "@(entityName)", value.@(entity.Name), EcsJsonContext.Default.@(entity.Name));
 </text>
 }
+			WriteProp(writer, "metadata", value.Metadata);
 
 			if (typeof(@Model.Base.Name) != value.GetType())
 				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v));

--- a/src/Elastic.CommonSchema.Generator/Views/EcsJsonContext.Generated.cshtml
+++ b/src/Elastic.CommonSchema.Generator/Views/EcsJsonContext.Generated.cshtml
@@ -15,7 +15,7 @@ If you wish to submit a PR please modify the original csharp file and submit the
 
 using System.Text.Json.Serialization;
 
-namespace Elastic.CommonSchema;
+namespace Elastic.CommonSchema.Serialization;
 
 @foreach (var property in Model.Base.EntityProperties)
 {

--- a/src/Elastic.CommonSchema.Generator/Views/EcsLogJsonConverter.Generated.cshtml
+++ b/src/Elastic.CommonSchema.Generator/Views/EcsLogJsonConverter.Generated.cshtml
@@ -1,0 +1,95 @@
+@using System.Collections.Generic
+@using Generator
+@inherits Elastic.CommonSchema.Generator.Views.CodeTemplatePage<Elastic.CommonSchema.Generator.Projection.CommonSchemaTypesProjection>
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+/*
+IMPORTANT NOTE
+==============
+This file has been generated. 
+If you wish to submit a PR please modify the original csharp file and submit the PR with that change. Thanks!
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Elastic.CommonSchema.Serialization
+{
+	public partial class Ecs@(Model.Log.Name)JsonConverter : EcsJsonConverterBase@(Raw("<Log>"))
+	{
+		private static bool ReadProperties(ref Utf8JsonReader reader, Log ecsEvent)
+		{
+			var propertyName = reader.GetString();
+			reader.Read();
+			return propertyName switch
+			{
+@foreach (var property in Model.Log.BaseFieldSet.ValueProperties)
+{
+	var name = property.JsonProperty;
+<text>				"@(name)" => ReadProp@(Raw(property.ReadJsonType))(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v),
+</text>
+}
+@foreach (var property in Model.Log.BaseFieldSet.InlineObjectProperties)
+{
+	var name = property.JsonProperty;
+<text>				"@(name)" => ReadProp<@(Raw(property.InlineObject.Name))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v),
+</text>
+}
+				_ => false
+			};
+		}
+
+@{
+	var manualFields = new List<string>() { "level" };
+}
+		public override void Write(Utf8JsonWriter writer, Log value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+			if (
+@foreach (var field in Model.Log.BaseFieldSet.ValueProperties)
+{
+	if (manualFields.Contains(field.JsonProperty)) 
+	{
+		continue;
+	}
+	<text>			value.@field.Name == null &&
+	</text>
+}
+@foreach (var property in Model.Log.BaseFieldSet.InlineObjectProperties)
+{
+<text>		value.@(property.Name) == null &&
+</text>
+}
+			true) {
+				writer.WriteNullValue();
+				return;
+			}
+			writer.WriteStartObject();
+
+@foreach (var field in Model.Log.BaseFieldSet.ValueProperties)
+{
+	if (manualFields.Contains(field.JsonProperty))
+	{
+		continue;
+	}
+	<text>			WriteProp(writer, "@field.JsonProperty", value.@field.Name);
+	</text>
+}
+@foreach (var property in Model.Log.BaseFieldSet.InlineObjectProperties)
+{
+	var name = property.JsonProperty;
+<text>		WriteProp(writer, "@(name)", value.@(property.Name));
+</text>
+}
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/Elastic.CommonSchema/Entities.cs
+++ b/src/Elastic.CommonSchema/Entities.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using Elastic.CommonSchema.Serialization;
+
+namespace Elastic.CommonSchema;
+
+// This file only contains manual additions to entities.
+// These should be exceptions and not the norm.
+// Most of the entities are generated under Entities.Generated.cs
+
+[JsonConverter(typeof(EcsLogJsonConverter))]
+public partial class Log
+{
+
+}

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.Generated.cs
@@ -92,6 +92,20 @@ namespace Elastic.CommonSchema.Serialization
 							: false
 			};
 		}
+		public void WriteLogEntity(Utf8JsonWriter writer, Log value) {
+			if (value == null) return;
+			// only write the log object if it has values other then log.level
+			if (
+			value.FilePath == null &&
+				value.Logger == null &&
+				value.OriginFileLine == null &&
+				value.OriginFileName == null &&
+				value.OriginFunction == null &&
+			value.Syslog == null &&
+			true) return;
+
+			WriteProp(writer, "log", value, EcsJsonContext.Default.Log);
+		}
 
 		public override void Write(Utf8JsonWriter writer, TBase value, JsonSerializerOptions options)
 		{
@@ -105,7 +119,7 @@ namespace Elastic.CommonSchema.Serialization
 			WriteTimestamp(writer, value);
 			WriteLogLevel(writer, value);
 			WriteMessage(writer, value);
-			WriteProp(writer, "metadata", value.Metadata);
+			WriteLogEntity(writer, value.Log);
 
 			// Base fields
 			WriteProp(writer, "tags", value.Tags);
@@ -137,7 +151,6 @@ namespace Elastic.CommonSchema.Serialization
 			WriteProp(writer, "host", value.Host, EcsJsonContext.Default.Host);
 			WriteProp(writer, "http", value.Http, EcsJsonContext.Default.Http);
 			WriteProp(writer, "interface", value.Interface, EcsJsonContext.Default.Interface);
-			WriteProp(writer, "log", value.Log, EcsJsonContext.Default.Log);
 			WriteProp(writer, "network", value.Network, EcsJsonContext.Default.Network);
 			WriteProp(writer, "observer", value.Observer, EcsJsonContext.Default.Observer);
 			WriteProp(writer, "orchestrator", value.Orchestrator, EcsJsonContext.Default.Orchestrator);
@@ -160,6 +173,7 @@ namespace Elastic.CommonSchema.Serialization
 			WriteProp(writer, "vlan", value.Vlan, EcsJsonContext.Default.Vlan);
 			WriteProp(writer, "vulnerability", value.Vulnerability, EcsJsonContext.Default.Vulnerability);
 			WriteProp(writer, "x509", value.X509, EcsJsonContext.Default.X509);
+			WriteProp(writer, "metadata", value.Metadata);
 
 			if (typeof(EcsDocument) != value.GetType())
 				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v));

--- a/src/Elastic.CommonSchema/Serialization/EcsJsonContext.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonContext.Generated.cs
@@ -12,7 +12,7 @@ If you wish to submit a PR please modify the original csharp file and submit the
 
 using System.Text.Json.Serialization;
 
-namespace Elastic.CommonSchema;
+namespace Elastic.CommonSchema.Serialization;
 
 [JsonSerializable(typeof(Agent))]
 [JsonSerializable(typeof(As))]

--- a/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
@@ -68,7 +68,31 @@ namespace Elastic.CommonSchema.Serialization
 			return JsonSerializer.Deserialize(ref reader, type, options);
 		}
 
-		protected static TValue ReadProp<TValue>(ref Utf8JsonReader reader, string key)  where TValue : class
+		private static long? ReadPropLong(ref Utf8JsonReader reader, string key)
+		{
+			if (reader.TokenType == JsonTokenType.PropertyName) reader.Read();
+			return reader.TokenType != JsonTokenType.Number ? null : reader.TryGetInt64(out var l) ? l : null;
+		}
+
+		protected static bool ReadPropLong(ref Utf8JsonReader reader, string key, T b, Action<T, long?> set)
+		{
+			set(b, ReadPropLong(ref reader, key));
+			return true;
+		}
+
+		private static string ReadPropString(ref Utf8JsonReader reader, string key)
+		{
+			if (reader.TokenType == JsonTokenType.PropertyName) reader.Read();
+			return reader.TokenType != JsonTokenType.String ? null : reader.GetString();
+		}
+
+		protected static bool ReadPropString(ref Utf8JsonReader reader, string key, T b, Action<T, string> set)
+		{
+			set(b, ReadPropString(ref reader, key));
+			return true;
+		}
+
+		private static TValue ReadProp<TValue>(ref Utf8JsonReader reader, string key)  where TValue : class
 		{
 			if (reader.TokenType == JsonTokenType.Null) return null;
 

--- a/src/Elastic.CommonSchema/Serialization/EcsLogJsonConverter.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsLogJsonConverter.Generated.cs
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+/*
+IMPORTANT NOTE
+==============
+This file has been generated. 
+If you wish to submit a PR please modify the original csharp file and submit the PR with that change. Thanks!
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Elastic.CommonSchema.Serialization
+{
+	public partial class EcsLogJsonConverter : EcsJsonConverterBase<Log>
+	{
+		private static bool ReadProperties(ref Utf8JsonReader reader, Log ecsEvent)
+		{
+			var propertyName = reader.GetString();
+			reader.Read();
+			return propertyName switch
+			{
+				"file.path" => ReadPropString(ref reader, "file.path", ecsEvent, (b, v) => b.FilePath = v),
+				"level" => ReadPropString(ref reader, "level", ecsEvent, (b, v) => b.Level = v),
+				"logger" => ReadPropString(ref reader, "logger", ecsEvent, (b, v) => b.Logger = v),
+				"origin.file.line" => ReadPropLong(ref reader, "origin.file.line", ecsEvent, (b, v) => b.OriginFileLine = v),
+				"origin.file.name" => ReadPropString(ref reader, "origin.file.name", ecsEvent, (b, v) => b.OriginFileName = v),
+				"origin.function" => ReadPropString(ref reader, "origin.function", ecsEvent, (b, v) => b.OriginFunction = v),
+				"syslog" => ReadProp<LogSyslog>(ref reader, "syslog", ecsEvent, (b, v) => b.Syslog = v),
+				_ => false
+			};
+		}
+
+		public override void Write(Utf8JsonWriter writer, Log value, JsonSerializerOptions options)
+		{
+			if (value == null)
+			{
+				writer.WriteNullValue();
+				return;
+			}
+			if (
+			value.FilePath == null &&
+				value.Logger == null &&
+				value.OriginFileLine == null &&
+				value.OriginFileName == null &&
+				value.OriginFunction == null &&
+			value.Syslog == null &&
+			true) {
+				writer.WriteNullValue();
+				return;
+			}
+			writer.WriteStartObject();
+
+			WriteProp(writer, "file.path", value.FilePath);
+				WriteProp(writer, "logger", value.Logger);
+				WriteProp(writer, "origin.file.line", value.OriginFileLine);
+				WriteProp(writer, "origin.file.name", value.OriginFileName);
+				WriteProp(writer, "origin.function", value.OriginFunction);
+			WriteProp(writer, "syslog", value.Syslog);
+
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/Elastic.CommonSchema/Serialization/EcsLogJsonConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsLogJsonConverter.cs
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text.Json;
+
+namespace Elastic.CommonSchema.Serialization
+{
+	public partial class EcsLogJsonConverter
+	{
+		public override Log Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null)
+			{
+				reader.Read();
+				return null;
+			}
+			if (reader.TokenType != JsonTokenType.StartObject)
+				throw new JsonException();
+
+			var ecsEvent = new Log();
+
+			while (reader.Read())
+			{
+				if (reader.TokenType == JsonTokenType.EndObject)
+					break;
+
+				if (reader.TokenType != JsonTokenType.PropertyName)
+					throw new JsonException();
+
+				var _ = ReadProperties(ref reader, ecsEvent);
+			}
+
+			return ecsEvent;
+		}
+	}
+}

--- a/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
+++ b/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
@@ -20,6 +20,7 @@ namespace Elastic.CommonSchema.Serialization
 			Converters =
 			{
 				new EcsDocumentJsonConverterFactory(),
+				new EcsLogJsonConverter(),
 				// System.Text.Json got significantly better at not tripping over BCL types with .NET 7.0.
 				// ECS should fallback from serialization failures in metadata however this list catches the most
 				// common offenders. This to ensure better interop with older ASP.NET version out of the box see:

--- a/tests/Elastic.CommonSchema.Tests/LogLevelTests.cs
+++ b/tests/Elastic.CommonSchema.Tests/LogLevelTests.cs
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Elastic.CommonSchema.Serialization;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.CommonSchema.Tests
+{
+	public class LogLevelTests
+	{
+		public LogLevelTests(ITestOutputHelper output) => _output = output;
+
+		private readonly ITestOutputHelper _output;
+
+		[Fact] public void SerializesLogLevelAtRoot()
+		{
+			var b = new EcsDocument { Log = new Log { Level = "debug" } };
+
+			var serialized = b.Serialize();
+			_output.WriteLine(serialized);
+			serialized.Should().NotBeNullOrWhiteSpace();
+			serialized.Should().Be("{\"log.level\":\"debug\"}");
+
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Log.Should().NotBeNull();
+			deserialized.Log.Level.Should().Be("debug");
+		}
+
+		[Fact] public void DeserializesFromNestedLevel()
+		{
+			var json = "{\"log\": { \"level\":\"DEBUG\"} }";
+
+			var deserialized = EcsDocument.Deserialize(json);
+			deserialized.Log.Should().NotBeNull();
+			deserialized.Log.Level.Should().Be("DEBUG");
+		}
+		[Fact] public void DeserializesFromBoth()
+		{
+			var json = "{\"log.level\": \"INFO\", \"log\": { \"level\":\"DEBUG\"} }";
+
+			var deserialized = EcsDocument.Deserialize(json);
+			deserialized.Log.Should().NotBeNull();
+			deserialized.Log.Level.Should().Be("INFO");
+		}
+
+		[Fact] public void SerializesLogProperties()
+		{
+			var b = new EcsDocument { Log = new Log { Level = "debug", Logger = "x"} };
+
+			var serialized = b.Serialize();
+			_output.WriteLine(serialized);
+			serialized.Should().NotBeNullOrWhiteSpace();
+			serialized.Should().Be("{\"log.level\":\"debug\",\"log\":{\"logger\":\"x\"}}");
+
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Log.Should().NotBeNull();
+			deserialized.Log.Level.Should().Be("debug");
+			deserialized.Log.Logger.Should().Be("x");
+		}
+	}
+}


### PR DESCRIPTION
With the new serialization generation we were emitting log level twice
once under `log.level` and once as `log: { level: }`

This PR addresses this to ensure we never emit the latter but are able
to read both versions of the json.

This to make sure the JSON we emit is compatible with the
`json.expand_keys` option in filebeat as identified as @elan-slovelock

This PR also makes sure we never emit `log: {}` if only log level is
set.
