### PR TITLE
Release to github package repository as well

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -39,6 +39,7 @@ jobs:
 
     - name: publish canary packages github package repository
       shell: bash
+      timeout-minutes: 10
       run: |
         until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols; do echo "Retrying"; sleep 1; done;
 

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -37,6 +37,11 @@ jobs:
         dotnet-sdk-version: ${{ env.DOTNET_VERSION }}
         command: ./build.sh generateapichanges -s true
 
+    - name: publish canary packages github package repository
+      shell: bash
+      run: |
+        until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols; do echo "Retrying"; sleep 1; done;
+
     - name: Prepare feedz.io
       uses: hashicorp/vault-action@v2.4.2
       with:

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -37,12 +37,6 @@ jobs:
         dotnet-sdk-version: ${{ env.DOTNET_VERSION }}
         command: ./build.sh generateapichanges -s true
 
-    - name: publish canary packages github package repository
-      shell: bash
-      timeout-minutes: 10
-      run: |
-        until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols; do echo "Retrying"; sleep 1; done;
-
     - name: Prepare feedz.io
       uses: hashicorp/vault-action@v2.4.2
       with:
@@ -59,6 +53,13 @@ jobs:
       with:
         dotnet-sdk-version: ${{ env.DOTNET_VERSION }}
         command: .ci/deploy.sh ${REPO_API_KEY} ${REPO_API_URL}
+
+    - name: publish canary packages github package repository
+      shell: bash
+      timeout-minutes: 10
+      continue-on-error: true
+      run: |
+          until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols; do echo "Retrying"; sleep 1; done;
 
     - if: ${{ failure() }}
       uses: elastic/apm-pipeline-library/.github/actions/slack-message@current


### PR DESCRIPTION
Sadly GH package repos still does not support anonymous access so we can't replace feedz.io with it yet. Feedz.io has also served us amazingly well for a long time so not in any rush replacing it. 

This additional push does help advertise which nuget packages this repository builds e.g:

![image](https://user-images.githubusercontent.com/245275/222144160-96959237-8ba7-4331-a492-550931b6c837.png)

From https://github.com/elastic/elastic-ingest-dotnet which already pushes to GH package repository.
