### PR TITLE
Update to latest Elastic.Ingest so we can more reliably log to selflog

### DIFF
--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporter.cs
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporter.cs
@@ -85,6 +85,8 @@ namespace Elastic.CommonSchema.BenchmarkDotNetExporter
 			};
 			Options.ChannelOptionsCallback?.Invoke(options);
 			var channel = new EcsDataStreamChannel<BenchmarkDocument>(options);
+			if (channel.DiagnosticsListener != null)
+				Options.ChannelDiagnosticsCallback?.Invoke(channel.DiagnosticsListener);
 			if (!channel.BootstrapElasticsearch(Options.BootstrapMethod)) return;
 
 			var benchmarks = CreateBenchmarkDocuments(summary);

--- a/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporterOptions.cs
+++ b/src/Elastic.CommonSchema.BenchmarkDotNetExporter/ElasticsearchBenchmarkExporterOptions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using Elastic.Channels.Diagnostics;
 using Elastic.CommonSchema.BenchmarkDotNetExporter.Domain;
 using Elastic.Ingest.Elasticsearch;
 using Elastic.Ingest.Elasticsearch.DataStreams;
@@ -95,6 +96,11 @@ namespace Elastic.CommonSchema.BenchmarkDotNetExporter
 		/// <summary> Allows the user to directly change <see cref="DataStreamChannelOptions{TEvent}"/> used to export the benchmarks </summary>
 		public Action<DataStreamChannelOptions<BenchmarkDocument>> ChannelOptionsCallback { get; set; }
 
+		/// <summary>
+		/// Allows programmatic access to active channel diagnostics listener when its created.
+		/// </summary>
+		public Action<IChannelDiagnosticsListener> ChannelDiagnosticsCallback { get; set; }
+
 		private static Uri[] Parse(string urls)
 		{
 			if (string.IsNullOrWhiteSpace(urls)) throw new ArgumentException("no urls provided, empty string or null", nameof(urls));
@@ -146,4 +152,5 @@ namespace Elastic.CommonSchema.BenchmarkDotNetExporter
 			return settings;
 		}
 	}
+
 }

--- a/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSink.cs
+++ b/src/Elastic.CommonSchema.Serilog.Sink/ElasticsearchSink.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using Elastic.Channels.Buffers;
+using Elastic.Channels.Diagnostics;
 using Elastic.Ingest.Elasticsearch;
 using Elastic.Ingest.Elasticsearch.CommonSchema;
 using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Ingest.Elasticsearch.Serialization;
 using Elastic.Transport;
 using Elastic.Transport.Products.Elasticsearch;
 using Serilog.Core;
@@ -46,6 +50,11 @@ namespace Elastic.CommonSchema.Serilog.Sink
 		/// </summary>
 		public Action<DataStreamChannelOptions<TEcsDocument>>? ConfigureChannel { get; set; }
 
+		/// <summary>
+		/// Allows programmatic access to active channel diagnostics listener when its created.
+		/// </summary>
+		public Action<IChannelDiagnosticsListener>? ChannelDiagnosticsCallback { get; set; }
+
 		/// <inheritdoc cref="BootstrapMethod"/>
 		public BootstrapMethod BootstrapMethod { get; set; }
 
@@ -73,22 +82,14 @@ namespace Elastic.CommonSchema.Serilog.Sink
 			_formatterConfiguration = options.TextFormatting;
 			var channelOptions = new DataStreamChannelOptions<TEcsDocument>(options.Transport)
 			{
-				DataStream = options.DataStream,
-				ExportResponseCallback = (response, _) =>
-				{
-					var errorItems = response.Items.Where(i => i.Status >= 300).ToList();
-					if (response.TryGetElasticsearchServerError(out var error))
-						SelfLog.WriteLine("{0}", error);
-					foreach (var errorItem in errorItems)
-						SelfLog.WriteLine("{0}", $"Failed to {errorItem.Action} document status: ${errorItem.Status}, error: ${errorItem.Error}");
-
-				}
+				DataStream = options.DataStream
 			};
 			options.ConfigureChannel?.Invoke(channelOptions);
