### PR TITLE
Ensure renames follow through in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Foundational project that contains a full C# representation of ECS. [Learn more.
 
 ## Logging
 
-### [Elasticsearch.Extensions.Logging](src/Elasticsearch.Extensions.Logging/ReadMe.md)
+### [Elastic.Extensions.Logging](src/Elastic.Extensions.Logging/ReadMe.md)
 
 Elastic Stack (ELK) logger provider for `Microsoft.Extensions.Logging`.
 
@@ -76,7 +76,7 @@ Writes direct to Elasticsearch using the Elastic Common Schema, with semantic lo
 This logger provider can be added directly to Microsoft.Extensions.Logging:
 
 ```csharp
-using Elasticsearch.Extensions.Logging;
+using Elastic.Extensions.Logging;
 
 // ...
 

--- a/docs/data-shippers/extensions-logging.asciidoc
+++ b/docs/data-shippers/extensions-logging.asciidoc
@@ -22,7 +22,7 @@ Then, add the provider to the loggingBuilder during host construction, using the
 
 [source,c#]
 ----
-using Elasticsearch.Extensions.Logging;
+using Elastic.Extensions.Logging;
 
 // ...
 
@@ -178,7 +178,7 @@ The `_source` field is the message sent from the LoggerProvider, along with the 
     ],
     "agent": {
       "version": "1.0.0+bd3ad6",
-      "type": "Elasticsearch.Extensions.Logging.LoggerProvider"
+      "type": "Elastic.Extensions.Logging.LoggerProvider"
     },
     "ecs": {
       "version": "1.5.0"
@@ -341,7 +341,7 @@ These identify the version of the logger provider being used.
 |===
 |Field |Type |Description 
 
-|agent.type |string |Name of the logger provider assembly, `Elasticsearch.Extensions.Logging.LoggerProvider`. 
+|agent.type |string |Name of the logger provider assembly, `Elastic.Extensions.Logging.LoggerProvider`. 
 |agent.version |string |Informational version number of the logger assembly, e.g. `1.1.1+bd3ad63`. 
 |ecs.version |string |Version of ECS standard used, currently `1.5`. 
 |===

--- a/docs/data-shippers/serilog.asciidoc
+++ b/docs/data-shippers/serilog.asciidoc
@@ -95,18 +95,18 @@ Will override `trace.id` on the resulting ECS json document.
 
 * `Serilog.Sinks.Elasticsearch` is an amazing community led sink that has a ton of options and works against older Elasticsearch versions `< 8.0`.
 * `Serilog.Sinks.Elasticsearch` is unofficially supported by Elastic with some of the .NET team helping to maintain it.
-* `Elastic.CommonSchema.Serilog.Sink` is *officially* supported by Elastic and was purposely build to adhere to newer best practices around logging, datastreams and ILM.
-* `Elastic.CommonSchema.Serilog.Sink` is purposely build to have fewer configuration options and be more prescriptive than `Serilog.Sinks.Elasticsearch`.
-* That is not to say there aren't plenty of configuration hooks in `Elastic.CommonSchema.Serilog.Sink`
+* `Elastic.Serilog.Sinks` is *officially* supported by Elastic and was purposely build to adhere to newer best practices around logging, datastreams and ILM.
+* `Elastic.Serilog.Sinks` is purposely build to have fewer configuration options and be more prescriptive than `Serilog.Sinks.Elasticsearch`.
+* That is not to say there aren't plenty of configuration hooks in `Elastic.Serilog.Sinks`
 
 ===== Notable absent features:
 
-* `Elastic.CommonSchema.Serilog.Sink` only works with `Elasticsearch 8.x` and up.
+* `Elastic.Serilog.Sinks` only works with `Elasticsearch 8.x` and up.
 * This is because the bootrapping (`BootstrapMethod`) attempts to load templates build for Elasticsearch 8.0 and up.
-* `Elastic.CommonSchema.Serilog.Sink` has only one way it emits data to Elasticsearch confirming to the https://github.com/elastic/ecs-logging[ecs-logging specification]
+* `Elastic.Serilog.Sinks` has only one way it emits data to Elasticsearch confirming to the https://github.com/elastic/ecs-logging[ecs-logging specification]
 * That doesn't mean you can not introduce your own additional properties though.
-* `Elastic.CommonSchema.Serilog.Sink` has no durable mode.
+* `Elastic.Serilog.Sinks` has no durable mode.
 * If you need higher guarantees on log delivery use https://github.com/serilog/serilog-sinks-file[`Serilog.Sinks.File`] with our https://www.nuget.org/packages/Elastic.CommonSchema.Serilog/[ECS log formatter] for Serilog and use https://www.elastic.co/beats/filebeat[filebeat] to ship these logs.
 * Check out {fleet-ref}/fleet-overview.html[Elastic Agent and Fleet] to simplify collecting logs and metrics on the edge.
 
-If you miss a particular feature from `Serilog.Sinks.Elasticsearch` in `Elastic.CommonSchema.Serilog.Sink` please open a https://github.com/elastic/ecs-dotnet/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D[feature request]! We'd love to grow this sink organically moving forward.
+If you miss a particular feature from `Serilog.Sinks.Elasticsearch` in `Elastic.Serilog.Sinks` please open a https://github.com/elastic/ecs-dotnet/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D[feature request]! We'd love to grow this sink organically moving forward.

--- a/examples/console-with-extensions-logging/ReadMe.md
+++ b/examples/console-with-extensions-logging/ReadMe.md
@@ -1,21 +1,21 @@
-# Console example with Elasticsearch.Extensions.Logging 
+# Console example with Elastic.Extensions.Logging 
 
-This example uses a stand alone logger provider, [Elasticsearch.Extensions.Logging](../../src/Elasticsearch.Extensions.Logging), that integrates directly with Microsoft.Extensions.Logging, and uses the Elastic Common Schema library.
+This example uses a stand alone logger provider, [Elastic.Extensions.Logging](../../src/Elastic.Extensions.Logging), that integrates directly with Microsoft.Extensions.Logging, and uses the Elastic Common Schema library.
 
 The example also uses LoggerMessage for [high performance logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage).
 
 ## Usage
 
-Add a reference to the `Elasticsearch.Extensions.Logging` package:
+Add a reference to the `Elastic.Extensions.Logging` package:
 
 ```powershell
