### PR TITLE
Fix #55 Centralize EcsDocument creation with defaults

### DIFF
--- a/src/Elastic.CommonSchema.Log4net/LoggingEventConverter.cs
+++ b/src/Elastic.CommonSchema.Log4net/LoggingEventConverter.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Diagnostics;
-using System.IO;
 using log4net.Core;
 using log4net.Util;
 
@@ -12,26 +10,28 @@ namespace Elastic.CommonSchema.Log4net;
 
 internal static class LoggingEventConverter
 {
-	public static EcsDocument ToEcs(this LoggingEvent loggingEvent)
+	private static Agent DefaultAgent { get; } = EcsDocument.CreateAgent(typeof(LoggingEventConverter));
+
+	public static EcsDocument ToEcs(this LoggingEvent logEvent)
 	{
-		var ecsDocument = new EcsDocument()
+		var ecsEvent = EcsDocument.CreateNewWithDefaults<EcsDocument>(logEvent.TimeStamp, logEvent.ExceptionObject);
+		ecsEvent.Agent = DefaultAgent;
+		// Prefer logging provided name
+		var hostName = logEvent.LookupProperty(LoggingEvent.HostNameProperty);
+		if (hostName != null)
 		{
-			Timestamp = loggingEvent.TimeStamp,
-			Ecs = new Ecs { Version = EcsDocument.Version },
-			Message = loggingEvent.RenderedMessage,
-			Log = GetLog(loggingEvent),
-			Event = GetEvent(loggingEvent),
-			Error = GetError(loggingEvent),
-			Process = GetProcess(loggingEvent),
-			Host = GetHost(loggingEvent),
-		};
-		ecsDocument.SetActivityData();
-		var metadata = GetMetadata(loggingEvent);
-		if (metadata == null) return ecsDocument;
+			ecsEvent.Host ??= new Host();
+			ecsEvent.Host.Name = hostName.ToString();
+		}
+		ecsEvent.Message = logEvent.RenderedMessage;
+		ecsEvent.Log = GetLog(logEvent);
+		ecsEvent.Event = GetEvent(logEvent);
+		var metadata = GetMetadata(logEvent);
+		if (metadata == null) return ecsEvent;
 
 		foreach(var kv in metadata)
-			ecsDocument.AssignField(kv.Key, kv.Value);
-		return ecsDocument;
+			ecsEvent.AssignField(kv.Key, kv.Value);
+		return ecsEvent;
 	}
 
 	private static Log GetLog(LoggingEvent loggingEvent)
@@ -44,13 +44,9 @@ internal static class LoggingEventConverter
 		};
 
 		if (!string.IsNullOrEmpty(loggingEvent.LocationInformation.FileName))
-		{
 			log.OriginFileName = loggingEvent.LocationInformation.FileName;
-		}
 		if (int.TryParse(loggingEvent.LocationInformation.LineNumber, out var ln) && ln > 0)
-		{
 			log.OriginFileLine = ln;
-		}
 
 		return log;
 	}
@@ -61,82 +57,6 @@ internal static class LoggingEventConverter
 			Created = loggingEvent.TimeStamp,
 			Timezone = TimeZoneInfo.Local.StandardName
 		};
