### PR TITLE
IncludeAspNetProperties property

### DIFF
--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="NLog" Version="4.7.15" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="4.15.0" />
         <PackageReference Include="Elastic.Apm" Version="1.22.0" />
     </ItemGroup>
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/WebTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/WebTests.cs
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Reflection;
+using FluentAssertions;
+using NLog.Config;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.CommonSchema.NLog.Tests
+{
+	public class WebTests : LogTestsBase
+	{
+		public WebTests(ITestOutputHelper output) : base(output) { }
+
+		private void TestLayout(bool withNLogWeb, Action<EcsLayout> setup, Action<EcsLayout> act)
+		{
+			// Setup basic factory without automatic loading of NLog extensions.
+			ConfigurationItemFactory.Default = new(typeof(ConfigurationItemFactory).Assembly);
+
+			try
+			{
+				if (withNLogWeb)
+				{
+					var nlogWebAssemblyName = new AssemblyName("NLog.Web.AspNetCore");
+					var nlogWebAssembly = Assembly.Load(nlogWebAssemblyName);
+					ConfigurationItemFactory.Default.RegisterItemsFromAssembly(nlogWebAssembly);
+				}
+
+				TestLoggerAndLayout(setup, (layout, logger, events) => act(layout));
+			}
+			finally
+			{
+				// Cleanup for the sake of other tests.
+				ConfigurationItemFactory.Default = null;
+			}
+		}
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void IncludeAspNetPropertiesIsTrueByDefault(bool withNLogWeb) =>
+			TestLayout(withNLogWeb, null, layout =>
+			{
+				layout.IncludeAspNetProperties.Should().BeTrue();
+			});
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void CanIncludeAspNetPropertiesRequiresNLogWebAspNet(bool withNLogWeb) =>
+			TestLayout(withNLogWeb, null, layout =>
+			{
+				if (withNLogWeb)
+				{
+					layout.CanIncludeAspNetProperties().Should().BeTrue();
+					layout.HttpRequestMethod.Should().NotBeNull();
+				}
+				else
+				{
+					layout.CanIncludeAspNetProperties().Should().BeFalse();
+					layout.HttpRequestMethod.Should().BeNull();
+				}
+			});
+
+		[Theory]
+		[InlineData(false)]
+		[InlineData(true)]
+		public void CannotIncludeAspNetPropertiesWhenDisabled(bool withNLogWeb) =>
+			TestLayout(withNLogWeb,
+				layout =>
+				{
+					layout.IncludeAspNetProperties = false;
+				},
+				layout =>
+				{
+					layout.IncludeAspNetProperties.Should().BeFalse();
+					layout.HttpRequestMethod.Should().BeNull();
+				});
+	}
+}


### PR DESCRIPTION
Resolves issue #296, by introducing IncludeAspNetProperties property to allow consumers to disable AspNet fields rendering. Extend support of AspNet fields rendering to NLog 4.7 (not only 5.0). AspNet related properties in EcsLayout class are not initialized in constructor as before, but in Initialize method.