-dotnet add package Elasticsearch.Extensions.Logging
+dotnet add package Elastic.Extensions.Logging
 ```
 
 Then, add the provider to the loggingBuilder during host construction, using the namespace and the provided extension method. 
 
 ```c#
-using Elasticsearch.Extensions.Logging;
+using Elastic.Extensions.Logging;
 
 // ...
 
@@ -27,7 +27,7 @@ using Elasticsearch.Extensions.Logging;
 
 The default configuration will write to a local Elasticsearch running at http://localhost:9200/.
 
-For more details on configuration, see [Elasticsearch.Extensions.Logging](../../src/Elasticsearch.Extensions.Logging).
+For more details on configuration, see [Elastic.Extensions.Logging](../../src/Elastic.Extensions.Logging).
 
 ## Running the sample
 
@@ -73,7 +73,7 @@ Document fields follows the Elastic Common Schema standards (using the library),
     ],
     "agent": {
       "version": "1.0.0+bd3ad6",
-      "type": "Elasticsearch.Extensions.Logging.LoggerProvider"
+      "type": "Elastic.Extensions.Logging.LoggerProvider"
     },
     "ecs": {
       "version": "1.5.0"

--- a/src/Elastic.Extensions.Logging/README.md
+++ b/src/Elastic.Extensions.Logging/README.md
@@ -10,16 +10,16 @@ manage the network connection to Elasticsearch.
 
 ## Usage
 
-Add a reference to the `Elasticsearch.Extensions.Logging` package:
+Add a reference to the `Elastic.Extensions.Logging` package:
 
 ```powershell
-dotnet add package Elasticsearch.Extensions.Logging
+dotnet add package Elastic.Extensions.Logging
 ```
 
 Then, add the provider to the loggingBuilder during host construction, using the provided extension method. 
 
 ```c#
-using Elasticsearch.Extensions.Logging;
+using Elastic.Extensions.Logging;
 
 // ...
 
@@ -173,7 +173,7 @@ The `_source` field is the message sent from the LoggerProvider, along with the 
     ],
     "agent": {
       "version": "1.0.0+bd3ad6",
-      "type": "Elasticsearch.Extensions.Logging.LoggerProvider"
+      "type": "Elastic.Extensions.Logging.LoggerProvider"
     },
     "ecs": {
       "version": "1.5.0"
@@ -324,7 +324,7 @@ These identify the version of the logger provider being used.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| agent.type | string | Name of the logger provider assembly, `Elasticsearch.Extensions.Logging.LoggerProvider`. |
+| agent.type | string | Name of the logger provider assembly, `Elastic.Extensions.Logging.LoggerProvider`. |
 | agent.version | string | Informational version number of the logger assembly, e.g. `1.1.1+bd3ad63`. |
 | ecs.version | string | Version of ECS standard used, currently `1.5`. |
 

--- a/src/Elastic.Serilog.Sinks/README.md
+++ b/src/Elastic.Serilog.Sinks/README.md
@@ -1,4 +1,4 @@
-# Elastic.CommonSchema.Serilog.Sink
+# Elastic.Serilog.Sinks
 
 A [Serilog](https://serilog.net/) sink that writes logs directly to [Elasticsearch](https://www.elastic.co/elasticsearch/) or [Elastic Cloud](https://www.elastic.co/cloud/)
 
@@ -71,18 +71,18 @@ Will override `trace.id` on the resulting ECS json document.
 
 * `Serilog.Sinks.Elasticsearch` is an amazing community led sink that has a ton of options and works against older Elasticsearch versions `< 8.0`.
 * `Serilog.Sinks.Elasticsearch` is unofficially supported by Elastic with some of the .NET team helping to maintain it.
-* `Elastic.CommonSchema.Serilog.Sink` is **officially** supported by Elastic and was purposely build to adhere to newer best practices around logging, datastreams and ILM.
-* `Elastic.CommonSchema.Serilog.Sink` is purposely build to have fewer configuration options and be more prescriptive than `Serilog.Sinks.Elasticsearch`.
-  * That is not to say there aren't plenty of configuration hooks in `Elastic.CommonSchema.Serilog.Sink` 
+* `Elastic.Serilog.Sinks` is **officially** supported by Elastic and was purposely build to adhere to newer best practices around logging, datastreams and ILM.
+* `Elastic.Serilog.Sinks` is purposely build to have fewer configuration options and be more prescriptive than `Serilog.Sinks.Elasticsearch`.
+  * That is not to say there aren't plenty of configuration hooks in `Elastic.Serilog.Sinks` 
 
 #### Notable absent features:
-* `Elastic.CommonSchema.Serilog.Sink` only works with `Elasticsearch 8.x` and up. 
+* `Elastic.Serilog.Sinks` only works with `Elasticsearch 8.x` and up. 
   * This is because the bootrapping (`BootstrapMethod`) attempts to load templates build for Elasticsearch 8.0 and up. 
-* `Elastic.CommonSchema.Serilog.Sink` has only one way it emits data to Elasticsearch confirming to the [ecs-logging specification](https://github.com/elastic/ecs-logging)
+* `Elastic.Serilog.Sinks` has only one way it emits data to Elasticsearch confirming to the [ecs-logging specification](https://github.com/elastic/ecs-logging)
   * That doesn't mean you can not introduce your own additional properties though.
-* `Elastic.CommonSchema.Serilog.Sink` has no durable mode. 
+* `Elastic.Serilog.Sinks` has no durable mode. 
   * If you need higher guarantees on log delivery use [`Serilog.Sinks.File`](https://github.com/serilog/serilog-sinks-file) with our [ECS log formatter](https://www.nuget.org/packages/Elastic.CommonSchema.Serilog/) for Serilog and use [filebeat](https://www.elastic.co/beats/filebeat) to ship these logs.
   * Check out [Elastic Agent & Fleet](https://www.elastic.co/guide/en/fleet/current/fleet-overview.html) to simplify collecting logs and metrics on the edge.
 
-If you miss a particular feature from `Serilog.Sinks.Elasticsearch` in `Elastic.CommonSchema.Serilog.Sink` please open a [feature request](https://github.com/elastic/ecs-dotnet/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D)! We'd love to grow this sink organically moving forward.
+If you miss a particular feature from `Serilog.Sinks.Elasticsearch` in `Elastic.Serilog.Sinks` please open a [feature request](https://github.com/elastic/ecs-dotnet/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE%5D)! We'd love to grow this sink organically moving forward.
 


### PR DESCRIPTION
- Rename Elastic.CommonSchema.Serilog.Sink to Elastic.Serilog.Sinks
- Rename Elasticsearch.Extensions.Logging to Elastic.Ext..