-
-	private static Error GetError(LoggingEvent loggingEvent)
-	{
-		var exception = loggingEvent.ExceptionObject;
-		if (exception == null)
-		{
-			return null;
-		}
-
-		return new Error
-		{
-			Message = exception.Message,
-			Type = exception.GetType().FullName,
-			StackTrace = GetStackTrace(exception)
-		};
-	}
-
-	private static string GetStackTrace(Exception exception)
-	{
-		var i = 1;
-		var fullText = new StringWriter();
-		var frame = new StackTrace(exception, true).GetFrame(0);
-
-		fullText.WriteLine($"Exception {i++:D2} ===================================");
-		fullText.WriteLine($"Type: {exception.GetType()}");
-		fullText.WriteLine($"Source: {exception.TargetSite?.DeclaringType?.AssemblyQualifiedName}");
-		fullText.WriteLine($"Message: {exception.Message}");
-		fullText.WriteLine($"Trace: {exception.StackTrace}");
-		if (frame != null)
-		{
-			fullText.WriteLine($"Location: {frame.GetFileName()}");
-			fullText.WriteLine($"Method: {frame.GetMethod()} ({frame.GetFileLineNumber()}, {frame.GetFileColumnNumber()})");
-		}
-
-		var innerException = exception.InnerException;
-		while (innerException != null)
-		{
-			frame = new StackTrace(innerException, true).GetFrame(0);
-			fullText.WriteLine($"\tException {i++:D2} inner --------------------------");
-			fullText.WriteLine($"\tType: {innerException.GetType()}");
-			fullText.WriteLine($"\tSource: {innerException.TargetSite?.DeclaringType?.AssemblyQualifiedName}");
-			fullText.WriteLine($"\tMessage: {innerException.Message}");
-			fullText.WriteLine($"\tTrace: {innerException.StackTrace}");
-			if (frame != null)
-			{
-				fullText.WriteLine($"\tLocation: {frame.GetFileName()}");
-				fullText.WriteLine($"\tMethod: {frame.GetMethod()} ({frame.GetFileLineNumber()}, {frame.GetFileColumnNumber()})");
-			}
-
-			innerException = innerException.InnerException;
-		}
-
-		return fullText.ToString();
-	}
-
-	private static Process GetProcess(LoggingEvent loggingEvent)
-	{
-		var threadName = loggingEvent.ThreadName;
-		if (string.IsNullOrEmpty(threadName))
-		{
-			return null;
-		}
-
-		var isNumericThreadName = int.TryParse(threadName, out var id);
-		return new Process
-		{
-			ThreadId = isNumericThreadName ? id : null,
-			ThreadName = !isNumericThreadName ? threadName : null
-		};
-	}
-
-	private static Host GetHost(LoggingEvent loggingEvent)
-	{
-		var hostName = loggingEvent.LookupProperty(LoggingEvent.HostNameProperty);
-		return hostName != null ? new Host { Hostname = hostName.ToString() } : null;
-	}
 
 	private static MetadataDictionary GetMetadata(LoggingEvent loggingEvent)
 	{
@@ -163,27 +83,19 @@ internal static class LoggingEventConverter
 			// - if stack contains one item log4net anyway supports only string values
 			// - if stack contains several items then we need all of them
 			if (value is ThreadContextStack tcs)
-			{
 				value = tcs.ToString();
-			}
 			else if (value is LogicalThreadContextStack ltcs)
-			{
 				value = ltcs.ToString();
-			}
 
 			if (value != null)
-			{
 				metadata[property] = value;
-			}
 		}
 
 		if (loggingEvent.MessageObject is SystemStringFormat format)
 		{
 			metadata["MessageTemplate"] = format.Format;
 			for (var i = 0; i < format.Args.Length; i++)
-			{
 				metadata[i.ToString()] = format.Args[0];
-			}
 		}
 
 		return metadata.Count > 0 ? metadata : null;

