### PR TITLE
make sure we read the junit files in the zip

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           artifact: test-results            # artifact name
           name: JUnit Tests                 # Name of the check run which will be created
-          path: "build/output/junit-*.xml"  # Path to test results (inside artifact .zip)
+          path: "junit-*.xml"  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results


### PR DESCRIPTION
These do not appear to preserve directories inside the zip:

```
Report name: JUnit Tests
  Skipping junit-Elastic.Apm.Disabled.Serilog.Tests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.Apm.NLog.Test-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.Apm.SerilogEnricher.Test-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.CommonSchema.Log4net.Tests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.CommonSchema.NLog.Tests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.CommonSchema.Serilog.Tests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.CommonSchema.Tests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elasticsearch.Extensions.Logging.IntegrationTests-NETCoreApp60-test-results.xml: filename does not match pattern
  Skipping junit-Elasticsearch.IntegrationDefaults-NETCoreApp60-test-results.xml: filename does not match pattern
```

e.g: https://github.com/elastic/ecs-dotnet/actions/runs/4066499945/jobs/7002661008