### PR TITLE
NLog EcsLayout - Added support for ProcessThreadName + MessageTemplate

### DIFF
--- a/src/Elastic.CommonSchema.NLog/README.md
+++ b/src/Elastic.CommonSchema.NLog/README.md
@@ -69,8 +69,9 @@ filesystem target and [Elastic Filebeat](https://www.elastic.co/downloads/beats/
   - _ProcessExecutable_ - Default: `${processname:FullName=true}`
   - _ProcessId_ - Default: `${processid}`
   - _ProcessName_ - Default: `${processname:FullName=false}`
-  - _ProcessThreadId_ - Default: `${threadid}`
   - _ProcessTitle_ - Default: `${processinfo:MainWindowTitle}`
+  - _ProcessThreadId_ - Default: `${threadid}`
+  - _ProcessThreadName_ -
 
 * **Server Options**
   -	_ServerAddress_ -
@@ -125,36 +126,46 @@ An example of the output is given below:
 
 ```json
 {
-   "@timestamp":"2020-02-20T16:07:06.7109766+11:00",
-   "log.level":"Info",
-   "message":"Info \"X\" 2.2",
-   "metadata":{
-      "value_x":"X",
-      "some_y":2.2
-   },
-   "ecs":{
-      "version":"1.4.0"
-   },
-   "event":{
-      "severity":6,
-      "timezone":"AUS Eastern Standard Time",
-      "created":"2020-02-20T16:07:06.7109766+11:00"
-   },
-   "host":{
-      "name":"LAPTOP"
-   },
-   "log":{
-      "logger":"Elastic.CommonSchema.NLog",
-      "original":"Info {ValueX} {SomeY}"
-   },
-   "process":{
-      "thread":{
-         "id":17592
-      },
-      "pid":17592,
-      "name":"dotnet",
-      "executable":"C:\\Program Files\\dotnet\\dotnet.exe"
-   }
+  "@timestamp": "2020-02-20T16:07:06.7109766+11:00",
+  "log.level": "Info",
+  "message": "Info \"X\" 2.2",
+  "ecs.version": "8.6.0",
+  "log": {
+    "logger": "Elastic.CommonSchema.NLog.Tests.LogTestsBase",
+  },
+  "labels": {
+    "ValueX": "X",
+    "MessageTemplate": "Info {ValueX} {SomeY} {NotX}"
+  },
+  "agent": {
+    "type": "Elastic.CommonSchema.NLog",
+    "version": "1.6.0"
+  },
+  "event": {
+    "created": "2020-02-20T16:07:06.7109766+11:00",
+    "severity": 6,
+    "timezone": "Romance Standard Time"
+  },
+  "host": {
+    "ip": [ "127.0.0.1" ],
+    "name": "LOCALHOST"
+  },
+  "process": {
+    "executable": "C:\\Program Files\\dotnet\\dotnet.exe",
+    "name": "dotnet",
+    "pid": 17592,
+    "thread.id": 17592,
+    "title": "15.0.0.0"
+  },
+  "server": { "user": { "name": "MyUser" } },
+  "service": {
+    "name": "Elastic.CommonSchema",
+    "type": "dotnet",
+    "version": "1.6.0"
+  },
+  "metadata": {
+    "SomeY": 2.2
+  }
 }
 ```
 

--- a/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
+++ b/src/Elastic.CommonSchema.Serilog/LogEventConverter.cs
@@ -133,7 +133,7 @@ namespace Elastic.CommonSchema.Serilog
 				dict.Add(logEventPropertyValue.Key, PropertyValueToObject(logEventPropertyValue.Value));
 			}
 
-			return dict.Count == 0 ? new MetadataDictionary() : dict;
+			return dict;
 		}
 
 		private static bool PropertyAlreadyMapped(string property)