-			_channel = new EcsDataStreamChannel<TEcsDocument>(channelOptions);
+			_channel = new EcsDataStreamChannel<TEcsDocument>(channelOptions, new [] { new SelfLogCallbackListener<TEcsDocument>(options)});
+			if (_channel.DiagnosticsListener != null)
+				options.ChannelDiagnosticsCallback?.Invoke(_channel.DiagnosticsListener);
 			_channel.BootstrapElasticsearch(options.BootstrapMethod);
 		}
-
 
 		/// <inheritdoc cref="ILogEventSink.Emit"/>
 		public void Emit(LogEvent logEvent)
@@ -97,5 +98,44 @@ namespace Elastic.CommonSchema.Serilog.Sink
 			_channel.TryWrite(ecsDoc);
 		}
 
+	}
+
+	internal class SelfLogCallbackListener<TEcsDocument> : IChannelCallbacks<TEcsDocument, BulkResponse> where TEcsDocument : EcsDocument, new()
+	{
+		public Action<Exception>? ExportExceptionCallback { get; }
+		public Action<BulkResponse, IWriteTrackingBuffer>? ExportResponseCallback { get; }
+
+		// ReSharper disable UnassignedGetOnlyAutoProperty
+		public Action<int, int>? ExportItemsAttemptCallback { get; }
+		public Action<IReadOnlyCollection<TEcsDocument>>? ExportMaxRetriesCallback { get; }
+		public Action<IReadOnlyCollection<TEcsDocument>>? ExportRetryCallback { get; }
+		public Action? PublishToInboundChannelCallback { get; }
+		public Action? PublishToInboundChannelFailureCallback { get; }
+		public Action? PublishToOutboundChannelCallback { get; }
+		public Action? OutboundChannelStartedCallback { get; }
+		public Action? OutboundChannelExitedCallback { get; }
+		public Action? InboundChannelStartedCallback { get; }
+		public Action? PublishToOutboundChannelFailureCallback { get; }
+		public Action? ExportBufferCallback { get; }
+		public Action<int>? ExportRetryableCountCallback { get; }
+		// ReSharper enable UnassignedGetOnlyAutoProperty
+
+		public SelfLogCallbackListener(ElasticsearchSinkOptions<TEcsDocument> options)
+		{
+			ExportExceptionCallback = e =>
+			{
+				SelfLog.WriteLine("Observed an exception while writing to {0}", options.DataStream);
+				SelfLog.WriteLine("{0}", e);
+			};
+			ExportResponseCallback = (response, _) =>
+			{
+				var errorItems = response.Items.Where(i => i.Status >= 300).ToList();
+				if (response.TryGetElasticsearchServerError(out var error))
+					SelfLog.WriteLine("{0}", error);
+				foreach (var errorItem in errorItems)
+					SelfLog.WriteLine("{0}", $"Failed to {errorItem.Action} document status: ${errorItem.Status}, error: ${errorItem.Error}");
+
+			};
+		}
 	}
 }

