### PR TITLE
Cache UserName and Domain to improve performance when creating new EcsDocument

### DIFF
--- a/src/Elastic.CommonSchema/EcsDocument.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.cs
@@ -57,9 +57,7 @@ public partial class EcsDocument
 
 		if (options?.IncludeHost is null or true) doc.Host = GetHost();
 		if (options?.IncludeProcess is null or true) doc.Process = GetProcess();
-		// TODO I think we can cache user? does CurrentPrincipal on Thread ever change?
-		if (options?.IncludeUser is null or true)
-			doc.User = new User { Id = Thread.CurrentPrincipal?.Identity.Name, Name = Environment.UserName, Domain = Environment.UserDomainName };
+		if (options?.IncludeUser is null or true) doc.User = GetUser();
 
 		return doc;
 	}
@@ -156,6 +154,12 @@ public partial class EcsDocument
 			ThreadId = currentThread.ManagedThreadId
 		};
 	}
+
+	private static readonly string UserName = Environment.UserName;
+	private static readonly string UserDomainName = Environment.UserDomainName;
+
+	//Can not cache current thread's identity as it's used for role based security, different threads can have different identities
+	private static User GetUser() => new User { Id = Thread.CurrentPrincipal?.Identity.Name, Name = UserName, Domain = UserDomainName };
 
 	private static Error GetError(Exception exception)
 	{


### PR DESCRIPTION
The **EcsTextFormatter** performs really slowly with the File sink in Serilog.

On my lower-end virtual machine, I performed the test cases below: I initialized Serilog with a simple configuration to sink logs in a file with different formatters:

1. CompactJsonFormatter
2. EcsTextFormatter

The CompactJsonFormatter took an average of **0.45 seconds** to write 12,000 log messages, while the EcsTextFormatter took **5.5 seconds**.

Surprisingly, through profiling, I found that _Environment.UserName_ and _Environment.UserDomainName_ were the hottest path in execution.

So I **cached those variables in a static field** and performed the same case, which brought down the time to **1 second**.

Overall, there will be a significant improvement in throughput.