--- a/src/Elastic.CommonSchema.Serilog/README.md
+++ b/src/Elastic.CommonSchema.Serilog/README.md
@@ -21,13 +21,13 @@ In ASP.NET (core) applications
 ```csharp
 .UseSerilog((ctx, config) =>
 {
-	// Ensure HttpContextAccessor is accessible
-	var httpAccessor = ctx.Configuration.Get<HttpContextAccessor>();
+  // Ensure HttpContextAccessor is accessible
+  var httpAccessor = ctx.Configuration.Get<HttpContextAccessor>();
 
-	config
-		.ReadFrom.Configuration(ctx.Configuration)
-		.Enrich.WithEcsHttpContext(httpAccessor)
-		.WriteTo.Async(a => a.Console(new EcsTextFormatter()));
+  config
+    .ReadFrom.Configuration(ctx.Configuration)
+    .Enrich.WithEcsHttpContext(httpAccessor)
+    .WriteTo.Async(a => a.Console(new EcsTextFormatter()));
 })
 ```
 
@@ -39,23 +39,52 @@ An example of the output is given below:
 {
   "@timestamp": "2019-11-22T14:59:02.5903135+11:00",
   "log.level": "Information",
-  "message": "Log message",
-  "ecs": {
-    "version": "1.4.0"
+  "message": "Info \"X\" 2.2",
+  "ecs.version": "8.6.0",
+  "log": { "logger": "Elastic.CommonSchema.Serilog.Tests.MessageTests" },
+  "labels": {
+    "MessageTemplate": "Info {ValueX} {SomeY}",
+    "ValueX": "X",
+    "ThreadName": ".NET Long Running Task"
+  },
+  "agent": {
+    "type": "Elastic.CommonSchema.Serilog",
+    "version": "1.6.0"
   },
   "event": {
-    "severity": 0,
-    "timezone": "AUS Eastern Standard Time",
-    "created": "2019-11-22T14:59:02.5903135+11:00"
+    "created": "2019-11-22T14:59:02.5903135+11:00",
+    "severity": 2,
+    "timezone": "Romance Standard Time"
   },
-  "log": {
-    "logger": "Elastic.CommonSchema.Serilog"
+  "host": {
+    "os": {
+      "full": "Microsoft Windows 10.0.19045",
+      "platform": "Win32NT",
+      "version": "10.0.19045.0"
+    },
+    "architecture": "X64",
+    "hostname": "LOCALHOST",
+    "name": "LOCALHOST"
   },
   "process": {
-    "thread": {
-      "id": 1
-    },
-    "executable": "System.Threading.ExecutionContext"
+    "name": "dotnet",
+    "pid": 1440,
+    "thread.id": 15,
+    "thread.name": ".NET Long Running Task",
+    "title": ""
+  },
+  "server": { "user": { "name": "MyDomain\\MyUserName" } },
+  "service": {
+    "name": "Elastic.CommonSchema",
+    "type": "dotnet",
+    "version": "1.6.0"
+  },
+  "user": {
+    "domain": "MyDomain",
+    "name": "MyUserName"
+  },
+  "metadata": {
+    "SomeY": 2.2
   }
 }
 ```

--- a/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
@@ -239,10 +239,9 @@ namespace Elastic.CommonSchema.NLog.Tests
 
 				var (json, info) = ecsEvents.First();
 
-				json.Should().Contain("\"labels\":{\"DupKey\":\"LoggerArg\",\"DupKey_1\":\"Mdlc\"}");
 				info.Message.Should().Be("Info \"LoggerArg\"");
-				info.Labels.Should().ContainKey("DupKey");
-				info.Labels.Should().ContainKey("DupKey_1");
+				info.Labels.Should().Contain("DupKey", "LoggerArg");
+				info.Labels.Should().Contain("DupKey_1", "Mdlc");
 
 				var x = info.Labels["DupKey"];
 				x.Should().NotBeNull().And.Be("LoggerArg");


### PR DESCRIPTION
"Original"-field was removed from "Log"-section with #194 . Now trying to restore it as "MessageTemplate" property.

Curious where the recommended place to put the original "MesageTemplate". See also: https://discuss.elastic.co/t/log-original-field-lost-with-upgrade-8-6-1-from-1-5-3/348363

Have tried to follow the Elastic Extensions logging, so "MesageTemplate" becomes additional property. See also: https://www.elastic.co/guide/en/ecs-logging/dotnet/current/extensions-logging-data-shipper.html#_example_document