--- a/src/Elastic.Ingest.Elasticsearch.CommonSchema/EcsDataStreamChannel.cs
+++ b/src/Elastic.Ingest.Elasticsearch.CommonSchema/EcsDataStreamChannel.cs
@@ -1,11 +1,14 @@
 ﻿#nullable enable
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Elastic.Channels.Diagnostics;
 using Elastic.CommonSchema;
 using Elastic.CommonSchema.Elasticsearch;
 using Elastic.CommonSchema.Serialization;
 using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Ingest.Elasticsearch.Serialization;
 
 namespace Elastic.Ingest.Elasticsearch.CommonSchema
 {
@@ -15,8 +18,15 @@ namespace Elastic.Ingest.Elasticsearch.CommonSchema
 	public class EcsDataStreamChannel<TEcsDocument> : DataStreamChannel<TEcsDocument>
 		where TEcsDocument : EcsDocument
 	{
+
 		/// <inheritdoc cref="EcsDataStreamChannel{TEcsDocument}"/>
-		public EcsDataStreamChannel(DataStreamChannelOptions<TEcsDocument> options) : base(options) =>
+		public EcsDataStreamChannel(DataStreamChannelOptions<TEcsDocument> options) : this(options, null) { }
+
+		/// <inheritdoc cref="EcsDataStreamChannel{TEcsDocument}"/>
+		public EcsDataStreamChannel(
+			DataStreamChannelOptions<TEcsDocument> options,
+			ICollection<IChannelCallbacks<TEcsDocument, BulkResponse>>? callbackListeners
+		) : base(options, callbackListeners) =>
 			options.WriteEvent = async (stream, ctx, @event) =>
 				await JsonSerializer.SerializeAsync(stream, @event, typeof(TEcsDocument), EcsJsonConfiguration.SerializerOptions, ctx)
 					.ConfigureAwait(false);

--- a/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
+++ b/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.3.2" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.4.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLogger.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLogger.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using Elastic.CommonSchema;
 using Elastic.Channels;
+using Elastic.Channels.Diagnostics;
 using Elasticsearch.Extensions.Logging.Options;
 using Microsoft.Extensions.Logging;
 
@@ -24,6 +25,9 @@ namespace Elasticsearch.Extensions.Logging
 		private readonly ElasticsearchLoggerOptions _options;
 		private readonly IExternalScopeProvider? _scopeProvider;
 
+		/// <inheritdoc cref="IChannelDiagnosticsListener"/>
+		public IChannelDiagnosticsListener? DiagnosticsListener { get; }
+
 		internal ElasticsearchLogger(
 			string categoryName,
 			IBufferedChannel<LogEvent> channel,
@@ -35,6 +39,7 @@ namespace Elasticsearch.Extensions.Logging
 			_channel = channel;
 			_options = options;
 			_scopeProvider = scopeProvider;
+			DiagnosticsListener = channel.DiagnosticsListener;
 		}
 
 		/// <inheritdoc cref="ILogger.BeginScope{TState}"/>

--- a/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerProvider.cs
+++ b/src/Elasticsearch.Extensions.Logging/ElasticsearchLoggerProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Elastic.Channels;
+using Elastic.Channels.Diagnostics;
 using Elastic.Ingest.Elasticsearch;
 using Elastic.Ingest.Elasticsearch.CommonSchema;
 using Elastic.Ingest.Elasticsearch.DataStreams;
@@ -32,6 +33,9 @@ namespace Elasticsearch.Extensions.Logging
 		private IExternalScopeProvider? _scopeProvider;
 		private IBufferedChannel<LogEvent> _shipper;
 
+		/// <inheritdoc cref="IChannelDiagnosticsListener"/>
+		public IChannelDiagnosticsListener? DiagnosticsListener { get; }
+
 		/// <inheritdoc cref="ElasticsearchLoggerProvider"/>
 		public ElasticsearchLoggerProvider(IOptionsMonitor<ElasticsearchLoggerOptions> options,
 			IEnumerable<IChannelSetup> channelConfigurations
@@ -46,6 +50,7 @@ namespace Elasticsearch.Extensions.Logging
 
 			_shipper = CreatIngestChannel(options.CurrentValue);
 			_optionsReloadToken = _options.OnChange(o => ReloadShipper(o));
+			DiagnosticsListener = _shipper.DiagnosticsListener;
 		}
 
 		// ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global

--- a/tests-integration/Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests/BdNetExporterTests.cs
+++ b/tests-integration/Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests/BdNetExporterTests.cs
@@ -52,20 +52,21 @@ namespace Elastic.CommonSchema.BenchmarkDotNetExporter.IntegrationTests
 		public void BenchmarkingPersistsResults()
 		{
 			var url = Client.ElasticsearchClientSettings.NodePool.Nodes.First().Uri;
-			var listener = new ChannelListener<BenchmarkDocument, BulkResponse>();
+			IChannelDiagnosticsListener listener = null;
 			var options = new ElasticsearchBenchmarkExporterOptions(url)
 			{
 				GitBranch = "externally-provided-branch",
 				GitCommitMessage = "externally provided git commit message",
 				GitRepositoryIdentifier = "repository",
 				BootstrapMethod = BootstrapMethod.Silent,
-				ChannelOptionsCallback = (o) => listener.Register(o)
+				ChannelDiagnosticsCallback = (l) => listener = l
 			};
 			var exporter = new ElasticsearchBenchmarkExporter(options);
 			var config = CreateDefaultConfig().AddExporter(exporter);
 			var summary = BenchmarkRunner.Run(typeof(Md5VsSha256), config);
 
 			// ensure publication was success
+			listener.Should().NotBeNull();
 			listener.PublishSuccess.Should().BeTrue("{0}", listener);
 
 			if (summary.HasCriticalValidationErrors)

--- a/tests-integration/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/Elastic.CommonSchema.Serilog.Sinks.IntegrationTests.csproj
+++ b/tests-integration/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/Elastic.CommonSchema.Serilog.Sinks.IntegrationTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsTestProject>False</IsTestProject>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/tests-integration/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/SerilogCluster.cs
+++ b/tests-integration/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/SerilogCluster.cs
@@ -3,11 +3,9 @@ using Xunit;
 
 [assembly: TestFramework("Elastic.Elasticsearch.Xunit.Sdk.ElasticTestFramework", "Elastic.Elasticsearch.Xunit")]
 
-namespace Elastic.CommonSchema.Serilog.Sinks.IntegrationTests
-{
-	public class SerilogCluster : TestClusterBase
-	{
-		public SerilogCluster() : base(9205) { }
+namespace Elastic.CommonSchema.Serilog.Sinks.IntegrationTests;
 
-	}
+public class SerilogCluster : TestClusterBase
+{
+	public SerilogCluster() : base(9205) { }
 }

--- a/tests-integration/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/SerilogTestBase.cs
+++ b/tests-integration/Elastic.CommonSchema.Serilog.Sink.IntegrationTests/SerilogTestBase.cs
@@ -1,4 +1,6 @@
-﻿using Elastic.Clients.Elasticsearch;
+﻿using System;
+using System.Collections.Generic;
+using Elastic.Clients.Elasticsearch;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Xunit.Abstractions;
 
@@ -8,8 +10,8 @@ namespace Elastic.CommonSchema.Serilog.Sinks.IntegrationTests
 	{
         protected ElasticsearchClient Client { get; }
 
-		protected SerilogTestBase(SerilogCluster cluster, ITestOutputHelper output) =>
-			Client = cluster.CreateClient(output);
+		protected SerilogTestBase(SerilogCluster cluster, ITestOutputHelper output, Func<ICollection<Uri>, ICollection<Uri>>? alterNodes = null) =>
+			Client = cluster.CreateClient(output, alterNodes);
 	}
 
 }

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/DataStreamIngestionTests.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/DataStreamIngestionTests.cs
@@ -31,7 +31,6 @@ namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests
 				DataStream = targetDataStream,
 				BufferOptions = new BufferOptions { WaitHandle = slim, OutboundBufferMaxSize = 1 },
 			};
-			var listener = new ChannelListener<TimeSeriesDocument, BulkResponse>().Register(options);
 			var channel = new EcsDataStreamChannel<TimeSeriesDocument>(options);
 
 			var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
@@ -43,7 +42,7 @@ namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests
 
 			channel.TryWrite(new TimeSeriesDocument { Timestamp = DateTimeOffset.Now, Message = "hello-world" });
 			if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
-				throw new Exception($"No flush occurred in 10 seconds: {listener}", listener.ObservedException);
+				throw new Exception($"No flush occurred in 10 seconds: {channel}", channel.DiagnosticsListener?.ObservedException);
 
 			var refreshResult = await Client.Indices.RefreshAsync(targetDataStream.ToString());
 			refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/IndexIngestionTests.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/IndexIngestionTests.cs
@@ -37,7 +37,6 @@ namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests
 					WaitHandle = slim, ExportMaxConcurrency = 1,
 				},
 			};
