### PR TITLE
Update to latest Elastic.Transport

### DIFF
--- a/examples/Elastic.Ingest.Apm.Example/Program.cs
+++ b/examples/Elastic.Ingest.Apm.Example/Program.cs
@@ -27,7 +27,7 @@ namespace Elastic.Ingest.Apm.Example
 				.EnableDebugMode()
 				.Authentication(new ApiKey(args[1]));
 			//TODO needs
-			var transport = new Transport<TransportConfiguration>(config);
+			var transport = new DefaultHttpTransport<TransportConfiguration>(config);
 
 			var numberOfEvents = 800;
 			var maxBufferSize = 200;
@@ -52,7 +52,7 @@ namespace Elastic.Ingest.Apm.Example
 				ResponseCallback = (r, b) =>
 				{
 					Interlocked.Increment(ref _responses);
-					Console.WriteLine(r.ApiCall.DebugInformation);
+					Console.WriteLine(r.ApiCallDetails.DebugInformation);
 				},
 				MaxRetriesExceededCallback = (list) => Interlocked.Increment(ref _maxRetriesExceeded),
 				RetryCallBack = (list) => Interlocked.Increment(ref _retries),

--- a/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
+++ b/examples/Elasticsearch.Extensions.Logging.Example/Program.cs
@@ -39,7 +39,7 @@ namespace Elasticsearch.Extensions.Logging.Example
 							channel.PublishRejectionCallback = e => Console.Write("!");
 						}
 						channel.ResponseCallback = (r, b) =>
