### PR TITLE
Fix #182 Ensure EcsDocumentJsonConverter reads to completion

### DIFF
--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
@@ -24,10 +24,15 @@ namespace Elastic.CommonSchema.Serialization
 			string loglevel = null;
 			string ecsVersion = null;
 			DateTimeOffset? timestamp = default;
+			var originalDepth = reader.CurrentDepth;
 			while (reader.Read())
 			{
 				if (reader.TokenType == JsonTokenType.EndObject)
-					break;
+				{
+					if (reader.CurrentDepth <= originalDepth)
+						break;
+					continue;
+				}
 
 				if (reader.TokenType != JsonTokenType.PropertyName)
 					throw new JsonException();

--- a/tests/Elastic.CommonSchema.Tests/Deserializes.cs
+++ b/tests/Elastic.CommonSchema.Tests/Deserializes.cs
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Elastic.CommonSchema.Serialization;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.CommonSchema.Tests
+{
+	public class Deserializes
+	{
+
+		[Fact]
+		public void DeserializeEmptyObject()
+		{
+			var serialized = @$"{{}}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializeNullTimestamp()
+		{
+			var serialized = @$"{{ ""timestamp"": null }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializesNullAgent()
+		{
+			var serialized = @$"{{ ""agent"": null }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializesAgentWithUnknownKeys()
+		{
+			var serialized = @$"{{ ""agent"": {{ ""unknown"": ""value"" }} }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+			deserialized.Agent.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializesAgentWithUnknownArray()
+		{
+			var serialized = @$"{{ ""agent"": {{ ""unknown"": [""value""] }} }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+			deserialized.Agent.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializesWithUnknownKeys()
+		{
+			var serialized = @$"{{ ""unknown"": ""value"" }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializesWithUnknownObject()
+		{
+			var serialized = @$"{{ ""unknown"": {{ ""prop"": ""value"" }} }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializesWithUnknownObjectBeforeAgent()
+		{
+			var serialized = @$"{{ ""unknown"": {{ ""prop"": ""value"" }}, ""agent"" : {{}} }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+			deserialized.Agent.Should().NotBeNull();
+		}
+
+		[Fact]
+		public void DeserializesWithUnknownObjectAfterAgent()
+		{
+			var serialized = @$"{{ ""agent"" : {{}}, ""unknown"": {{ ""prop"": ""value"" }} }}";
+			var deserialized = EcsDocument.Deserialize(serialized);
+			deserialized.Should().NotBeNull();
+			deserialized.Agent.Should().NotBeNull();
+		}
+	}
+}


### PR DESCRIPTION
Similar fix as #187 but with failing (now fixed) unit tests
