### PR TITLE
Add nullable support to Elastic.CommonSchema.Serilog

### DIFF
--- a/src/Elastic.CommonSchema.Serilog/Adapters/HttpContextAccessorAdapter.cs
+++ b/src/Elastic.CommonSchema.Serilog/Adapters/HttpContextAccessorAdapter.cs
@@ -17,21 +17,21 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 	{
 		private static readonly Parser UAParser = Parser.GetDefault();
 
-		private readonly IHttpContextAccessor _httpContextAccessor;
+		private readonly IHttpContextAccessor? _httpContextAccessor;
 
 		/// <inheritdoc cref="IHttpAdapter"/>
-		public HttpAdapter(IHttpContextAccessor httpContextAccessor) =>
+		public HttpAdapter(IHttpContextAccessor? httpContextAccessor) =>
 			_httpContextAccessor = httpContextAccessor;
 
 		/// <inheritdoc cref="IHttpAdapter.HasContext"/>
 		public bool HasContext => _httpContextAccessor?.HttpContext != null;
 
 		/// <inheritdoc cref="IHttpAdapter.UserAgent"/>
-		public UserAgent UserAgent
+		public UserAgent? UserAgent
 		{
 			get
 			{
-				if (!HasContext)
+				if (_httpContextAccessor?.HttpContext == null)
 					return null;
 
 				var userAgent = _httpContextAccessor.HttpContext.Request.Headers["User-Agent"];
@@ -57,11 +57,11 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 		}
 
 		/// <inheritdoc cref="IHttpAdapter.Http"/>
-		public Http Http
+		public Http? Http
 		{
 			get
 			{
-				if (!HasContext)
+				if (_httpContextAccessor?.HttpContext == null)
 					return null;
 
 				var http = new Http
@@ -89,9 +89,7 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 
 		private void SetRequestBody(Http http)
 		{
-			if (!HasContext) return;
-
-			if (!_httpContextAccessor.HttpContext.Request.ContentLength.HasValue)
+			if (_httpContextAccessor?.HttpContext?.Request.ContentLength == null)
 				return;
 
 			http.RequestBodyBytes = _httpContextAccessor.HttpContext.Request.ContentLength;
@@ -100,11 +98,11 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 		}
 
 		/// <inheritdoc cref="IHttpAdapter.Url"/>
-		public Url Url
+		public Url? Url
 		{
 			get
 			{
-				if (!HasContext) return null;
+				if (_httpContextAccessor?.HttpContext == null) return null;
 
 				var request = _httpContextAccessor.HttpContext.Request;
 
@@ -122,11 +120,11 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 		}
 
 		/// <inheritdoc cref="IHttpAdapter.Server"/>
-		public Server Server
+		public Server? Server
 		{
 			get
 			{
-				if (!HasContext)
+				if (_httpContextAccessor?.HttpContext == null)
 					return null;
 
 				var ip4 = _httpContextAccessor.HttpContext.Connection.LocalIpAddress.MapToIPv4();
@@ -143,11 +141,11 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 		}
 
 		/// <inheritdoc cref="IHttpAdapter.Client"/>
-		public Client Client
+		public Client? Client
 		{
 			get
 			{
-				if (!HasContext)
+				if (_httpContextAccessor?.HttpContext == null)
 					return null;
 
 				var ip4 = _httpContextAccessor.HttpContext.Features.Get<IHttpConnectionFeature>()?.RemoteIpAddress.MapToIPv4();
@@ -163,11 +161,11 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 		}
 
 		/// <inheritdoc cref="IHttpAdapter.User"/>
-		public User User
+		public User? User
 		{
 			get
 			{
-				if (!HasContext)
+				if (_httpContextAccessor?.HttpContext == null)
 					return null;
 
 				var idClaims = _httpContextAccessor.HttpContext.User.FindAll(ClaimTypes.NameIdentifier);

--- a/src/Elastic.CommonSchema.Serilog/Adapters/HttpContextAdapter.cs
+++ b/src/Elastic.CommonSchema.Serilog/Adapters/HttpContextAdapter.cs
@@ -10,19 +10,19 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 	/// <inheritdoc cref="IHttpAdapter"/>
 	public class HttpAdapter : IHttpAdapter
 	{
-		private readonly HttpContext _httpContext;
+		private readonly HttpContext? _httpContext;
 
 		/// <inheritdoc cref="IHttpAdapter"/>
-		public HttpAdapter(HttpContext httpContext) => _httpContext = httpContext;
+		public HttpAdapter(HttpContext? httpContext) => _httpContext = httpContext;
 
 		/// <inheritdoc cref="IHttpAdapter.Client"/>
-		public Client Client => null;
+		public Client? Client => null;
 
 		/// <inheritdoc cref="IHttpAdapter.HasContext"/>
 		public bool HasContext => _httpContext != null;
 
 		/// <inheritdoc cref="IHttpAdapter.Http"/>
-		public Http Http => !HasContext ? null : new Http
+		public Http? Http => _httpContext == null ? null : new Http
 		{
 			RequestMethod = _httpContext.Request.HttpMethod,
 			RequestBytes = _httpContext.Request.TotalBytes,
@@ -36,13 +36,13 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 		};
 
 		/// <inheritdoc cref="IHttpAdapter.Server"/>
-		public Server Server => !HasContext ? null : new Server
+		public Server? Server => _httpContext == null ? null : new Server
 		{
 			Domain = _httpContext.Request.Url.Authority
 		};
 
 		/// <inheritdoc cref="IHttpAdapter.Url"/>
-		public Url Url => !HasContext ? null : new Url
+		public Url? Url => _httpContext == null ? null : new Url
 		{
 			Original = _httpContext.Request.RawUrl,
 			Full = _httpContext.Request.Url.ToString(),
@@ -55,10 +55,10 @@ namespace Elastic.CommonSchema.Serilog.Adapters
 		};
 
 		/// <inheritdoc cref="IHttpAdapter.User"/>
-		public User User => null;
+		public User? User => null;
 
 		/// <inheritdoc cref="IHttpAdapter.UserAgent"/>
-		public UserAgent UserAgent => !HasContext ? null : new UserAgent
+		public UserAgent? UserAgent => _httpContext == null ? null : new UserAgent
 		{
 			DeviceName = _httpContext.Request.Browser?.MobileDeviceModel,
 			Name = _httpContext.Request.Browser?.Browser,

--- a/src/Elastic.CommonSchema.Serilog/Adapters/IHttpAdapter.cs
+++ b/src/Elastic.CommonSchema.Serilog/Adapters/IHttpAdapter.cs
@@ -10,17 +10,17 @@ namespace Elastic.CommonSchema.Serilog.Adapters;
 public interface IHttpAdapter
 {
 	/// <summary> The current <see cref="Client"/> information</summary>
-	Client Client { get; }
+	Client? Client { get; }
 	/// <summary> The current <see cref="Http"/> information</summary>
-	Http Http { get; }
+	Http? Http { get; }
 	/// <summary> The current <see cref="Server"/> information</summary>
-	Server Server { get; }
+	Server? Server { get; }
 	/// <summary> The current <see cref="Url"/> information</summary>
-	Url Url { get; }
+	Url? Url { get; }
 	/// <summary> The current <see cref="User"/> information</summary>
-	User User { get; }
+	User? User { get; }
 	/// <summary> The current <see cref="UserAgent"/> information</summary>
-	UserAgent UserAgent { get; }
+	UserAgent? UserAgent { get; }
 
 	/// <summary>Whether there is a context to infer information from</summary>
 	bool HasContext { get; }

--- a/src/Elastic.CommonSchema.Serilog/EcsTextFormatter.cs
+++ b/src/Elastic.CommonSchema.Serilog/EcsTextFormatter.cs
@@ -22,7 +22,7 @@ namespace Elastic.CommonSchema.Serilog
 		public EcsTextFormatter() : this(new EcsTextFormatterConfiguration<TEcsDocument>()) { }
 
 		/// <inheritdoc cref="EcsTextFormatter{TEcsDocument}"/>
-		public EcsTextFormatter(EcsTextFormatterConfiguration<TEcsDocument> configuration) =>
+		public EcsTextFormatter(EcsTextFormatterConfiguration<TEcsDocument>? configuration) =>
 			Configuration = configuration ?? new EcsTextFormatterConfiguration<TEcsDocument>();
 
 		/// <inheritdoc cref="ITextFormatter.Format"/>

--- a/src/Elastic.CommonSchema.Serilog/EcsTextFormatterConfiguration.cs
+++ b/src/Elastic.CommonSchema.Serilog/EcsTextFormatterConfiguration.cs
@@ -26,12 +26,12 @@ namespace Elastic.CommonSchema.Serilog
 		///			.Enrich.WithEcsHttpContext(httpAccessor);
 		/// </code>
 		/// </summary>
-		IHttpAdapter MapHttpAdapter { get; set; }
+		IHttpAdapter? MapHttpAdapter { get; set; }
 
 		/// <summary>
 		/// Stop certain keys to be persisted as <see cref="EcsDocument.Metadata"/> or <see cref="BaseFieldSet.Labels"/>
 		/// </summary>
-		ISet<string> LogEventPropertiesToFilter { get;set; }
+		ISet<string>? LogEventPropertiesToFilter { get;set; }
 	}
 
 	/// <summary> Provides configuration options for <see cref="EcsTextFormatter{TEcsDocument}"/> </summary>
@@ -41,7 +41,7 @@ namespace Elastic.CommonSchema.Serilog
 		/// <summary>
 		/// Allows you to enrich <typeparamref name="TEcsDocument"/> using <see cref="LogEvent"/> before its being formatted
 		/// </summary>
-		Func<TEcsDocument, LogEvent, TEcsDocument> MapCustom { get; set; }
+		Func<TEcsDocument, LogEvent, TEcsDocument>? MapCustom { get; set; }
 	}
 
 	/// <inheritdoc cref="IEcsTextFormatterConfiguration{TEcsDocument}"/>
@@ -58,11 +58,13 @@ namespace Elastic.CommonSchema.Serilog
 		public bool IncludeUser { get; set; } = true;
 
 		/// <inheritdoc cref="IEcsTextFormatterConfiguration.MapHttpAdapter"/>
-		public IHttpAdapter MapHttpAdapter { get; set; }
+		public IHttpAdapter? MapHttpAdapter { get; set; }
+
 		/// <inheritdoc cref="IEcsTextFormatterConfiguration.LogEventPropertiesToFilter"/>
-		public ISet<string> LogEventPropertiesToFilter { get; set; }
+		public ISet<string>? LogEventPropertiesToFilter { get; set; }
+
 		/// <inheritdoc cref="IEcsTextFormatterConfiguration{TEcsDocument}.MapCustom"/>
-		public Func<TEcsDocument, LogEvent, TEcsDocument> MapCustom { get; set; }
+		public Func<TEcsDocument, LogEvent, TEcsDocument>? MapCustom { get; set; }
 	}
 
 	// ReSharper disable once ClassNeverInstantiated.Global

--- a/src/Elastic.CommonSchema.Serilog/Elastic.CommonSchema.Serilog.csproj
+++ b/src/Elastic.CommonSchema.Serilog/Elastic.CommonSchema.Serilog.csproj
@@ -6,6 +6,7 @@
     <Title>Elastic Common Schema (ECS) Serilog Formatter</Title>
     <Description>Serilog TextFormatter that formats log events in accordance with Elastic Common Schema (ECS).</Description>
     <IsPackable>True</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Lib\UAParser.regexes.yaml" />
@@ -19,11 +20,13 @@
     <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.13.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Serilog" Version="2.9.0.0" />
-    <PackageReference Condition="$(DefineConstants.Contains(NETSTANDARD))"
-                      Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0.0" />
-    <PackageReference Condition="$(DefineConstants.Contains(NETSTANDARD))"
-                      Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.0.0" />
+    <PackageReference Condition="$(DefineConstants.Contains(NETSTANDARD))" Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0.0" />
+    <PackageReference Condition="$(DefineConstants.Contains(NETSTANDARD))" Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.0.0" />
     <Reference Condition="$(DefineConstants.Contains(FULLFRAMEWORK))" Include="System.Web" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.Serilog/HttpContextEnricher.cs
+++ b/src/Elastic.CommonSchema.Serilog/HttpContextEnricher.cs
@@ -51,11 +51,11 @@ public class HttpContextEnricher : ILogEventEnricher
 
 	internal class HttpContextEnrichments
 	{
-		public Client Client { get; set; }
-		public Http Http { get; set; }
-		public Server Server { get; set; }
-		public Url Url { get; set; }
-		public User User { get; set; }
-		public UserAgent UserAgent { get; set; }
+		public Client? Client { get; set; }
+		public Http? Http { get; set; }
+		public Server? Server { get; set; }
+		public Url? Url { get; set; }
+		public User? User { get; set; }
+		public UserAgent? UserAgent { get; set; }
 	}
 }

--- a/src/Elastic.CommonSchema.Serilog/Lib/UAParser.cs
+++ b/src/Elastic.CommonSchema.Serilog/Lib/UAParser.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
+#nullable disable
 
 // ReSharper disable once CheckNamespace
 namespace UAParser
@@ -38,10 +39,8 @@ namespace UAParser
         internal Device(string family, string brand, string model)
         {
             Family = family.Trim();
-            if (brand != null)
-                Brand = brand.Trim();
-            if (model != null)
-                Model = model.Trim();
+            Brand = brand?.Trim();
+            Model = model?.Trim();
         }
 
         /// <summary>

--- a/src/Elastic.CommonSchema.Serilog/ScalarPropertyExtensions.cs
+++ b/src/Elastic.CommonSchema.Serilog/ScalarPropertyExtensions.cs
@@ -2,13 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Diagnostics.CodeAnalysis;
 using Serilog.Events;
 
 namespace Elastic.CommonSchema.Serilog
 {
 	internal static class ScalarPropertyExtensions
 	{
-		public static bool TryGetScalarPropertyValue(this LogEvent e, string key, out ScalarValue value)
+		public static bool TryGetScalarPropertyValue(this LogEvent e, string key, [NotNullWhen(true)]out ScalarValue? value)
 		{
 			if (!e.Properties.TryGetValue(key, out var scalarValue))
 			{
@@ -24,6 +25,19 @@ namespace Elastic.CommonSchema.Serilog
 
 			value = propertyValue;
 			return true;
+		}
+
+		public static bool TryGetScalarString(this LogEvent e, string key, [NotNullWhen(true)]out string? value)
+		{
+			value = null;
+			if (!e.TryGetScalarPropertyValue(key, out var scalar) || scalar.Value == null)
+				return false;
+
+			value = scalar.Value.ToString();
+			if (!string.IsNullOrWhiteSpace(value)) return true;
+
+			value = null;
+			return false;
 		}
 	}
 }

--- a/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
@@ -92,7 +92,9 @@ namespace Elastic.CommonSchema.Log4net.Tests
 			var (_, info) = ToEcsEvents(logEvents).First();
 
 			info.Host.Should().NotBeNull();
-			info.Host.Hostname.Should().Be(loggingEvent.LookupProperty(LoggingEvent.HostNameProperty).ToString());
+			var fqdn = loggingEvent.LookupProperty(LoggingEvent.HostNameProperty).ToString();
+			fqdn.Should().NotBeNullOrEmpty();
+			info.Host.Hostname.Should().StartWith(fqdn.Split('.', StringSplitOptions.None).First());
 		});
 
 		[Fact]

--- a/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
@@ -48,7 +48,7 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			info.Process.Pid.Should().BeGreaterThan(0);
 			info.Process.ThreadId.Should().NotBeNull().And.NotBe(info.Process.Pid);
 
-			info.Server.Should().NotBeNull();
+			info.Server.Should().BeNull();
 			// We can not reliably test this on CI as the username variable is set but empty
 			// info.Server.User.Name.Should().NotBeEmpty();
 		});

--- a/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/EnrichmentsTests.cs
@@ -48,8 +48,8 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			info.Process.Pid.Should().BeGreaterThan(0);
 			info.Process.ThreadId.Should().NotBeNull().And.NotBe(info.Process.Pid);
 
-			info.Server.Should().BeNull();
 			// We can not reliably test this on CI as the username variable is set but empty
+			// info.Server.Should().BeNull();
 			// info.Server.User.Name.Should().NotBeEmpty();
 		});
 

--- a/tests/Elastic.CommonSchema.Serilog.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/MessageTests.cs
@@ -205,7 +205,10 @@ namespace Elastic.CommonSchema.Serilog.Tests
 			var ecsEvents = ToEcsEvents(logEvents);
 
 			var (_, info) = ecsEvents.First();
-			((object)info.Url.Query).Should().Be(expectedValue);
+			if (expectedValue == null)
+				info.Url.Should().BeNull();
+			else
+				((object)info.Url.Query).Should().Be(expectedValue);
 			info.Metadata.Should().BeNull();
 		});
 


### PR DESCRIPTION
Introduce `TryGetScalarString` as extention to `TryGetScalarPropertyValue` that does not assume `ScalarProperty.Value` is never null if returned. 

Further more this enables stricter null checks.