-							Console.WriteLine($"Indexed: {r.ApiCall.Success} items: {b.Count} time since first read: {b.DurationSinceFirstRead}");
+							Console.WriteLine($"statusCode: {r.ApiCallDetails.HttpStatusCode} items: {b.Count} time since first read: {b.DurationSinceFirstRead}");
 					});
 				})
 				.ConfigureServices((hostContext, services) =>

--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Domain/BenchmarkDocument.cs
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/Domain/BenchmarkDocument.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
+using Elastic.CommonSchema.Serialization;
 
 namespace Elastic.CommonSchema.BenchmarkDotNetExporter.Domain
 {
 	/// <summary>
 	/// Represents a benchmark case with information of the overall benchmark run.
 	/// </summary>
+	[JsonConverter(typeof(EcsDocumentJsonConverterFactory))]
 	public class BenchmarkDocument : EcsDocument
 	{
 		[JsonPropertyName("benchmark"), DataMember(Name = "benchmark")]

--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporter.cs
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporter.cs
@@ -30,17 +30,17 @@ namespace Elastic.CommonSchema.BenchmarkDotNetExporter
 		{
 			Options = options;
 			var config = Options.CreateTransportConfiguration();
-			Transport = new Transport<TransportConfiguration>(config);
+			Transport = new DefaultHttpTransport<TransportConfiguration>(config);
 		}
 
 		public ElasticsearchBenchmarkExporter(ElasticsearchBenchmarkExporterOptions options, Func<ElasticsearchBenchmarkExporterOptions, TransportConfiguration> configure)
 		{
 			Options = options;
-			Transport = new Transport<TransportConfiguration>(configure(Options));
+			Transport = new DefaultHttpTransport<TransportConfiguration>(configure(Options));
 		}
 
 
-		private Transport<TransportConfiguration> Transport { get; }
+		private HttpTransport<TransportConfiguration> Transport { get; }
 		private ElasticsearchBenchmarkExporterOptions Options { get; }
 
 		// We only log when we cannot write to Elasticsearch

--- a/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSink.cs
+++ b/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSink.cs
@@ -15,9 +15,9 @@ namespace Elastic.CommonSchema.Serilog.Sink
 	public class ElasticsearchSchemaSinkOptions
 	{
 		public ElasticsearchSchemaSinkOptions() : this(TransportHelper.Default()) {}
-		public ElasticsearchSchemaSinkOptions(ITransport transport) => Transport = transport;
+		public ElasticsearchSchemaSinkOptions(HttpTransport transport) => Transport = transport;
 
-		public ITransport Transport { get; }
+		public HttpTransport Transport { get; }
 		public EcsTextFormatterConfiguration EcsTextFormatterConfiguration { get; set; } = new ();
 		public DataStreamName DataStream { get; set; } = new("logs", "dotnet");
 		public Action<DataStreamChannelOptions<EcsDocument>>? ConfigureChannel { get; set; }

--- a/src/Elastic.CommonSchema.Serilog.Sink/TransportHelper.cs
+++ b/src/Elastic.CommonSchema.Serilog.Sink/TransportHelper.cs
@@ -9,33 +9,33 @@ namespace Elastic.CommonSchema.Serilog.Sink
 {
 	internal static class TransportHelper
 	{
-		private static IProductRegistration DefaultProduct = new ElasticsearchProductRegistration();
-		public static ITransport Default() =>
-			new Transport.Transport(new TransportConfiguration(new Uri("http://localhost:9200"), DefaultProduct));
+		private static ProductRegistration DefaultProduct = new ElasticsearchProductRegistration();
+		public static HttpTransport Default() =>
+			new DefaultHttpTransport(new TransportConfiguration(new Uri("http://localhost:9200"), DefaultProduct));
 
-		public static ITransport Static(IEnumerable<string> nodes)
+		public static HttpTransport Static(IEnumerable<string> nodes)
 		{
 			var pool = new StaticNodePool(nodes.Select(e => new Node(new Uri(e))));
-			return new Transport.Transport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
+			return new DefaultHttpTransport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
 		}
-		public static ITransport Sniffing(IEnumerable<string> nodes)
+		public static HttpTransport Sniffing(IEnumerable<string> nodes)
 		{
 			var pool = new SniffingNodePool(nodes.Select(e => new Node(new Uri(e))));
-			return new Transport.Transport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
+			return new DefaultHttpTransport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
 		}
 
-		public static ITransport Cloud(string endpoint, string apiKey)
+		public static HttpTransport Cloud(string endpoint, string apiKey)
 		{
 			var header = new ApiKey(apiKey);
 			var pool = new CloudNodePool(endpoint, header);
-			return new Transport.Transport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
+			return new DefaultHttpTransport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
 		}
 
-		public static ITransport Cloud(string endpoint, string username, string password)
+		public static HttpTransport Cloud(string endpoint, string username, string password)
 		{
 			var header = new BasicAuthentication(username, password);
 			var pool = new CloudNodePool(endpoint, header);
-			return new Transport.Transport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
+			return new DefaultHttpTransport(new TransportConfiguration(pool, productRegistration: DefaultProduct));
 		}
 
 	}

--- a/src/Elastic.CommonSchema/EcsDcocument.Serialization.cs
+++ b/src/Elastic.CommonSchema/EcsDcocument.Serialization.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.CommonSchema.Serialization;
@@ -14,6 +15,7 @@ using static Elastic.CommonSchema.Serialization.EcsJsonConfiguration;
 
 namespace Elastic.CommonSchema
 {
+	[JsonConverter(typeof(EcsDocumentJsonConverterFactory))]
 	public partial class EcsDocument : BaseFieldSet
 	{
 		/// <summary>

--- a/src/Elastic.CommonSchema/README.md
+++ b/src/Elastic.CommonSchema/README.md
@@ -169,6 +169,7 @@ Through `TryRead`/`ReceiveProperty`/`WriteAdditionalProperties` you can hook int
 /// <summary>
 /// An extended ECS document with an additional property
 /// </summary>
+[JsonConverter(typeof(EcsDocumentJsonConverterFactory))]
 public class MyEcsDocument : EcsDocument
 {
 	[JsonPropertyName("my_root_property"), DataMember(Name = "my_root_property")]

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverterFactory.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverterFactory.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Elastic.CommonSchema.Serialization
 {
-	internal class EcsDocumentJsonConverterFactory : JsonConverterFactory
+	public class EcsDocumentJsonConverterFactory : JsonConverterFactory
 	{
 		public override bool CanConvert(Type typeToConvert) => typeof(EcsDocument).IsAssignableFrom(typeToConvert);
 

--- a/src/Elastic.Ingest.Apm/ApmChannelOptions.cs
+++ b/src/Elastic.Ingest.Apm/ApmChannelOptions.cs
@@ -7,7 +7,7 @@ namespace Elastic.Ingest.Apm
 {
 	public class ApmChannelOptions : TransportChannelOptionsBase<IIntakeObject, EventIntakeResponse, IntakeErrorItem, ApmBufferOptions>
 	{
-		public ApmChannelOptions(ITransport<ITransportConfiguration> transport) : base(transport) { }
+		public ApmChannelOptions(HttpTransport transport) : base(transport) { }
 	}
 
 

--- a/src/Elastic.Ingest.Apm/Model/IngestResponse.cs
+++ b/src/Elastic.Ingest.Apm/Model/IngestResponse.cs
@@ -4,13 +4,8 @@ using Elastic.Transport;
 
 namespace Elastic.Ingest.Apm.Model
 {
-	public class EventIntakeResponse : ITransportResponse
+	public class EventIntakeResponse : TransportResponse
 	{
-		[JsonIgnore]
-		IApiCallDetails ITransportResponse.ApiCall { get; set; } = null!;
-		[JsonIgnore]
-		public IApiCallDetails ApiCall => ((ITransportResponse)this).ApiCall;
-
 		[JsonPropertyName("accepted")]
 		public long Accepted { get; set; }
 

--- a/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannelOptions.cs
+++ b/src/Elastic.Ingest.Elasticsearch/DataStreams/DataStreamChannelOptions.cs
@@ -4,7 +4,7 @@ namespace Elastic.Ingest.Elasticsearch.DataStreams
 {
 	public class DataStreamChannelOptions<TEvent> : ElasticsearchChannelOptionsBase<TEvent>
 	{
-		public DataStreamChannelOptions(ITransport transport) : base(transport) =>
+		public DataStreamChannelOptions(HttpTransport transport) : base(transport) =>
 			DataStream = new DataStreamName(typeof(TEvent).Name.ToLowerInvariant());
 
 		public DataStreamName DataStream { get; set; }

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelOptionsBase.cs
@@ -6,7 +6,7 @@ namespace Elastic.Ingest.Elasticsearch
 {
 	public class ElasticsearchChannelOptionsBase<TEvent> : TransportChannelOptionsBase<TEvent, BulkResponse, BulkResponseItem, ElasticsearchBufferOptions<TEvent>>
 	{
-		protected ElasticsearchChannelOptionsBase(ITransport transport) : base(transport)
+		protected ElasticsearchChannelOptionsBase(HttpTransport transport) : base(transport)
 		{
 		}
 	}

--- a/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelStatics.cs
+++ b/src/Elastic.Ingest.Elasticsearch/ElasticsearchChannelStatics.cs
@@ -11,6 +11,7 @@ using Elastic.Transport;
 
 namespace Elastic.Ingest.Elasticsearch
 {
+	internal class ElasticsearchRequestParameters : RequestParameters { }
 	internal static class ElasticsearchChannelStatics
 	{
 		public static readonly byte[] LineFeed = { (byte)'\n' };
@@ -18,12 +19,12 @@ namespace Elastic.Ingest.Elasticsearch
 		public static readonly byte[] DocUpdateHeaderStart = Encoding.UTF8.GetBytes("{\"doc\": ");
 		public static readonly byte[] DocUpdateHeaderEnd = Encoding.UTF8.GetBytes(" }");
 
-		public static readonly RequestParameters RequestParams =
+		public static readonly ElasticsearchRequestParameters RequestParams =
 			new() { QueryString = { { "filter_path", "error, items.*.status,items.*.error" } } };
 
 		public static readonly HashSet<int> RetryStatusCodes = new(new[] { 502, 503, 504, 429 });
 
-		public static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions()
+		public static readonly JsonSerializerOptions SerializerOptions = new ()
 		{
 			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
 			Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,

--- a/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannelOptions.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Indices/IndexChannelOptions.cs
@@ -5,7 +5,7 @@ namespace Elastic.Ingest.Elasticsearch.Indices
 {
 	public class IndexChannelOptions<TEvent> : ElasticsearchChannelOptionsBase<TEvent>
 	{
-		public IndexChannelOptions(ITransport<ITransportConfiguration> transport) : base(transport) { }
+		public IndexChannelOptions(HttpTransport transport) : base(transport) { }
 
 		/// <summary>
 		/// Gets or sets the format string for the Elastic search index. The current <c>DateTimeOffset</c> is passed as parameter

--- a/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponse.cs
+++ b/src/Elastic.Ingest.Elasticsearch/Serialization/BulkResponse.cs
@@ -9,13 +9,8 @@ using Elastic.Transport.Products.Elasticsearch;
 namespace Elastic.Ingest.Elasticsearch.Serialization
 {
 
-	public class BulkResponse : ITransportResponse
+	public class BulkResponse : TransportResponse
 	{
-		[JsonIgnore]
-		IApiCallDetails ITransportResponse.ApiCall { get; set; } = null!;
-		[JsonIgnore]
-		public IApiCallDetails ApiCall => ((ITransportResponse)this).ApiCall;
-
 		[JsonPropertyName("items")]
 		[JsonConverter(typeof(ResponseItemsConverter))]
 		public IReadOnlyCollection<BulkResponseItem> Items { get; set; } = null!;
@@ -29,7 +24,7 @@ namespace Elastic.Ingest.Elasticsearch.Serialization
 			return !string.IsNullOrWhiteSpace(reason);
 		}
 
-		public override string ToString() => ApiCall.DebugInformation;
+		public override string ToString() => ApiCallDetails.DebugInformation;
 	}
 	internal class ResponseItemsConverter : JsonConverter<IReadOnlyCollection<BulkResponseItem>>
 	{

--- a/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
+++ b/src/Elastic.Ingest.Transport/Elastic.Ingest.Transport.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Ingest\Elastic.Ingest.csproj" />
-    <PackageReference Include="Elastic.Transport" Version="0.3.2" />
+    <PackageReference Include="Elastic.Transport" Version="0.4.5" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>
 

--- a/src/Elastic.Ingest.Transport/TransportChannelBase.cs
+++ b/src/Elastic.Ingest.Transport/TransportChannelBase.cs
@@ -14,7 +14,7 @@ namespace Elastic.Ingest.Transport
 		ChannelBase<TChannelOptions, TBuffer, TEvent, TResponse, TBulkResponseItem>, IDisposable
 		where TChannelOptions : TransportChannelOptionsBase<TEvent, TResponse, TBulkResponseItem, TBuffer>
 		where TBuffer : BufferOptions<TEvent>, new()
-		where TResponse : class, ITransportResponse, new()
+		where TResponse : TransportResponse, new()
 
 	{
 		protected TransportChannelBase(TChannelOptions options) : base(options) { }
@@ -23,7 +23,7 @@ namespace Elastic.Ingest.Transport
 		/// <param name="transport"></param>
 		/// <param name="page">Active page of the buffer that needs to be send to the output</param>
 		/// <returns><see cref="TResponse"/></returns>
-		protected abstract Task<TResponse> Send(ITransport transport, IReadOnlyCollection<TEvent> page);
+		protected abstract Task<TResponse> Send(HttpTransport transport, IReadOnlyCollection<TEvent> page);
 
 		protected override Task<TResponse> Send(IReadOnlyCollection<TEvent> page) => Send(Options.Transport, page);
 	}

--- a/src/Elastic.Ingest.Transport/TransportChannelOptionsBase.cs
+++ b/src/Elastic.Ingest.Transport/TransportChannelOptionsBase.cs
@@ -6,8 +6,8 @@ namespace Elastic.Ingest.Transport
 		: ChannelOptionsBase<TEvent, TBuffer, TResponse, TResponseItem>
 		where TBuffer : BufferOptions<TEvent>, new()
 	{
-		protected TransportChannelOptionsBase(ITransport transport) => Transport = transport;
+		protected TransportChannelOptionsBase(HttpTransport transport) => Transport = transport;
 
-		public ITransport Transport { get; }
+		public HttpTransport Transport { get; }
 	}
 }

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerProvider.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerProvider.cs
@@ -99,14 +99,14 @@ namespace Elasticsearch.Extensions.Logging
 			}
 		}
 
-		private static ITransport<ITransportConfiguration> CreateTransport(ElasticsearchLoggerOptions loggerOptions)
+		private static HttpTransport<TransportConfiguration> CreateTransport(ElasticsearchLoggerOptions loggerOptions)
 		{
 			// TODO: Check if Uri has changed before recreating
 			// TODO: Injectable factory? Or some way of testing.
 			var connectionPool = CreateConnectionPool(loggerOptions);
 			var config = new TransportConfiguration(connectionPool, productRegistration: new ElasticsearchProductRegistration());
 
-			var transport = new Transport<TransportConfiguration>(config);
+			var transport = new DefaultHttpTransport<TransportConfiguration>(config);
 			return transport;
 		}
 

--- a/src/Elasticsearch.Extensions.Logging/LogEvent.cs
+++ b/src/Elasticsearch.Extensions.Logging/LogEvent.cs
@@ -11,6 +11,7 @@ using Elastic.CommonSchema.Serialization;
 
 namespace Elasticsearch.Extensions.Logging
 {
+	[JsonConverter(typeof(EcsDocumentJsonConverterFactory))]
 	public class LogEvent : EcsDocument
 	{
 		// Custom fields; use capitalisation as per ECS

--- a/tests/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/Elastic.CommonSchema.Serilog.Sinks.IntegrationTests.csproj
+++ b/tests/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/Elastic.CommonSchema.Serilog.Sinks.IntegrationTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0-beta.4" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
 
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.3.5" />

--- a/tests/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/SerilogOutputTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/SerilogOutputTests.cs
@@ -62,7 +62,7 @@ namespace Serilog.Sinks.Elasticsearch.IntegrationTests
 
 			var indexName = SinkOptions.DataStream.ToString();
 			var refreshed = await Client.Indices.RefreshAsync(new RefreshRequest(indexName));
-			refreshed.IsValid.Should().BeTrue("{0}", refreshed.DebugInformation);
+			refreshed.IsValidResponse.Should().BeTrue("{0}", refreshed.DebugInformation);
 
 			var search = await Client.SearchAsync<EcsDocument>(new SearchRequest(indexName));
 

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Repro/GithubIssue167.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Repro/GithubIssue167.cs
@@ -16,6 +16,7 @@ namespace Elastic.CommonSchema.Serilog.Tests.Repro
 {
 	public class GithubIssue167
 	{
+		[JsonConverter(typeof(EcsDocumentJsonConverterFactory))]
 		public class ContosoDocument : EcsDocument
 		{
 			[JsonPropertyName("contoso"), DataMember(Name = "contoso")]

--- a/tests/Elastic.CommonSchema.Tests/Serializes.cs
+++ b/tests/Elastic.CommonSchema.Tests/Serializes.cs
@@ -70,6 +70,7 @@ namespace Elastic.CommonSchema.Tests
 			deserialized.Metadata.Should().ContainKey("rule");
 		}
 
+		[JsonConverter(typeof(EcsDocumentJsonConverterFactory))]
 		public class SubclassedDocument : EcsDocument
 		{
 			[JsonPropertyName("agent2")]

--- a/tests/Elastic.Ingest.IntegrationTests/CommonSchemaIngestionTests.cs
+++ b/tests/Elastic.Ingest.IntegrationTests/CommonSchemaIngestionTests.cs
@@ -54,7 +54,7 @@ namespace Elastic.Ingest.IntegrationTests
 
 			exists.Exists.Should().BeTrue("{0}", exists);
 
-			var dataStream = await Client.Indices.GetDataStreamAsync(new DataStreamRequest(targetDataStream.ToString()));
+			var dataStream = await Client.Indices.GetDataStreamAsync(new GetDataStreamRequest(targetDataStream.ToString()));
 			dataStream.DataStreams.Should().BeNullOrEmpty();
 
 			ecsChannel.TryWrite(new EcsDocument { Timestamp = DateTimeOffset.Now, Message = "hello-world" });

--- a/tests/Elastic.Ingest.IntegrationTests/Elastic.Ingest.IntegrationTests.csproj
+++ b/tests/Elastic.Ingest.IntegrationTests/Elastic.Ingest.IntegrationTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0-beta.4" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.3.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />

--- a/tests/Elastic.Ingest.Tests/Elastic.Ingest.Tests.csproj
+++ b/tests/Elastic.Ingest.Tests/Elastic.Ingest.Tests.csproj
@@ -14,7 +14,7 @@
     </PackageReference>
 
 
-    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.3.2" />
+    <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="0.4.5" />
 
 
     <PackageReference Include="XunitContext" Version="3.0.0" />

--- a/tests/Elastic.Ingest.Tests/Elasticsearch/Setup.cs
+++ b/tests/Elastic.Ingest.Tests/Elasticsearch/Setup.cs
@@ -13,7 +13,7 @@ namespace Elastic.Ingest.Tests.Elasticsearch
 {
 	public static class TestSetup
 	{
-		public static ITransport<ITransportConfiguration> CreateClient(Func<VirtualCluster, VirtualCluster> setup)
+		public static HttpTransport<TransportConfiguration> CreateClient(Func<VirtualCluster, VirtualCluster> setup)
 		{
 			var cluster = Virtual.Elasticsearch.Bootstrap(numberOfNodes: 1).Ping(c=>c.SucceedAlways());
 			var virtualSettings = setup(cluster)
@@ -26,7 +26,7 @@ namespace Elastic.Ingest.Tests.Elasticsearch
 			var settings = new TransportConfiguration(virtualSettings.ConnectionPool, virtualSettings.Connection)
 				.DisablePing()
 				.EnableDebugMode();
-			return new Transport<TransportConfiguration>(settings);
+			return new DefaultHttpTransport<TransportConfiguration>(settings);
 		}
 
 		public static ClientCallRule BulkResponse(this ClientCallRule rule, params int[] statusCodes) =>
@@ -40,7 +40,7 @@ namespace Elastic.Ingest.Tests.Elasticsearch
 			private int _retries;
 			private int _maxRetriesExceeded;
 
-			public TestSession(ITransport<ITransportConfiguration> transport)
+			public TestSession(HttpTransport<TransportConfiguration> transport)
 			{
 				Transport = transport;
 				BufferOptions = new ElasticsearchBufferOptions<EcsDocument>()
@@ -67,7 +67,7 @@ namespace Elastic.Ingest.Tests.Elasticsearch
 
 			public IndexChannel<EcsDocument> Channel { get; }
 
-			public ITransport<ITransportConfiguration> Transport { get; }
+			public HttpTransport<TransportConfiguration> Transport { get; }
 
 			public IndexChannelOptions<EcsDocument> ChannelOptions { get; }
 
@@ -95,7 +95,7 @@ namespace Elastic.Ingest.Tests.Elasticsearch
 			}
 		}
 
-		public static TestSession CreateTestSession(ITransport<ITransportConfiguration> transport) =>
+		public static TestSession CreateTestSession(HttpTransport<TransportConfiguration> transport) =>
 			new TestSession(transport);
 
 		public static void WriteAndWait(this TestSession session, int events = 1)

--- a/tests/Elasticsearch.Extensions.Logging.IntegrationTests/Elasticsearch.Extensions.Logging.IntegrationTests.csproj
+++ b/tests/Elasticsearch.Extensions.Logging.IntegrationTests/Elasticsearch.Extensions.Logging.IntegrationTests.csproj
@@ -12,7 +12,8 @@
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.3.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="NEST" Version="7.8.1" />
+<!--    <PackageReference Include="NEST" Version="7.8.1" />-->
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingCluster.cs
+++ b/tests/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingCluster.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Linq;
+using Elastic.Clients.Elasticsearch;
 using Elastic.Elasticsearch.Xunit;
+using Elastic.Transport;
 using Xunit;
+using Xunit.Abstractions;
 
 [assembly: TestFramework("Elastic.Elasticsearch.Xunit.Sdk.ElasticTestFramework", "Elastic.Elasticsearch.Xunit")]
 
@@ -12,5 +17,24 @@ namespace Elasticsearch.Extensions.Logging.IntegrationTests
 		{
 			StartingPortNumber = 9201
 		}) { }
+
+		public ElasticsearchClient CreateClient(ITestOutputHelper output) =>
+			this.GetOrAddClient(c =>
+			{
+				var hostName = (System.Diagnostics.Process.GetProcessesByName("mitmproxy").Any()
+					? "ipv4.fiddler"
+					: "localhost");
+				var nodes = NodesUris(hostName);
+				var connectionPool = new StaticNodePool(nodes);
+				var settings = new ElasticsearchClientSettings(connectionPool)
+					.Proxy(new Uri("http://ipv4.fiddler:8080"), (string)null, (string)null)
+					.OnRequestCompleted(d =>
+					{
+						try { output.WriteLine(d.DebugInformation);}
+						catch { }
+					})
+					.EnableDebugMode();
+				return new ElasticsearchClient(settings);
+			});
 	}
 }


### PR DESCRIPTION
This ensures the logging and ingest libraries can be used in conjunction with the new Elasticsearch client.

Includes refactoring from https://github.com/elastic/elastic-transport-net/pull/52

cc @stevejgordon 