--- a/src/Elastic.CommonSchema.Serilog/EcsTextFormatterConfiguration.cs
+++ b/src/Elastic.CommonSchema.Serilog/EcsTextFormatterConfiguration.cs
@@ -15,11 +15,8 @@ using Serilog.Events;
 namespace Elastic.CommonSchema.Serilog
 {
 	/// <summary> Provides configuration options for <see cref="EcsTextFormatter"/> </summary>
-	public interface IEcsTextFormatterConfiguration
+	public interface IEcsTextFormatterConfiguration : IEcsDocumentCreationOptions
 	{
-		/// <summary>Defaults to true, attempts to get the current <see cref="System.Diagnostics.Process" /> and thread id. </summary>
-		bool MapCurrentThread { get; set; }
-
 		/// <summary>
 		/// Expert option, its recommended to use <see cref="EnricherExtensions.WithEcsHttpContext"/> to ensure HttpContext gets mapped
 		/// to the appropriate ECS fields.
@@ -56,8 +53,15 @@ namespace Elastic.CommonSchema.Serilog
 	public class EcsTextFormatterConfiguration<TEcsDocument> : IEcsTextFormatterConfiguration<TEcsDocument>
 		where TEcsDocument : EcsDocument, new()
 	{
-		/// <inheritdoc cref="IEcsTextFormatterConfiguration.MapCurrentThread"/>
-		public bool MapCurrentThread { get; set; } = true;
+		/// <inheritdoc cref="IEcsDocumentCreationOptions.IncludeHost"/>
+		public bool IncludeHost { get; set; } = true;
+
+		/// <inheritdoc cref="IEcsDocumentCreationOptions.IncludeProcess"/>
+		public bool IncludeProcess { get; set; } = true;
+
+		/// <inheritdoc cref="IEcsDocumentCreationOptions.IncludeUser"/>
+		public bool IncludeUser { get; set; } = true;
+
 		/// <inheritdoc cref="IEcsTextFormatterConfiguration.MapHttpAdapter"/>
 		public IHttpAdapter MapHttpAdapter { get; set; }
 		/// <inheritdoc cref="IEcsTextFormatterConfiguration.LogEventPropertiesToFilter"/>

--- a/src/Elastic.CommonSchema.Serilog/Http/IHttpAdapter.cs
+++ b/src/Elastic.CommonSchema.Serilog/Http/IHttpAdapter.cs
@@ -10,7 +10,6 @@ namespace Elastic.CommonSchema.Serilog
 	public interface IHttpAdapter
 	{
 		Client Client { get; }
-		IEnumerable<Exception> Exceptions { get; }
 		Http Http { get; }
 		Server Server { get; }
 		Url Url { get; }

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -3,12 +3,8 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using Serilog.Events;
 
 namespace Elastic.CommonSchema.Serilog
@@ -18,54 +14,56 @@ namespace Elastic.CommonSchema.Serilog
 	/// </summary>
 	public static class LogEventConverter
 	{
+		private static Agent DefaultAgent { get; } = EcsDocument.CreateAgent(typeof(LogEventConverter));
 
 		public static TEcsDocument ConvertToEcs<TEcsDocument>(LogEvent logEvent, IEcsTextFormatterConfiguration<TEcsDocument> configuration)
 			where TEcsDocument : EcsDocument, new()
 		{
-			var exceptions = logEvent.Exception != null
-				? new List<Exception> { logEvent.Exception }
-				: new List<Exception>();
+			var ecsEvent = EcsDocument.CreateNewWithDefaults<TEcsDocument>(logEvent.Timestamp, logEvent.Exception, configuration);
 
-			if (configuration.MapHttpAdapter != null)
-				exceptions.AddRange(configuration.MapHttpAdapter.Exceptions);
-
-			var ecsEvent = new TEcsDocument
+			if (logEvent.TryGetScalarPropertyValue(SpecialKeys.MachineName, out var machineName))
 			{
-				Timestamp = logEvent.Timestamp,
-				Message = logEvent.RenderMessage(),
-				Ecs = new Ecs { Version = EcsDocument.Version },
-				Log = GetLog(logEvent, exceptions, configuration),
-				Service = GetService(logEvent),
-				Agent = GetAgent(logEvent),
-				Event = GetEvent(logEvent),
-				Process = GetProcess(logEvent, configuration.MapCurrentThread),
-				Host = GetHost(logEvent),
-				TraceId = GetTrace(logEvent),
-				TransactionId = GetTransaction(logEvent),
-				SpanId = GetSpan(logEvent),
-				Server = GetServer(logEvent, configuration),
-				Http = GetHttp(logEvent, configuration),
-				Url = GetUrl(logEvent, configuration),
-				UserAgent = GetUserAgent(logEvent, configuration),
-				Client = GetClient(logEvent, configuration),
-				User = GetUser(logEvent, configuration)
-			};
-			ecsEvent.SetActivityData();
+				ecsEvent.Host ??= new Host();
+				ecsEvent.Host.Name = machineName.Value.ToString();
+			}
+
+			// if we don't want to lookup up process through System.Diagnostics still include whatever information we get from
+			// serilog
+			if (!configuration.IncludeProcess)
+				ecsEvent.Process = GetProcessFromProperties(logEvent);
+
+			// prefer tracing information set by Elastic APM
+			if (TryGetTrace(logEvent, out var traceId)) ecsEvent.TraceId = traceId;
+			if (TryGetTransaction(logEvent, out var transactionId)) ecsEvent.TransactionId = transactionId;
+			if (TryGetSpan(logEvent, out var spanId)) ecsEvent.SpanId = spanId;
+
+			// prefer service information set by Elastic APM
+			var service = GetService(logEvent);
+			if (service != null) ecsEvent.Service = service;
+
+			// prefer our own user information, especially in web contexts this is richer
+			var user = GetUser(logEvent, configuration);
+			if (user != null) ecsEvent.User = user;
+
+			ecsEvent.Message = logEvent.RenderMessage();
+			ecsEvent.Log = GetLog(logEvent);
+			ecsEvent.Agent = GetAgent(logEvent) ?? DefaultAgent;
+			ecsEvent.Event = GetEvent(logEvent);
+			ecsEvent.Server = GetServer(logEvent, configuration);
+			ecsEvent.Http = GetHttp(logEvent, configuration);
+			ecsEvent.Url = GetUrl(logEvent, configuration);
+			ecsEvent.UserAgent = GetUserAgent(logEvent, configuration);
+			ecsEvent.Client = GetClient(logEvent, configuration);
 
 			var metaData = GetMetadata(logEvent, configuration.LogEventPropertiesToFilter);
 			foreach (var kv in metaData)
 				ecsEvent.AssignField(kv.Key, kv.Value);
-
-			ecsEvent.Error = GetError(exceptions);
 
 			if (configuration.MapCustom != null)
 				ecsEvent = configuration.MapCustom(ecsEvent, logEvent);
 
 			return ecsEvent;
 		}
-
-		public static EcsDocument ConvertToEcs(LogEvent logEvent, IEcsTextFormatterConfiguration<EcsDocument> configuration) =>
-			ConvertToEcs<EcsDocument>(logEvent, configuration);
 
 		private static Service GetService(LogEvent logEvent)
 		{
@@ -76,30 +74,31 @@ namespace Elastic.CommonSchema.Serilog
 			{
 				Name = serviceName.Value.ToString(),
 				Version = logEvent.TryGetScalarPropertyValue("ElasticApmServiceVersion", out var version) ? version.Value.ToString() : null,
-				NodeName = logEvent.TryGetScalarPropertyValue("ElasticApmServiceNodeName", out var name) ? name.Value.ToString() : null,
+				NodeName = logEvent.TryGetScalarPropertyValue("ElasticApmServiceNodeName", out var name) ? name.Value.ToString() : null
 			};
 		}
 
-		private static string GetTrace(LogEvent logEvent) => !logEvent.TryGetScalarPropertyValue("ElasticApmTraceId", out var traceId)
-			? null
-			: traceId.Value.ToString();
+		private static bool TryGetTrace(LogEvent logEvent, out string traceId)
+		{
+			traceId = logEvent.TryGetScalarPropertyValue("ElasticApmTraceId", out var prop) ? prop.Value.ToString() : null;
+			return !string.IsNullOrWhiteSpace(traceId);
+		}
 
-		private static string GetTransaction(LogEvent logEvent) =>
-			!logEvent.TryGetScalarPropertyValue("ElasticApmTransactionId", out var transactionId)
-				? null
-				: transactionId.Value.ToString();
+		private static bool TryGetTransaction(LogEvent logEvent, out string transactionId)
+		{
+			transactionId = logEvent.TryGetScalarPropertyValue("ElasticApmTransactionId", out var prop) ? prop.Value.ToString() : null;
+			return !string.IsNullOrWhiteSpace(transactionId);
+		}
 
-		private static string GetSpan(LogEvent logEvent) =>
-			!logEvent.TryGetScalarPropertyValue("ElasticApmSpanId", out var spanId)
-				? null
-				: spanId.Value.ToString();
+		private static bool TryGetSpan(LogEvent logEvent, out string spanId)
+		{
+			spanId = logEvent.TryGetScalarPropertyValue("ElasticApmSpanId", out var prop) ? prop.Value.ToString() : null;
+			return !string.IsNullOrWhiteSpace(spanId);
+		}
 
 		private static MetadataDictionary GetMetadata(LogEvent logEvent, ISet<string> logEventPropertiesToFilter)
 		{
-			var dict = new MetadataDictionary
-			{
-				{ "MessageTemplate", logEvent.MessageTemplate.Text }
-			};
+			var dict = new MetadataDictionary { { "MessageTemplate", logEvent.MessageTemplate.Text } };
 
 			//TODO what does this do and where does it come from?
 			if (logEvent.Properties.TryGetValue("ActionPayload", out var actionPayload))
@@ -175,13 +174,15 @@ namespace Elastic.CommonSchema.Serilog
 
 		private static object PropertyValueToObject(LogEventPropertyValue propertyValue)
 		{
-			switch (propertyValue) {
+			switch (propertyValue)
+			{
 				case SequenceValue values:
 					return values.Elements.Select(PropertyValueToObject).ToArray();
 				case ScalarValue sv:
 					return sv.Value;
 				case DictionaryValue dv:
-					return dv.Elements.ToDictionary(keySelector: kvp => kvp.Key.Value.ToString(), elementSelector: (kvp) => PropertyValueToObject(kvp.Value));
+					return dv.Elements.ToDictionary(keySelector: kvp => kvp.Key.Value.ToString(),
+						elementSelector: (kvp) => PropertyValueToObject(kvp.Value));
 				case StructureValue ov:
 				{
 					var dict = ov.Properties.ToDictionary(p => p.Name, p => PropertyValueToObject(p.Value));
@@ -191,20 +192,6 @@ namespace Elastic.CommonSchema.Serilog
 				default:
 					return propertyValue;
 			}
-		}
-
-		private static Host GetHost(LogEvent e)
-		{
-			if (!e.TryGetScalarPropertyValue(SpecialKeys.MachineName, out var machineName))
-				return null;
-
-			var host = new Host
-			{
-				Name = machineName.Value.ToString()
-			};
-
-			//todo map more uptime etc
-			return host;
 		}
 
 		private static Server GetServer(LogEvent e, IEcsTextFormatterConfiguration configuration)
@@ -225,15 +212,12 @@ namespace Elastic.CommonSchema.Serilog
 			return server;
 		}
 
-		private static Process GetProcess(LogEvent e, bool mapFromCurrentThread)
+		private static Process GetProcessFromProperties(LogEvent e)
 		{
 			e.TryGetScalarPropertyValue(SpecialKeys.ProcessName, out var processNameProp);
 			e.TryGetScalarPropertyValue(SpecialKeys.ProcessId, out var processIdProp);
 			e.TryGetScalarPropertyValue(SpecialKeys.ThreadId, out var threadIdProp);
-			if (processNameProp == null
-			    && processIdProp == null
-			    && threadIdProp == null
-			    && !mapFromCurrentThread)
+			if (processNameProp == null && processIdProp == null && threadIdProp == null)
 				return null;
 
 			var processName = processNameProp?.Value.ToString();
@@ -242,76 +226,16 @@ namespace Elastic.CommonSchema.Serilog
 			var pid = int.TryParse(processId ?? "", out var p)
 				? p
 				: (int?)null;
-
-			if (!mapFromCurrentThread)
-			{
-				return new Process
-				{
-					Title = string.IsNullOrEmpty(processName) ? null : processName,
-					Name = processName,
-					Pid = pid,
-					ThreadId = int.TryParse(threadId ?? processId, out var id) ? id : null,
-				};
-			}
-
-			if (pid == null)
-				return CurrentProcess ??= ToEcsProcess(null, processName);
-
-			if (ProcessLookup.TryGetValue(pid.Value, out var cachedProcess))
-				return cachedProcess;
-
-			var process = ToEcsProcess(pid, processName);
-			if (!ProcessLookup.TryAdd(pid.Value, process)) return process;
-
-			// simplistic fixed memory cache
-			// if we spot that we are caching more then 10k process id's assume something is wrong
-			// and purge cache
-			var count = Interlocked.Increment(ref LookupCount);
-			if (count <= 10_000) return process;
-
-			ProcessLookup.Clear();
-			// This could reset a previous increment from possible other threads adding.
-			// The count being approximately 10k is good enough
-			Interlocked.Exchange(ref LookupCount, 0);
-			return process;
-		}
-
-		private static Process CurrentProcess = null;
-		private static readonly ConcurrentDictionary<int, Process> ProcessLookup = new();
-		private static int LookupCount = 0;
-
-		private static Process ToEcsProcess(int? pid, string processName)
-		{
-			var process = TryGetProcess(pid);
-
-			var mainWindowTitle = process?.MainWindowTitle;
-			var currentThread = Thread.CurrentThread;
 			return new Process
 			{
-				Title = string.IsNullOrEmpty(mainWindowTitle) ? null : mainWindowTitle,
-				Name = process?.ProcessName ?? processName,
-				Pid = process?.Id ?? pid,
-				Executable = process?.ProcessName ?? processName,
-				ThreadId = currentThread.ManagedThreadId
+				Title = string.IsNullOrEmpty(processName) ? null : processName,
+				Name = processName,
+				Pid = pid,
+				ThreadId = int.TryParse(threadId ?? processId, out var id) ? id : null,
 			};
 		}
 
-		private static System.Diagnostics.Process TryGetProcess(int? processId)
-		{
-			try
-			{
-				var pid = processId != null
-					? System.Diagnostics.Process.GetProcessById(processId.Value)
-					: System.Diagnostics.Process.GetCurrentProcess();
-				return pid;
-			}
-			catch (Exception)
-			{
-				return null;
-			}
-		}
-
-		private static Log GetLog(LogEvent e, IReadOnlyList<Exception> exceptions, IEcsTextFormatterConfiguration configuration)
+		private static Log GetLog(LogEvent e)
 		{
 			var source = e.TryGetScalarPropertyValue(SpecialKeys.SourceContext, out var context)
 				? context.Value.ToString()
@@ -319,30 +243,22 @@ namespace Elastic.CommonSchema.Serilog
 
 			var log = new Log { Level = e.Level.ToString("F"), Logger = source };
 
-			if (exceptions.Count > 0)
-			{
-				// TODO - walk stack trace for other information
-			}
-
 			return log;
 		}
-
-		private static Error GetError(IReadOnlyList<Exception> exceptions) =>
-			exceptions != null && exceptions.Count > 0
-				? new Error { Message = exceptions[0].Message, StackTrace = CatchErrors(exceptions), Type = exceptions[0].GetType().ToString() }
-				: null;
 
 		private static Event GetEvent(LogEvent e)
 		{
 			var elapsedMs = e.TryGetScalarPropertyValue(SpecialKeys.Elapsed, out var elapsed)
 				? elapsed.Value
-				: e.TryGetScalarPropertyValue(SpecialKeys.ElapsedMilliseconds, out elapsed) ? elapsed.Value : null;
+				: e.TryGetScalarPropertyValue(SpecialKeys.ElapsedMilliseconds, out elapsed)
+					? elapsed.Value
+					: null;
 
 			var evnt = new Event
 			{
 				Created = e.Timestamp,
 				Category = e.TryGetScalarPropertyValue(SpecialKeys.ActionCategory, out var actionCategoryProperty)
-					? new [] { actionCategoryProperty.Value.ToString() }
+					? new[] { actionCategoryProperty.Value.ToString() }
 					: null,
 				Action = e.TryGetScalarPropertyValue(SpecialKeys.ActionName, out var action)
 					? action.Value.ToString()
@@ -380,54 +296,11 @@ namespace Elastic.CommonSchema.Serilog
 			return agent;
 		}
 
-		private static string CatchErrors(IReadOnlyCollection<Exception> errors)
-		{
-			if (errors == null || errors.Count <= 0)
-				return string.Empty;
-
-			var i = 1;
-			var fullText = new StringWriter();
-			foreach (var error in errors)
-			{
-				var frame = new StackTrace(error, true).GetFrame(0);
-
-				fullText.WriteLine($"Exception {i++:D2} ===================================");
-				fullText.WriteLine($"Type: {error.GetType()}");
-				fullText.WriteLine($"Source: {error.TargetSite?.DeclaringType?.AssemblyQualifiedName}");
-				fullText.WriteLine($"Message: {error.Message}");
-				fullText.WriteLine($"Trace: {error.StackTrace}");
-				if (frame != null)
-				{
-					fullText.WriteLine($"Location: {frame.GetFileName()}");
-					fullText.WriteLine($"Method: {frame.GetMethod()} ({frame.GetFileLineNumber()}, {frame.GetFileColumnNumber()})");
-				}
-
-				var exception = error.InnerException;
-				while (exception != null)
-				{
-					frame = new StackTrace(exception, true).GetFrame(0);
-					fullText.WriteLine($"\tException {i++:D2} inner --------------------------");
-					fullText.WriteLine($"\tType: {exception.GetType()}");
-					fullText.WriteLine($"\tSource: {exception.TargetSite?.DeclaringType?.AssemblyQualifiedName}");
-					fullText.WriteLine($"\tMessage: {exception.Message}");
-					fullText.WriteLine($"\tTrace: {exception.StackTrace}");
-					if (frame != null)
-					{
-						fullText.WriteLine($"\tLocation: {frame.GetFileName()}");
-						fullText.WriteLine($"\tMethod: {frame.GetMethod()} ({frame.GetFileLineNumber()}, {frame.GetFileColumnNumber()})");
-					}
-
-					exception = exception.InnerException;
-				}
-			}
-
-			return fullText.ToString();
-		}
 
 		private static Http GetHttp(LogEvent e, IEcsTextFormatterConfiguration configuration)
 		{
 			if (e.TryGetScalarPropertyValue(SpecialKeys.HttpContext, out var httpContext)
-				&& httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
+			    && httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
 				return enriched.Http;
 
 			var http = configuration.MapHttpAdapter?.Http;
@@ -461,7 +334,7 @@ namespace Elastic.CommonSchema.Serilog
 		private static Url GetUrl(LogEvent e, IEcsTextFormatterConfiguration configuration)
 		{
 			if (e.TryGetScalarPropertyValue(SpecialKeys.HttpContext, out var httpContext)
-				&& httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
+			    && httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
 				return enriched.Url;
 
 			var url = configuration.MapHttpAdapter?.Url;
@@ -491,25 +364,27 @@ namespace Elastic.CommonSchema.Serilog
 		private static UserAgent GetUserAgent(LogEvent e, IEcsTextFormatterConfiguration configuration)
 		{
 			if (e.TryGetScalarPropertyValue(SpecialKeys.HttpContext, out var httpContext)
-				&& httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
+			    && httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
 				return enriched.UserAgent;
+
 			return configuration.MapHttpAdapter?.UserAgent;
 		}
 
 		private static User GetUser(LogEvent e, IEcsTextFormatterConfiguration configuration)
 		{
 			if (e.TryGetScalarPropertyValue(SpecialKeys.HttpContext, out var httpContext)
-				&& httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
+			    && httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
 				return enriched.User;
-			return configuration.MapHttpAdapter?.User;
 
+			return configuration.MapHttpAdapter?.User;
 		}
 
 		private static Client GetClient(LogEvent e, IEcsTextFormatterConfiguration configuration)
 		{
 			if (e.TryGetScalarPropertyValue(SpecialKeys.HttpContext, out var httpContext)
-				&& httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
+			    && httpContext?.Value is HttpContextEnricher.HttpContextEnrichments enriched)
 				return enriched.Client;
+
 			return configuration.MapHttpAdapter?.Client;
 		}
 	}

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -8,6 +8,7 @@
     <IsPackable>True</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>

--- a/src/Elasticsearch.Extensions.Logging/LogEventToEcsHelper.cs
+++ b/src/Elasticsearch.Extensions.Logging/LogEventToEcsHelper.cs
@@ -1,22 +1,9 @@
-using System;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
-using Elastic.CommonSchema;
 using Microsoft.Extensions.Logging;
 
 namespace Elasticsearch.Extensions.Logging
 {
 	internal static class LogEventToEcsHelper
 	{
-		private static Agent? _agent;
-		private static Ecs? _ecs;
-		private static Host? _host;
-		private static int _processId;
-		private static string? _processName;
-		private static Service? _service;
-
 		public static int GetSeverity(LogLevel logLevel) =>
 			logLevel switch
 			{
@@ -42,78 +29,6 @@ namespace Elasticsearch.Extensions.Logging
 				LogLevel.None => nameof(LogLevel.None),
 				_ => "Unknown"
 			};
-
-		public static Ecs GetEcs() => _ecs ??= new Ecs() { Version = EcsDocument.Version };
-
-		public static Agent GetAgent()
-		{
-			if (!(_agent is null)) return _agent;
-
-			var assembly = typeof(ElasticsearchLogger).Assembly;
-			var type = assembly.GetName().Name;
-			var versionAttribute = assembly.GetCustomAttributes(false)
-				.OfType<AssemblyInformationalVersionAttribute>()
-				.FirstOrDefault();
-			var version = versionAttribute?.InformationalVersion;
-			_agent = new Agent { Type = type, Version = version };
-
-			return _agent;
-		}
-
-		public static Host GetHost()
-		{
-			if (!(_host is null)) return _host;
-
-			_host = new Host
-			{
-				Hostname = Environment.MachineName,
-				Architecture = RuntimeInformation.OSArchitecture.ToString(),
-				Os = new Os
-				{
-					Full = RuntimeInformation.OSDescription,
-					Platform = Environment.OSVersion.Platform.ToString(),
-					Version = Environment.OSVersion.Version.ToString()
-				}
-			};
-
-			return _host;
-		}
-
-		public static Process GetProcess()
-		{
-			if (_processName is null)
-			{
-				using var process = System.Diagnostics.Process.GetCurrentProcess();
-				_processId = process.Id;
-				_processName = process.ProcessName;
-			}
-
-			var currentThread = Thread.CurrentThread;
-
-			return new Process
-			{
-				Name = _processName,
-				Pid = _processId,
-				ThreadName = currentThread.Name,
-				ThreadId = currentThread.ManagedThreadId
-			};
-		}
-
-		public static Service GetService()
-		{
-			if (!(_service is null)) return _service;
-
-			var entryAssembly = Assembly.GetEntryAssembly();
-			var entryAssemblyName = entryAssembly.GetName();
-			var type = entryAssemblyName.Name;
-			var versionAttribute = entryAssembly.GetCustomAttributes(false)
-				.OfType<AssemblyInformationalVersionAttribute>()
-				.FirstOrDefault();
-			var version = versionAttribute?.InformationalVersion ?? entryAssemblyName.Version.ToString();
-			_service = new Service { Type = type, Version = version };
-
-			return _service;
-		}
 
 	}
 }

--- a/src/Elasticsearch.Extensions.Logging/Options/ElasticsearchLoggerOptions.cs
+++ b/src/Elasticsearch.Extensions.Logging/Options/ElasticsearchLoggerOptions.cs
@@ -1,8 +1,9 @@
+using Elastic.CommonSchema;
 using Elastic.Ingest.Elasticsearch;
 
 namespace Elasticsearch.Extensions.Logging.Options
 {
-	public class ElasticsearchLoggerOptions
+	public class ElasticsearchLoggerOptions : IEcsDocumentCreationOptions
 	{
 		/// <summary>
 		/// Gets or sets a flag indicating whether host details should be included in the message. Defaults to <c>true</c>.
@@ -66,6 +67,6 @@ namespace Elasticsearch.Extensions.Logging.Options
 		/// Gets or sets additional tags to pass in the message, for example you can tag with the environment name ('Development',
 		/// 'Production', etc).
 		/// </summary>
-		public string[] Tags { get; set; } = new string[0];
+		public string[]? Tags { get; set; }
 	}
 }

--- a/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
@@ -128,10 +128,10 @@ namespace Elastic.CommonSchema.Log4net.Tests
 				info.Error.Type.Should().Be(e.GetType().FullName);
 
 				info.Error.StackTrace.Should().Contain(e.Message);
-				info.Error.StackTrace.Should().Contain(e.StackTrace);
+				info.Error.StackTrace.Should().Contain("at void");
 
 				info.Error.StackTrace.Should().Contain(innerException.Message);
-				info.Error.StackTrace.Should().Contain(innerException.StackTrace);
+				info.Error.StackTrace.Should().Contain("at void");
 			}
 		});
 


### PR DESCRIPTION
All integrations now create a new `EcsDocument` (or subclass) instance through:

```csharp
var ecs = EcsDocument.CreateNewWithDefaults<EcsDocument>(log.TimeStamp, log.Exception);
```


This ensures a default common minimum is achieved across all logging integrations:

- `ecs.version` is set and cached.
- tracing information is applied if available on `Activity.Current` this also addresses:
	- #152 
	- #169 
	- #210
- `process.*` is set and cached
- `service.*` is set and cached
- `user.*` is set
- A helper also is added to ensure `agent.*` is set using the same assembly version resolvment logic as `service.*`
- Exceptions are now all translated to `error.*` in the same way.