### PR TITLE
#357 add in dotnet 6 TFM and tweak dependencies

### DIFF
--- a/src/Elastic.CommonSchema/EcsDocument.DefaultService.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.DefaultService.cs
@@ -89,8 +89,10 @@ public partial class EcsDocument
 	}
 
 
-	internal static bool IsMsOrElastic(byte[] array)
+	internal static bool IsMsOrElastic(byte[]? array)
 	{
+		if (array == null) return false;
+
 		var elasticApmToken = new byte[] { 174, 116, 0, 210, 193, 137, 207, 34 };
 		var mscorlibToken = new byte[] { 183, 122, 92, 86, 25, 52, 224, 137 };
 		var systemWebToken = new byte[] { 176, 63, 95, 127, 17, 213, 10, 58 };

--- a/src/Elastic.CommonSchema/EcsDocument.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.cs
@@ -100,11 +100,13 @@ public partial class EcsDocument
 		return ParseOTelResourceAttributes(resourceAttributes);
 	}
 
-	private static IDictionary<string, string> ParseOTelResourceAttributes(string resourceAttributes)
+	private static IDictionary<string, string> ParseOTelResourceAttributes(string? resourceAttributes)
 	{
 		if (string.IsNullOrEmpty(resourceAttributes)) return new Dictionary<string, string>();
 
-		var keyValues = resourceAttributes
+		// Needed to satisfy all TFM's sadly.
+		// ReSharper disable once RedundantSuppressNullableWarningExpression
+		var keyValues = resourceAttributes!
 			.Split(new[] { ',' }, RemoveEmptyEntries)
 			.Select(k => k.Split(new[] { '=' }, 2, RemoveEmptyEntries))
 			.Where(kv => kv.Length == 2)
@@ -125,14 +127,14 @@ public partial class EcsDocument
 		return new Agent { Type = type, Version = version };
 	}
 
-	private static (string, string) GetAssemblyVersion(Assembly assembly)
+	private static (string?, string?) GetAssemblyVersion(Assembly assembly)
 	{
 		var name = assembly.GetName();
 		var type = name.Name;
 		var versionAttribute = assembly.GetCustomAttributes(false)
 			.OfType<AssemblyInformationalVersionAttribute>()
 			.FirstOrDefault();
-		var version = versionAttribute?.InformationalVersion ?? name.Version.ToString();
+		var version = versionAttribute?.InformationalVersion ?? name?.Version?.ToString();
 		return (type, version);
 	}
 
@@ -209,7 +211,7 @@ public partial class EcsDocument
 	private static readonly string UserDomainName = Environment.UserDomainName;
 
 	//Can not cache current thread's identity as it's used for role based security, different threads can have different identities
-	private static User GetUser() => new () { Id = Thread.CurrentPrincipal?.Identity.Name, Name = UserName, Domain = UserDomainName };
+	private static User GetUser() => new () { Id = Thread.CurrentPrincipal?.Identity?.Name, Name = UserName, Domain = UserDomainName };
 
 	private static Error? GetError(Exception? exception)
 	{

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net6.0</TargetFrameworks>
     <Title>Elastic Common Schema (ECS) Types</Title>
     <Description>Maps Elastic Common Schema (ECS) to .NET types including (de)serialization using System.Text.Json</Description>
     <LangVersion>latest</LangVersion>
@@ -10,11 +10,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
     <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net461' OR $(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\NullableExtensions.cs" />

--- a/src/Elastic.CommonSchema/Location.cs
+++ b/src/Elastic.CommonSchema/Location.cs
@@ -55,7 +55,7 @@ namespace Elastic.CommonSchema
 			Longitude.ToString("#0.0#######", CultureInfo.InvariantCulture);
 
 		/// <inheritdoc cref="object.Equals(object)"/>>
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			if (ReferenceEquals(null, obj))
 				return false;

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverterFactory.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverterFactory.cs
@@ -14,10 +14,13 @@ namespace Elastic.CommonSchema.Serialization
 		public override bool CanConvert(Type typeToConvert) => typeof(EcsDocument).IsAssignableFrom(typeToConvert);
 
 		/// <inheritdoc cref="JsonConverterFactory.CreateConverter"/>
-		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
-			typeToConvert == typeof(EcsDocument)
-				? EcsJsonConfiguration.DefaultEcsDocumentJsonConverter
-				// TODO validate this is only called once
-				: (JsonConverter)Activator.CreateInstance(typeof(EcsDocumentJsonConverter<>).MakeGenericType(typeToConvert));
+		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (typeToConvert == typeof(EcsDocument))
+				return EcsJsonConfiguration.DefaultEcsDocumentJsonConverter;
+
+			var instance = Activator.CreateInstance(typeof(EcsDocumentJsonConverter<>).MakeGenericType(typeToConvert));
+			return (JsonConverter)instance!;
+		}
 	}
 }


### PR DESCRIPTION
This adds dotnet 6 as a TFM so that explicit dependencies can be reduced by using framework provided implementations.

closes #357 