### PR TITLE
action: update test-report and use failed types

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,12 +12,11 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/test-report@feature/update-test-reporter-action
+      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
           artifact: test-results        # artifact name
           name: Test Summary            # Name of the check run which will be created
           path: "junit-*.xml"           # Path to test results (inside artifact .zip)
           reporter: java-junit          # Format of test results
-          # https://github.com/elastic/apm-pipeline-library/issues/2063
-          #list-suites: 'only-failed'
-          #list-tests: 'only-failed'
+          list-suites: 'only-failed'
+          list-tests: 'only-failed'


### PR DESCRIPTION
### What

Use the `current` tag version for the composite actions defined in the `elastic/apm-pipeline-library`
Enable the `failed` values

### Issue

Requires https://github.com/elastic/apm-pipeline-library/pull/2106

Then let's wait for 