### PR TITLE
Elastic.Apm.NLog + Elastic.CommonSchema.Nlog with NLog v4.7.15

### DIFF
--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -13,7 +13,7 @@
       Feel free to open an issue on our repos to discuss if you feel you need to target 
       a lower NLog version
     -->
-    <PackageReference Include="NLog" Version="4.5.4" />
+    <PackageReference Include="NLog" Version="4.7.15" />
     <PackageReference Include="Elastic.Apm" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
+++ b/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
@@ -10,6 +10,6 @@
       <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NLog" Version="4.5.4" />
+      <PackageReference Include="NLog" Version="4.7.15" />
     </ItemGroup>
 </Project>

--- a/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
+++ b/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
@@ -7,10 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Apm" Version="1.8.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NLog" Version="4.6.4" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NLog" Version="4.5.11" />
-        <PackageReference Include="NLog.Config" Version="4.5.4" />
+        <PackageReference Include="NLog" Version="4.7.15" />
         <PackageReference Include="Elastic.Apm" Version="1.8.0" />
     </ItemGroup>
 


### PR DESCRIPTION
NLog v4.7.15 has no breaking changes (remains strong-version 4.0.0.0), and lots of improvements and bug-fixes.

Ensures `${hostname}` and `${local-ip}` and `${environment-user}` works as expected in EcsLayout (improve out-of-the-box experience)