### PR TITLE
action: use push for the tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 
 on:
-  create:
+  push:
     tags: [ '[0-9]+.[0-9]+.[0-9]+.*' ]
 
 permissions:


### PR DESCRIPTION
tags filter is not available for `create` but `push` instead.

https://github.com/actions/runner/issues/1007