-			var listener = new ChannelListener<CatalogDocument, BulkResponse>().Register(options);
 			var channel = new EcsIndexChannel<CatalogDocument>(options);
 			var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
 			bootstrapped.Should().BeTrue("Expected to be able to bootstrap index channel");
@@ -50,7 +49,7 @@ namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests
 
 			channel.TryWrite(new CatalogDocument { Created = date, Title = "Hello World!", Id = "hello-world" });
 			if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
-				throw new Exception($"No flush occurred in 10 seconds: {listener}", listener.ObservedException);
+				throw new Exception($"No flush occurred in 10 seconds: {channel.DiagnosticsListener}", channel.DiagnosticsListener?.ObservedException);
 
 			var refreshResult = await Client.Indices.RefreshAsync(indexName);
 			refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);

--- a/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingToDataStreamTests.cs
+++ b/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingToDataStreamTests.cs
@@ -23,7 +23,7 @@ namespace Elasticsearch.Extensions.Logging.IntegrationTests
 			out ElasticsearchLoggerProvider provider,
 			out string @namespace,
 			out WaitHandle waitHandle,
-			out ChannelListener<LogEvent, BulkResponse> listener
+			out IChannelDiagnosticsListener listener
 		) =>
 			base.CreateLogger(out logger, out provider, out @namespace, out waitHandle, out listener, (o, s) =>
 			{

--- a/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingToIndexTests.cs
+++ b/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/LoggingToIndexTests.cs
@@ -23,7 +23,7 @@ namespace Elasticsearch.Extensions.Logging.IntegrationTests
 			out ElasticsearchLoggerProvider provider,
 			out string @namespace,
 			out WaitHandle waitHandle,
-			out ChannelListener<LogEvent, BulkResponse> listener
+			out IChannelDiagnosticsListener listener
 		) =>
 			base.CreateLogger(out logger, out provider, out @namespace, out waitHandle, out listener, (o, s) =>
 			{

--- a/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/TestBase.cs
+++ b/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/TestBase.cs
@@ -57,6 +57,7 @@ public abstract class TestBase : IClusterFixture<LoggingCluster>
 			new LoggerFilterOptions { MinLevel = LogLevel.Information }
 		);
 		logger = loggerFactory.CreateLogger<ElasticsearchLogger>();
+		listener = provider.DiagnosticsListener;
 		return loggerFactory;
 	}
 }

