### PR TITLE
fix/terser ci test logging

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -18,5 +18,6 @@ jobs:
           name: Test Summary            # Name of the check run which will be created
           path: "junit-*.xml"           # Path to test results (inside artifact .zip)
           reporter: java-junit          # Format of test results
-          list-suites: only-failed
-          list-tests: only-failed
+          # https://github.com/elastic/apm-pipeline-library/issues/2063
+          #list-suites: 'only-failed'
+          #list-tests: 'only-failed'

--- a/build/scripts/Program.fs
+++ b/build/scripts/Program.fs
@@ -1,32 +1,45 @@
 ﻿module Program
 
+open System
 open Argu
 open Bullseye
 open ProcNet
 open CommandLine
-    
+
 [<EntryPoint>]
 let main argv =
     let parser = ArgumentParser.Create<Arguments>(programName = "./build.sh")
-    let parsed = 
+
+    let parsed =
         try
             let parsed = parser.ParseCommandLine(inputs = argv, raiseOnUsage = true)
             let arguments = parsed.GetSubCommand()
-            Some (parsed, arguments)
+            Some(parsed, arguments)
         with e ->
             printfn "%s" e.Message
             None
-    
+
     match parsed with
     | None -> 2
     | Some (parsed, arguments) ->
-        
+
         let target = arguments.Name
-        
+
         Targets.Setup parsed arguments
-        let swallowTypes = [typeof<ProcExecException>; typeof<ExceptionExiter>]
-        
-        Targets.RunTargetsAndExit
-            ([target], (fun e -> swallowTypes |> List.contains (e.GetType()) ), ":")
-        0
-        
+        let swallowTypes = [ typeof<ProcExecException>; typeof<ExceptionExiter> ]
+
+        // temp fix for unit reporting: https://github.com/elastic/apm-pipeline-library/issues/2063
+        let exitCode =
+            try
+                try
+                    Targets.RunTargetsWithoutExiting([ target ], (fun e -> swallowTypes |> List.contains (e.GetType())), ":")
+                    0
+                with
+                | :? InvalidUsageException as ex ->
+                    Console.WriteLine ex.Message
+                    2
+                | :? TargetFailedException as ex -> 1
+            finally
+                Targets.teardown()
+
+        exitCode

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -242,15 +242,15 @@ let private publish (arguments: ParseResults<Arguments>) = printfn "publish"
 
 // temp fix for unit reporting: https://github.com/elastic/apm-pipeline-library/issues/2063
 let teardown () =
-    let isSkippedFile p =
-        File.ReadLines(p).FirstOrDefault() = "<testsuites />"
-    let junitFiles =
+    if Paths.Output.Exists then
+        let isSkippedFile p =
+            File.ReadLines(p).FirstOrDefault() = "<testsuites />"
         Paths.Output.GetFiles("junit-*.xml")
-        |> Seq.filter (fun p -> isSkippedFile p.FullName)
-        |> Seq.iter (fun f ->
-            printfn $"Removing empty test file: %s{f.FullName}"
-            f.Delete()
-        )
+            |> Seq.filter (fun p -> isSkippedFile p.FullName)
+            |> Seq.iter (fun f ->
+                printfn $"Removing empty test file: %s{f.FullName}"
+                f.Delete()
+            )
     Console.WriteLine "Ran teardown"
 
 let Setup (parsed: ParseResults<Arguments>) (subCommand: Arguments) =


### PR DESCRIPTION
- Only log failed request, this makes the junit xml much more readable
- manually cleanup skipped testfiles
