### PR TITLE
ensure log jsonconverter can handle extra properties

### DIFF
--- a/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
@@ -121,8 +121,15 @@ namespace Elastic.CommonSchema.Serialization
 		protected static bool ReadProp<TValue>(ref Utf8JsonReader reader, string key, JsonTypeInfo<TValue> typeInfo, T b, Action<T, TValue?> set)
 			where TValue : class
 		{
-			var value = JsonSerializer.Deserialize(ref reader, typeInfo);
-			set(b, value);
+			try
+			{
+				var value = JsonSerializer.Deserialize(ref reader, typeInfo);
+				set(b, value);
+			}
+			catch (Exception e)
+			{
+				throw new Exception(key, e);
+			}
 			return true;
 		}
 	}

--- a/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
@@ -27,10 +27,15 @@ namespace Elastic.CommonSchema.Serialization
 				throw new JsonException($"JsonTokenType was of type {reader.TokenType}, only objects are supported");
 
 			var dictionary = new MetadataDictionary();
+			var originalDepth = reader.CurrentDepth;
 			while (reader.Read())
 			{
 				if (reader.TokenType == JsonTokenType.EndObject)
-					return dictionary;
+				{
+					if (reader.CurrentDepth <= originalDepth)
+						break;
+					continue;
+				}
 
 				if (reader.TokenType != JsonTokenType.PropertyName)
 					throw new JsonException("JsonTokenType was not PropertyName");

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
@@ -34,9 +34,11 @@ internal partial class LogEntityJsonConverter : PropertiesReaderJsonConverterBas
 			"origin.file.name" => ReadPropString(ref reader, "origin.file.name", ecsEvent, (b, v) => b.OriginFileName = v),
 			"origin.function" => ReadPropString(ref reader, "origin.function", ecsEvent, (b, v) => b.OriginFunction = v),
 	"syslog" => ReadProp<LogSyslog>(ref reader, "syslog", ecsEvent, (b, v) => b.Syslog = v),
-			_ => false
+			_ => ReadProperty(ref reader, propertyName, ecsEvent)
 		};
 	}
+
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Log ecsEvent);
 		
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, Log value, JsonSerializerOptions options)
@@ -70,9 +72,11 @@ internal partial class EcsEntityJsonConverter : PropertiesReaderJsonConverterBas
 		return propertyName switch
 		{
 			"version" => ReadPropString(ref reader, "version", ecsEvent, (b, v) => b.Version = v),
-			_ => false
+			_ => ReadProperty(ref reader, propertyName, ecsEvent)
 		};
 	}
+
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Ecs ecsEvent);
 		
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, Ecs value, JsonSerializerOptions options)

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
@@ -3,50 +3,90 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Runtime.Serialization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace Elastic.CommonSchema.Serialization
+namespace Elastic.CommonSchema.Serialization;
+
+/// <summary>
+/// An abstract implementation that makes it easier to read all properties of a json object.
+/// Used to read properties both as <c>x.y: 1</c> and <c>x : { y: 1 }</c> for specific fields.
+/// </summary>
+public abstract class PropertiesReaderJsonConverterBase<T> : EcsJsonConverterBase<T>
+	where T : new()
 {
-	/// <summary>
-	/// An abstract implementation that makes it easier to read all properties of a json object.
-	/// Used to read properties both as <c>x.y: 1</c> and <c>x : { y: 1 }</c> for specific fields.
-	/// </summary>
-	public abstract class PropertiesReaderJsonConverterBase<T> : EcsJsonConverterBase<T>
-		where T : new()
+	/// <inheritdoc cref="System.Text.Json.Serialization.JsonConverter{T}.Read"/>
+	public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		/// <inheritdoc cref="System.Text.Json.Serialization.JsonConverter{T}.Read"/>
-		public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		if (reader.TokenType == JsonTokenType.Null)
 		{
-			if (reader.TokenType == JsonTokenType.Null)
+			reader.Read();
+			return default;
+		}
+		if (reader.TokenType != JsonTokenType.StartObject)
+			throw new JsonException();
+
+		var ecsEvent = new T();
+
+		var originalDepth = reader.CurrentDepth;
+		while (reader.Read())
+		{
+			if (reader.TokenType == JsonTokenType.EndObject)
 			{
-				reader.Read();
-				return default;
+				if (reader.CurrentDepth <= originalDepth)
+					break;
+				continue;
 			}
-			if (reader.TokenType != JsonTokenType.StartObject)
+
+			if (reader.TokenType != JsonTokenType.PropertyName)
 				throw new JsonException();
 
-			var ecsEvent = new T();
-
-			var originalDepth = reader.CurrentDepth;
-			while (reader.Read())
-			{
-				if (reader.TokenType == JsonTokenType.EndObject)
-				{
-					if (reader.CurrentDepth <= originalDepth)
-						break;
-					continue;
-				}
-
-				if (reader.TokenType != JsonTokenType.PropertyName)
-					throw new JsonException();
-
-				var _ = ReadProperties(ref reader, ecsEvent);
-			}
-
-			return ecsEvent;
+			var _ = ReadProperties(ref reader, ecsEvent);
 		}
 
-		/// <summary> Handle reading the current property</summary>
-		protected abstract bool ReadProperties(ref Utf8JsonReader reader, T ecsEvent);
+		return ecsEvent;
 	}
