### PR TITLE
Use Convert instead of cast for formatting ElapsedMilliseconds

### DIFF
--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -247,11 +247,10 @@ namespace Elastic.CommonSchema.Serilog
 
 		private static Event GetEvent(LogEvent e)
 		{
-			var elapsedMs = e.TryGetScalarPropertyValue(SpecialKeys.Elapsed, out var elapsed)
-				? elapsed.Value
-				: e.TryGetScalarPropertyValue(SpecialKeys.ElapsedMilliseconds, out elapsed)
-					? elapsed.Value
-					: null;
+			var hasElapsedMs = e.TryGetScalarPropertyValue(SpecialKeys.Elapsed, out var elapsedMsObj)
+				|| e.TryGetScalarPropertyValue(SpecialKeys.ElapsedMilliseconds, out elapsedMsObj);
+
+			var elapsedMs = hasElapsedMs ? (double?)Convert.ToDouble(elapsedMsObj!.Value) : null;
 
 			var evnt = new Event
 			{
@@ -270,7 +269,7 @@ namespace Elastic.CommonSchema.Serilog
 					? long.Parse(actionSev)
 					: (int)e.Level,
 				Timezone = TimeZoneInfo.Local.StandardName,
-				Duration = elapsedMs != null ? (long)((double)elapsedMs * 1000000) : null
+				Duration = elapsedMs != null ? (long)(elapsedMs * 1000000) : null
 			};
 
 			return evnt;

--- a/tests/Elastic.CommonSchema.Serilog.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Serilog.Tests/MessageTests.cs
@@ -128,6 +128,23 @@ namespace Elastic.CommonSchema.Serilog.Tests
 		});
 
 		[Theory]
+		[InlineData("Elapsed")]
+		[InlineData("ElapsedMilliseconds")]
+		public void SeesMessageWithElapsedLongProp(string property) => TestLogger((logger, getLogEvents) =>
+		{
+			logger.Information($"Info {{{property}}}", (long)2);
+
+			var logEvents = getLogEvents();
+			logEvents.Should().HaveCount(1);
+
+			var ecsEvents = ToEcsEvents(logEvents);
+
+			var (_, info) = ecsEvents.First();
+			info.Event.Duration.Should().Be(2000000);
+			info.Metadata.Should().BeNull();
+		});
+
+		[Theory]
 		[InlineData("Method")]
 		[InlineData("RequestMethod")]
 		public void SeesMessageWithMethodProp(string property) => TestLogger((logger, getLogEvents) =>


### PR DESCRIPTION
For a project I'm using [SerilogWeb.Classic](https://github.com/serilog-web/classic) to log HTTP requests. The ECS formatter crashed when it tried to cast `ElapsedMilliseconds` from a message template, because `SerilogWeb.Classic` passed a `long`, while the ECS formatter expected a `double`.

Because the property is boxed, the formatter would crash when trying to cast a boxed `long` to a `double`.

I can't find any specification on the specific type that this property should have, so I figured the formatter should be agnostic about the exact numerical type.