### PR TITLE
Add generic config options to LoggerSinkConfiguration

### DIFF
--- a/examples/Elastic.CommonSchema.Serilog.Sink.Example/Program.cs
+++ b/examples/Elastic.CommonSchema.Serilog.Sink.Example/Program.cs
@@ -2,6 +2,7 @@
 
 using Elastic.Channels;
 using Elastic.Clients.Elasticsearch;
+using Elastic.CommonSchema;
 using Elastic.CommonSchema.Serilog;
 using Elastic.CommonSchema.Serilog.Sink;
 using Elastic.CommonSchema.Serilog.Sink.Example;

--- a/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSink.cs
+++ b/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSink.cs
@@ -12,29 +12,41 @@ using Serilog.Events;
 
 namespace Elastic.CommonSchema.Serilog.Sink
 {
-	public class ElasticsearchSchemaSinkOptions
+	public class ElasticsearchSchemaSinkOptions : ElasticsearchSchemaSinkOptions<EcsDocument>
+	{
+		public ElasticsearchSchemaSinkOptions() : base() { }
+
+		public ElasticsearchSchemaSinkOptions(HttpTransport transport) : base(transport) { }
+	}
+	public class ElasticsearchSchemaSinkOptions<TEcsDocument> where TEcsDocument : EcsDocument, new()
 	{
 		public ElasticsearchSchemaSinkOptions() : this(TransportHelper.Default()) { }
 
 		public ElasticsearchSchemaSinkOptions(HttpTransport transport) => Transport = transport;
 
 		public HttpTransport Transport { get; }
-		public EcsTextFormatterConfiguration TextFormatting { get; set; } = new();
+		public EcsTextFormatterConfiguration<TEcsDocument> TextFormatting { get; set; } = new();
 		public DataStreamName DataStream { get; set; } = new("logs", "dotnet");
-		public Action<DataStreamChannelOptions<EcsDocument>>? ConfigureChannel { get; set; }
+		public Action<DataStreamChannelOptions<TEcsDocument>>? ConfigureChannel { get; set; }
 		public BootstrapMethod BootstrapMethod { get; set; }
 
 	}
 
-	public class ElasticsearchSink : ILogEventSink
+	public class ElasticsearchSink : ElasticsearchSink<EcsDocument>
 	{
-		private readonly EcsTextFormatterConfiguration _formatterConfiguration;
-		private readonly EcsDataStreamChannel<EcsDocument> _channel;
+		public ElasticsearchSink(ElasticsearchSchemaSinkOptions options) : base(options) {}
+	}
 
-		public ElasticsearchSink(ElasticsearchSchemaSinkOptions options)
+	public class ElasticsearchSink<TEcsDocument> : ILogEventSink
+		where TEcsDocument : EcsDocument, new()
+	{
+		private readonly EcsTextFormatterConfiguration<TEcsDocument> _formatterConfiguration;
+		private readonly EcsDataStreamChannel<TEcsDocument> _channel;
+
+		public ElasticsearchSink(ElasticsearchSchemaSinkOptions<TEcsDocument> options)
 		{
 			_formatterConfiguration = options.TextFormatting;
-			var channelOptions = new DataStreamChannelOptions<EcsDocument>(options.Transport)
+			var channelOptions = new DataStreamChannelOptions<TEcsDocument>(options.Transport)
 			{
 				DataStream = options.DataStream,
 				ResponseCallback = ((response, statistics) =>
@@ -48,15 +60,16 @@ namespace Elastic.CommonSchema.Serilog.Sink
 				})
 			};
 			options.ConfigureChannel?.Invoke(channelOptions);
-			_channel = new EcsDataStreamChannel<EcsDocument>(channelOptions);
+			_channel = new EcsDataStreamChannel<TEcsDocument>(channelOptions);
 			_channel.BootstrapElasticsearch(options.BootstrapMethod);
 		}
 
 
 		public void Emit(LogEvent logEvent)
 		{
-			var ecsDoc = LogEventConverter.ConvertToEcs(logEvent, _formatterConfiguration);
+			var ecsDoc = LogEventConverter.ConvertToEcs<TEcsDocument>(logEvent, _formatterConfiguration);
 			_channel.TryWrite(ecsDoc);
 		}
+
 	}
 }