+
+	/// <summary> Handle reading the current property</summary>
+	protected abstract bool ReadProperties(ref Utf8JsonReader reader, T ecsEvent);
+}
+
+internal partial class EcsEntityJsonConverter
+{
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Ecs ecsEvent) => false;
+}
+
+internal partial class LogEntityJsonConverter
+{
+	private class LogFileOriginInvalid
+	{
+		[JsonPropertyName("name"), DataMember(Name = "name")]
+		public string? Name { get; set; }
+
+		[JsonPropertyName("line"), DataMember(Name = "line")]
+		public int? Line { get; set; }
+	}
+	private class LogOriginInvalid
+	{
+		[JsonPropertyName("function"), DataMember(Name = "function")]
+		public string? Function { get; set; }
+
+		[JsonPropertyName("file"), DataMember(Name = "file")]
+		public LogFileOriginInvalid? File { get; set; }
+	}
+
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Log ecsEvent) =>
+		propertyName switch
+		{
+			"origin" => ReadProp<LogOriginInvalid>(ref reader, "origin", ecsEvent, (b, v) =>
+			{
+				if (v == null) return;
+				b.OriginFunction = v.Function;
+				if (v.File == null) return;
+				b.OriginFileLine = v.File.Line;
+				b.OriginFileName = v.File.Name;
+			}),
+			_ => false
+		};
 }

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
@@ -27,10 +27,15 @@ namespace Elastic.CommonSchema.Serialization
 
 			var ecsEvent = new T();
 
+			var originalDepth = reader.CurrentDepth;
 			while (reader.Read())
 			{
 				if (reader.TokenType == JsonTokenType.EndObject)
-					break;
+				{
+					if (reader.CurrentDepth <= originalDepth)
+						break;
+					continue;
+				}
 
 				if (reader.TokenType != JsonTokenType.PropertyName)
 					throw new JsonException();

--- a/tests/Elastic.CommonSchema.Tests/EcsServiceTests.cs
+++ b/tests/Elastic.CommonSchema.Tests/EcsServiceTests.cs
@@ -90,4 +90,5 @@ public class EcsServiceTests
 		b.Service.Should().NotBeNull();
 		b.Service.Environment.Should().Be("production");
 	}
+
 }

--- a/tests/Elastic.CommonSchema.Tests/Repro/GithubIssue316.cs
+++ b/tests/Elastic.CommonSchema.Tests/Repro/GithubIssue316.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.CommonSchema.Tests.Repro
+{
+	public class GithubIssue316
+	{
+		[Fact]
+		public void Reproduce()
+		{
+			var json =
+				@"{""@timestamp"":""2022-11-08T09:36:37.249Z"",""log.level"":""info"",""message"":""['vo_phi_pkg\\\\runtime_recon.py']"""
+				+ @",""ecs"":{""version"":""1.6.0""},""log"":{""logger"":""root"""
+				+ @",""origin"":{""file"":{""line"":90,""name"":""main.py""},""function"":""prepare_logging""},""original"":""['vo_phi_pkg\\\\runtime_recon.py']""}"
+				+ @",""process"":{""name"":""MainProcess"",""pid"":35436,""thread"":{""id"":13180,""name"":""MainThread""}}}";
+
+			var doc = EcsDocument.Deserialize(json);
+
+			doc.Log.Should().NotBeNull();
+			doc.Log.Logger.Should().Be("root");
+			doc.Log.Level.Should().Be("info");
+
+		}
+	}
+}

--- a/tests/Elastic.CommonSchema.Tests/Repro/GithubIssue316.cs
+++ b/tests/Elastic.CommonSchema.Tests/Repro/GithubIssue316.cs
@@ -20,7 +20,9 @@ namespace Elastic.CommonSchema.Tests.Repro
 			doc.Log.Should().NotBeNull();
 			doc.Log.Logger.Should().Be("root");
 			doc.Log.Level.Should().Be("info");
-
+			doc.Log.OriginFunction.Should().Be("prepare_logging");
+			doc.Log.OriginFileName.Should().Be("main.py");
+			doc.Log.OriginFileLine.Should().Be(90);
 		}
 	}
 }

--- a/tools/Elastic.CommonSchema.Generator/Views/PropertiesReaderJsonConverterBase.Generated.cshtml
+++ b/tools/Elastic.CommonSchema.Generator/Views/PropertiesReaderJsonConverterBase.Generated.cshtml
@@ -45,9 +45,11 @@ internal partial class @(entity.Name)EntityJsonConverter : PropertiesReaderJsonC
 <text>	"@(name)" => ReadProp<@(Raw(property.InlineObject.Name))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v),
 </text>
 		}
-			_ => false
+			_ => ReadProperty(ref reader, propertyName, ecsEvent)
 		};
 	}
+
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, @entity.Name ecsEvent);
 		
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, @entity.Name value, JsonSerializerOptions options)


### PR DESCRIPTION
Ensures we don't fail on deserialising: 

```json
"log": {
  "logger":"root",
  "origin": {
    "file": {"line":90,"name":"main.py"},
    "function":"prepare_logging"
  }
}
```

Technically the ecs-json should be in the following format:

```json
"log":{
   "logger":"root",
   "origin.file.line":90,
   "origin.file.name":"main.py"
   "origin.function":"prepare_logging"
}
```

This is also the format that beats will emit see e.g: https://github.com/elastic/beats/blob/e9272adcfcdd674b7a787ddd3a2416ad6f2c12be/libbeat/ecs/log.go#L48

Since this might be common enough this PR also adds support for deserializing the expanded form of `log`. 