--- a/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/TestBase.cs
+++ b/tests-integration/Elasticsearch.Extensions.Logging.IntegrationTests/TestBase.cs
@@ -24,12 +24,10 @@ public abstract class TestBase : IClusterFixture<LoggingCluster>
 		out ElasticsearchLoggerProvider provider,
 		out string @namespace,
 		out WaitHandle waitHandle,
-		out ChannelListener<LogEvent, BulkResponse> listener,
+		out IChannelDiagnosticsListener listener,
 		Action<ElasticsearchLoggerOptions, string> setupLogger
 	)
 	{
-		listener = new ChannelListener<LogEvent, BulkResponse>();
-		var l = listener;
 		@namespace = Guid.NewGuid().ToString("N").ToLowerInvariant().Substring(0, 6);
 		var slim = new CountdownEvent(1);
 		waitHandle = slim.WaitHandle;
@@ -45,7 +43,6 @@ public abstract class TestBase : IClusterFixture<LoggingCluster>
 				c.BufferOptions.OutboundBufferMaxLifetime = TimeSpan.FromSeconds(1);
 				c.BufferOptions.ExportMaxRetries = 0;
 				c.BufferOptions.ExportMaxConcurrency = 1;
-				l.Register(c);
 			})
 		};
 

--- a/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
+++ b/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.3.5" />
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.3.2" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.4.3" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Elastic.Ingest now models the callbacks more rigourously allowing
implementations to inject their own into the channel without overriding
anything the channel itself might rely on or the user might override in
their channeloptions.

This allows e.g the serilog implementation to inject its own listeners
in isolation to log to SelfLog in isolation