--- a/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSinkExtensions.cs
+++ b/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSinkExtensions.cs
@@ -7,11 +7,12 @@ namespace Elastic.CommonSchema.Serilog.Sink
 {
 	public static class ElasticsearchSinkExtensions
 	{
-		public static LoggerConfiguration Elasticsearch(
-			this LoggerSinkConfiguration loggerConfiguration,
-			ElasticsearchSchemaSinkOptions? options = null
-		) =>
+		public static LoggerConfiguration Elasticsearch(this LoggerSinkConfiguration loggerConfiguration, ElasticsearchSchemaSinkOptions? options = null) =>
 			loggerConfiguration.Sink(new ElasticsearchSink(options ?? new ElasticsearchSchemaSinkOptions()));
+
+		public static LoggerConfiguration Elasticsearch<TEcsDocument>(this LoggerSinkConfiguration loggerConfiguration, ElasticsearchSchemaSinkOptions<TEcsDocument>? options = null)
+			where TEcsDocument : EcsDocument, new() =>
+			loggerConfiguration.Sink(new ElasticsearchSink<TEcsDocument>(options ?? new ElasticsearchSchemaSinkOptions<TEcsDocument>()));
 
 		public static LoggerConfiguration Elasticsearch(
 			this LoggerSinkConfiguration loggerConfiguration,
@@ -26,6 +27,19 @@ namespace Elastic.CommonSchema.Serilog.Sink
 			return loggerConfiguration.Sink(new ElasticsearchSink(sinkOptions));
 		}
 
+		public static LoggerConfiguration Elasticsearch<TEcsDocument>(
+			this LoggerSinkConfiguration loggerConfiguration,
+			ICollection<Uri> nodes,
+			Action<ElasticsearchSchemaSinkOptions<TEcsDocument>>? configureOptions = null,
+			bool useSniffing = true
+		) where TEcsDocument : EcsDocument, new()
+		{
+			var sinkOptions = new ElasticsearchSchemaSinkOptions<TEcsDocument>(useSniffing ? TransportHelper.Static(nodes) : TransportHelper.Sniffing(nodes));
+			configureOptions?.Invoke(sinkOptions);
+
+			return loggerConfiguration.Sink(new ElasticsearchSink<TEcsDocument>(sinkOptions));
+		}
+
 		public static LoggerConfiguration ElasticCloud(
 			this LoggerSinkConfiguration loggerConfiguration,
 			string endpoint,
@@ -37,6 +51,18 @@ namespace Elastic.CommonSchema.Serilog.Sink
 			configureOptions?.Invoke(sinkOptions);
 
 			return loggerConfiguration.Sink(new ElasticsearchSink(sinkOptions));
+		}
+		public static LoggerConfiguration ElasticCloud<TEcsDocument>(
+			this LoggerSinkConfiguration loggerConfiguration,
+			string endpoint,
+			string apiKey,
+			Action<ElasticsearchSchemaSinkOptions<TEcsDocument>>? configureOptions = null
+		) where TEcsDocument : EcsDocument, new()
+		{
+			var sinkOptions = new ElasticsearchSchemaSinkOptions<TEcsDocument>(TransportHelper.Cloud(endpoint, apiKey));
+			configureOptions?.Invoke(sinkOptions);
+
+			return loggerConfiguration.Sink(new ElasticsearchSink<TEcsDocument>(sinkOptions));
 		}
 
 		public static LoggerConfiguration ElasticCloud(
@@ -51,6 +77,20 @@ namespace Elastic.CommonSchema.Serilog.Sink
 			configureOptions?.Invoke(sinkOptions);
 
 			return loggerConfiguration.Sink(new ElasticsearchSink(sinkOptions));
+		}
+
+		public static LoggerConfiguration ElasticCloud<TEcsDocument>(
+			this LoggerSinkConfiguration loggerConfiguration,
+			string endpoint,
+			string username,
+			string password,
+			Action<ElasticsearchSchemaSinkOptions<TEcsDocument>>? configureOptions = null
+		) where TEcsDocument : EcsDocument, new()
+		{
+			var sinkOptions = new ElasticsearchSchemaSinkOptions<TEcsDocument>(TransportHelper.Cloud(endpoint, username, password));
+			configureOptions?.Invoke(sinkOptions);
+
+			return loggerConfiguration.Sink(new ElasticsearchSink<TEcsDocument>(sinkOptions));
 		}
 	}
 }


### PR DESCRIPTION
This allows you to use the Serilog Sink with your own EcsDocument
subclasses
