### PR TITLE
Bump minimum Elastic.APM to version that eagerly reads configuration

### DIFF
--- a/examples/Elastic.CommonSchema.Serilog.Sink.Example/Elastic.CommonSchema.Serilog.Sink.Example.csproj
+++ b/examples/Elastic.CommonSchema.Serilog.Sink.Example/Elastic.CommonSchema.Serilog.Sink.Example.csproj
@@ -8,21 +8,18 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Elastic.Apm" Version="1.22.0" />
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
       <PackageReference Include="Elastic.Elasticsearch.Ephemeral" Version="0.3.5" />
       <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\src\Elastic.Apm.SerilogEnricher\Elastic.Apm.SerilogEnricher.csproj" />
       <ProjectReference Include="..\..\src\Elastic.CommonSchema.Serilog.Sink\Elastic.CommonSchema.Serilog.Sink.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Elastic.Clients.Elasticsearch">
-        <HintPath>..\..\..\..\.nuget\packages\elastic.clients.elasticsearch\8.0.4\lib\net6.0\Elastic.Clients.Elasticsearch.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
 </Project>

--- a/examples/aspnetcore-with-serilog/AspnetCoreExample.csproj
+++ b/examples/aspnetcore-with-serilog/AspnetCoreExample.csproj
@@ -5,12 +5,16 @@
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Elastic.Apm" Version="1.22.0" />
+    <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.22.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0"/>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Apm.SerilogEnricher\Elastic.Apm.SerilogEnricher.csproj" />
     <ProjectReference Include="..\..\src\Elastic.CommonSchema.Serilog\Elastic.CommonSchema.Serilog.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/aspnetcore-with-serilog/Program.cs
+++ b/examples/aspnetcore-with-serilog/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Elastic.Apm.SerilogEnricher;
 using Elastic.CommonSchema.Serilog;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
@@ -27,6 +28,7 @@ namespace AspnetCoreExample
 
 					config
 						.ReadFrom.Configuration(ctx.Configuration)
+						.Enrich.WithElasticApmCorrelationInfo()
 						.Enrich.WithEcsHttpContext(httpAccessor);
 
 					//config.WriteTo.Console(formatter);

--- a/examples/aspnetcore-with-serilog/Startup.cs
+++ b/examples/aspnetcore-with-serilog/Startup.cs
@@ -1,3 +1,4 @@
+using Elastic.Apm.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -28,6 +29,7 @@ namespace AspnetCoreExample
 				app.UseDeveloperExceptionPage();
 
 			app.UseRouting();
+			app.UseElasticApm();
 
 			app.UseAuthorization();
 

--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -14,6 +14,6 @@
       a lower NLog version
     -->
     <PackageReference Include="NLog" Version="4.7.15" />
-    <PackageReference Include="Elastic.Apm" Version="1.8.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.22.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm.SerilogEnricher/Elastic.Apm.SerilogEnricher.csproj
+++ b/src/Elastic.Apm.SerilogEnricher/Elastic.Apm.SerilogEnricher.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Elastic.Apm" Version="1.8.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.22.0" />
   </ItemGroup>
 </Project>

--- a/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
+++ b/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Apm" Version="1.8.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.22.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="NLog" Version="4.7.15" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.5" />

--- a/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
+++ b/tests/Elastic.Apm.Test.Common/Elastic.Apm.Test.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Apm" Version="1.8.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.22.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Elastic.Apm.Test.Common/MockConfiguration.cs
+++ b/tests/Elastic.Apm.Test.Common/MockConfiguration.cs
@@ -31,6 +31,8 @@ namespace Elastic.Apm.Test.Common
 
 		public bool Enabled { get; }
 
+		public string Description { get; } = nameof(MockConfiguration);
+
 		public IReadOnlyDictionary<string, string> GlobalLabels { get; }
 		public string ServiceName { get; }
 		public string ServiceNodeName { get; }
@@ -43,8 +45,10 @@ namespace Elastic.Apm.Test.Common
 		public LogLevel LogLevel { get; } = LogLevel.Information;
 
 		// ReSharper disable UnassignedGetOnlyAutoProperty
+		public IReadOnlyList<WildcardMatcher> IgnoreMessageQueues { get; }
 		public bool Recording { get; }
 		public string HostName { get; }
+		public string ServerCert { get; }
 		public Uri ServerUrl { get; }
 		public string CloudProvider { get; }
 		public IReadOnlyCollection<string> ApplicationNamespaces { get; }
@@ -53,6 +57,7 @@ namespace Elastic.Apm.Test.Common
 		public bool CentralConfig { get; }
 		public string Environment { get; }
 		public IReadOnlyCollection<string> ExcludedNamespaces { get; }
+		public double ExitSpanMinDuration { get; }
 		public TimeSpan FlushInterval { get; }
 		public int MaxBatchEventCount { get; }
 		public int MaxQueueEventCount { get; }
@@ -61,11 +66,19 @@ namespace Elastic.Apm.Test.Common
 		public string ApiKey { get; }
 		public double SpanFramesMinDurationInMilliseconds { get; }
 		public int StackTraceLimit { get; }
+		public bool TraceContextIgnoreSampledFalse { get; }
+		public string TraceContinuationStrategy { get; }
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls { get; }
 		public int TransactionMaxSpans { get; }
 		public double TransactionSampleRate { get; }
 		public bool UseElasticTraceparentHeader { get; }
 		public bool VerifyServerCert { get; }
+		public bool OpenTelemetryBridgeEnabled { get; }
+		public bool UseWindowsCredentials { get; }
+		public bool SpanCompressionEnabled { get; }
+		public double SpanCompressionExactMatchMaxDuration { get; }
+		public double SpanCompressionSameKindMaxDuration { get; }
+		public double SpanStackTraceMinDurationInMilliseconds { get; }
 		// ReSharper restore UnassignedGetOnlyAutoProperty
 	}
 }

--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="NLog" Version="4.7.15" />
-        <PackageReference Include="Elastic.Apm" Version="1.8.0" />
+        <PackageReference Include="Elastic.Apm" Version="1.22.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/Elastic.CommonSchema.Serilog.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
         <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />
-        <PackageReference Include="Elastic.Apm" Version="1.8.0" />
+        <PackageReference Include="Elastic.Apm" Version="1.22.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Fix #292 bump apm to version that eagerly reads configuration
- Ensure our examples are using the APM corrolation providers
