### PR TITLE
log4net layout: log latest scope value

### DIFF
--- a/src/Elastic.CommonSchema.Log4net/Elastic.CommonSchema.Log4net.csproj
+++ b/src/Elastic.CommonSchema.Log4net/Elastic.CommonSchema.Log4net.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="2.0.17" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.Log4net/LoggingEventConverter.cs
+++ b/src/Elastic.CommonSchema.Log4net/LoggingEventConverter.cs
@@ -78,14 +78,17 @@ internal static class LoggingEventConverter
 
 			var value = properties[property];
 
-			// use string representation of stacks because:
-			// - if stack is empty then null is returned
-			// - if stack contains one item log4net anyway supports only string values
-			// - if stack contains several items then we need all of them
+			// use latest string representation of the value in the stack
 			if (value is ThreadContextStack tcs)
-				value = tcs.ToString();
+			{
+				var stackValue = tcs.Peek();
+				value = !string.IsNullOrEmpty(stackValue) ? stackValue : null;
+			}
 			else if (value is LogicalThreadContextStack ltcs)
-				value = ltcs.ToString();
+			{
+				var stackValue = ltcs.Peek();
+				value = !string.IsNullOrEmpty(stackValue) ? stackValue : null;
+			}
 
 			if (value != null)
 				metadata[property] = value;

--- a/src/Elastic.CommonSchema.Log4net/README.md
+++ b/src/Elastic.CommonSchema.Log4net/README.md
@@ -45,6 +45,7 @@ is supported and will directly set the appropriate ECS field.
 
 Apart from [mandatory fields](https://www.elastic.co/guide/en/ecs/current/ecs-guidelines.html#_general_guidelines), the output contains additional data:
 
+- `labels` is taken from `metadata` (string and boolean properties)
 - `log.origin.file.name` is taken from `LocationInformation`
 - `log.origin.file.line` is taken from `LocationInformation`
 - `log.origin.function` is taken from `LocationInformation`
@@ -67,21 +68,7 @@ Sample log event output (formatted for readability):
     "@timestamp": "2022-08-28T14:06:28.5121651+02:00",
     "log.level": "INFO",
     "message": "Hi! Welcome to example!",
-    "metadata": {
-        "global_property": "Example",
-        "message_template": "{0}! Welcome to example!"
-        "0": "Hi"
-    },
-    "ecs": {
-        "version": "8.3.1"
-    },
-    "event": {
-        "timezone": "Central European Time",
-        "created": "2022-08-28T14:06:28.5121651+02:00"
-    },
-    "host": {
-        "hostname": "HGU780D3"
-    },
+    "ecs.version": "8.6.0",
     "log": {
         "logger": "Elastic.CommonSchema.Log4net.Example.Program",
         "original": null,
@@ -93,14 +80,46 @@ Sample log event output (formatted for readability):
             "function": "Main"
         }
     },
+    "labels": {
+        "MessageTemplate": "{0}! Welcome to example!"
+        "0": "Hi"
+    },
+    "agent": {
+        "type": "Elastic.CommonSchema.Log4net.Example",
+        "version": "1.0.0.0"
+    },
+    "event": {
+        "created": "2024-04-02T17:43:55.3829964+02:00",
+        "timezone": "W. Europe Standard Time"
+    },
+    "host": {
+        "os": {
+            "full": "Microsoft Windows 10.0.22631",
+            "platform": "Win32NT",
+            "version": "10.0.22631.0"
+        },
+        "architecture": "X64",
+        "hostname": "HGU780D3",
+        "name": "HGU780D3"
+    },
     "process": {
-        "thread": {
-            "id": 1
-        }
+        "name": "Elastic.CommonSchema.Log4net.Example",
+        "pid": 39652,
+        "thread.id": 17,
+        "thread.name": ".NET Long Running Task",
+        "title": ""
     },
     "service": {
         "name": "Elastic.CommonSchema.Log4net.Example",
+        "type": "dotnet",
         "version": "1.0.0.0"
+    },
+    "user": {
+        "domain": "company",
+        "name": "user"
+    },
+    "metadata": {
+        "GlobalAmountProperty": 3.14
     }
 }
 ```

--- a/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
@@ -9,203 +9,180 @@ using log4net;
 using log4net.Core;
 using Xunit;
 
-namespace Elastic.CommonSchema.Log4net.Tests
+namespace Elastic.CommonSchema.Log4net.Tests;
+
+public class MessageTests : LogTestsBase
 {
-	public class MessageTests : LogTestsBase
+	[Fact]
+	public void ToEcs_AnyEvent_PopulatesBaseFields() => TestLogger((log, getLogEvents) =>
 	{
-		[Fact]
-		public void ToEcs_AnyEvent_PopulatesBaseFields() => TestLogger((log, getLogEvents) =>
+		log.Info("DummyText");
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		info.Should().NotBeNull();
+
+		info.Timestamp.Should().BeWithin(TimeSpan.FromSeconds(5));
+		info.Ecs.Version.Should().Be(EcsDocument.Version);
+		info.Message.Should().Be("DummyText");
+	});
+
+	[Fact]
+	public void ToEcs_AnyEvent_PopulatesLogField() => TestLogger((log, getLogEvents) =>
+	{
+		log.Info("DummyText");
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		info.Log.Should().NotBeNull();
+
+		info.Log.Level.Should().Be("INFO");
+		info.Log.Logger.Should().Be(GetType().Name);
+		info.Log.OriginFunction.Should().NotBeNullOrEmpty();
+	});
+
+	[Fact]
+	public void ToEcs_AnyEvent_PopulatesEventField() => TestLogger((log, getLogEvents) =>
+	{
+		log.Info("DummyText");
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		info.Event.Should().NotBeNull();
+		info.Event.Created.Should().BeWithin(TimeSpan.FromSeconds(5));
+		info.Event.Timezone.Should().Be(TimeZoneInfo.Local.StandardName);
+	});
+
+	[Fact]
+	public void ToEcs_AnyEvent_PopulatesProcessField() => TestLogger((log, getLogEvents) =>
+	{
+		var loggingEvent = new LoggingEvent(GetType(), log.Logger.Repository, log.Logger.Name, Level.Info, "DummyText", null);
+		log.Logger.Log(loggingEvent);
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		info.Process.Should().NotBeNull();
+		if (int.TryParse(loggingEvent.ThreadName, out var threadId))
+			info.Process.ThreadId.Should().Be(threadId);
+		else
+			info.Process.ThreadName.Should().Be(loggingEvent.ThreadName);
+	});
+
+	[Fact]
+	public void ToEcs_AnyEvent_PopulatesHostField() => TestLogger((log, getLogEvents) =>
+	{
+		var loggingEvent = new LoggingEvent(GetType(), log.Logger.Repository, log.Logger.Name, Level.Info, "DummyText", null);
+		log.Logger.Log(loggingEvent);
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		info.Host.Should().NotBeNull();
+		var fqdn = loggingEvent.LookupProperty(LoggingEvent.HostNameProperty).ToString();
+		fqdn.Should().NotBeNullOrEmpty();
+		info.Host.Hostname.Should().StartWithEquivalent(fqdn.Split('.', StringSplitOptions.None).First());
+	});
+
+	[Fact]
+	public void ToEcs_EventWithException_PopulatesErrorField() => TestLogger((log, getLogEvents) =>
+	{
+		var innerException = new ArgumentException("Wrong argument");
+		try
 		{
-			log.Info("DummyText");
-
-			var logEvents = getLogEvents();
-			logEvents.Should().HaveCount(1);
-
-			var (_, info) = ToEcsEvents(logEvents).First();
-
-			info.Should().NotBeNull();
-
-			info.Timestamp.Should().BeWithin(TimeSpan.FromSeconds(5));
-			info.Ecs.Version.Should().Be(EcsDocument.Version);
-			info.Message.Should().Be("DummyText");
-		});
-
-		[Fact]
-		public void ToEcs_AnyEvent_PopulatesLogField() => TestLogger((log, getLogEvents) =>
-		{
-			log.Info("DummyText");
-
-			var logEvents = getLogEvents();
-			logEvents.Should().HaveCount(1);
-
-			var (_, info) = ToEcsEvents(logEvents).First();
-
-			info.Log.Should().NotBeNull();
-
-			info.Log.Level.Should().Be("INFO");
-			info.Log.Logger.Should().Be(GetType().Name);
-			info.Log.OriginFunction.Should().NotBeNullOrEmpty();
-		});
-
-		[Fact]
-		public void ToEcs_AnyEvent_PopulatesEventField() => TestLogger((log, getLogEvents) =>
-		{
-			log.Info("DummyText");
-
-			var logEvents = getLogEvents();
-			logEvents.Should().HaveCount(1);
-
-			var (_, info) = ToEcsEvents(logEvents).First();
-
-			info.Event.Should().NotBeNull();
-			info.Event.Created.Should().BeWithin(TimeSpan.FromSeconds(5));
-			info.Event.Timezone.Should().Be(TimeZoneInfo.Local.StandardName);
-		});
-
-		[Fact]
-		public void ToEcs_AnyEvent_PopulatesProcessField() => TestLogger((log, getLogEvents) =>
-		{
-			var loggingEvent = new LoggingEvent(GetType(), log.Logger.Repository, log.Logger.Name, Level.Info, "DummyText", null);
-			log.Logger.Log(loggingEvent);
-
-			var logEvents = getLogEvents();
-			logEvents.Should().HaveCount(1);
-
-			var (_, info) = ToEcsEvents(logEvents).First();
-
-			info.Process.Should().NotBeNull();
-			if (int.TryParse(loggingEvent.ThreadName, out var threadId))
-				info.Process.ThreadId.Should().Be(threadId);
-			else
-				info.Process.ThreadName.Should().Be(loggingEvent.ThreadName);
-		});
-
-		[Fact]
-		public void ToEcs_AnyEvent_PopulatesHostField() => TestLogger((log, getLogEvents) =>
-		{
-			var loggingEvent = new LoggingEvent(GetType(), log.Logger.Repository, log.Logger.Name, Level.Info, "DummyText", null);
-			log.Logger.Log(loggingEvent);
-
-			var logEvents = getLogEvents();
-			logEvents.Should().HaveCount(1);
-
-			var (_, info) = ToEcsEvents(logEvents).First();
-
-			info.Host.Should().NotBeNull();
-			var fqdn = loggingEvent.LookupProperty(LoggingEvent.HostNameProperty).ToString();
-			fqdn.Should().NotBeNullOrEmpty();
-			info.Host.Hostname.Should().StartWith(fqdn.Split('.', StringSplitOptions.None).First());
-		});
-
-		[Fact]
-		public void ToEcs_EventWithException_PopulatesErrorField() => TestLogger((log, getLogEvents) =>
-		{
-			var innerException = new ArgumentException("Wrong argument");
 			try
 			{
-				try
-				{
-					throw innerException;
-				}
-				catch (Exception e)
-				{
-					throw new InvalidOperationException("Oops", e);
-				}
+				throw innerException;
 			}
 			catch (Exception e)
 			{
-				log.Info("DummyText", e);
-
-				var logEvents = getLogEvents();
-				logEvents.Should().HaveCount(1);
-
-				var (_, info) = ToEcsEvents(logEvents).First();
-
-				info.Error.Should().NotBeNull();
-				info.Error.Message.Should().Be(e.Message);
-				info.Error.Type.Should().Be(e.GetType().FullName);
-
-				info.Error.StackTrace.Should().Contain(e.Message);
-				info.Error.StackTrace.Should().Contain("at void");
-
-				info.Error.StackTrace.Should().Contain(innerException.Message);
-				info.Error.StackTrace.Should().Contain("at void");
+				throw new InvalidOperationException("Oops", e);
 			}
-		});
-
-		[Fact]
-		public void ToEcs_EventWithFormat_MetadataContainsTemplateAndArgs() => TestLogger((log, getLogEvents) =>
+		}
+		catch (Exception e)
 		{
-			log.InfoFormat("Log with {0}", "format");
+			log.Info("DummyText", e);
 
 			var logEvents = getLogEvents();
 			logEvents.Should().HaveCount(1);
 
 			var (_, info) = ToEcsEvents(logEvents).First();
 
-			info.Should().NotBeNull();
-			info.Labels.Should().NotBeNull();
+			info.Error.Should().NotBeNull();
+			info.Error.Message.Should().Be(e.Message);
+			info.Error.Type.Should().Be(e.GetType().FullName);
 
-			info.Labels["MessageTemplate"].Should().Be("Log with {0}");
-			info.Labels["0"].Should().Be("format");
-		});
+			info.Error.StackTrace.Should().Contain(e.Message);
+			info.Error.StackTrace.Should().Contain("at void");
 
-		[Fact]
-		public void ToEcs_AnyEvent_PopulatesMetadataFieldWithoutLog4netProperties() => TestLogger((log, getLogEvents) =>
+			info.Error.StackTrace.Should().Contain(innerException.Message);
+			info.Error.StackTrace.Should().Contain("at void");
+		}
+	});
+
+	[Fact]
+	public void ToEcs_EventWithFormat_MetadataContainsTemplateAndArgs() => TestLogger((log, getLogEvents) =>
+	{
+		log.InfoFormat("Log with {0}", "format");
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		info.Should().NotBeNull();
+		info.Labels.Should().NotBeNull();
+
+		info.Labels["MessageTemplate"].Should().Be("Log with {0}");
+		info.Labels["0"].Should().Be("format");
+	});
+
+	[Fact]
+	public void ToEcs_AnyEvent_PopulatesMetadataFieldWithoutLog4netProperties() => TestLogger((log, getLogEvents) =>
+	{
+		log.Info("DummyText");
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		if (info.Metadata != null)
 		{
-			log.Info("DummyText");
-
-			var logEvents = getLogEvents();
-			logEvents.Should().HaveCount(1);
-
-			var (_, info) = ToEcsEvents(logEvents).First();
-
-			if (info.Metadata != null)
-			{
-				info.Metadata.Should().NotContainKey(LoggingEvent.IdentityProperty);
-				info.Metadata.Should().NotContainKey(LoggingEvent.HostNameProperty);
-				info.Metadata.Should().NotContainKey(LoggingEvent.UserNameProperty);
-			}
-			if (info.Labels != null)
-			{
-				info.Labels.Should().NotContainKey(LoggingEvent.IdentityProperty);
-				info.Labels.Should().NotContainKey(LoggingEvent.HostNameProperty);
-				info.Labels.Should().NotContainKey(LoggingEvent.UserNameProperty);
-			}
-		});
-
-		[Fact]
-		public void ToEcs_EventWithGlobalContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+			info.Metadata.Should().NotContainKey(LoggingEvent.IdentityProperty);
+			info.Metadata.Should().NotContainKey(LoggingEvent.HostNameProperty);
+			info.Metadata.Should().NotContainKey(LoggingEvent.UserNameProperty);
+		}
+		if (info.Labels != null)
 		{
-			const string property = "global-prop";
-			const string propertyValue = "global-value";
-			GlobalContext.Properties[property] = propertyValue;
+			info.Labels.Should().NotContainKey(LoggingEvent.IdentityProperty);
+			info.Labels.Should().NotContainKey(LoggingEvent.HostNameProperty);
+			info.Labels.Should().NotContainKey(LoggingEvent.UserNameProperty);
+		}
+	});
 
-			try
-			{
-				log.Info("DummyText");
+	[Fact]
+	public void ToEcs_EventWithGlobalContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	{
+		const string property = "global-prop";
+		const string propertyValue = "global-value";
+		GlobalContext.Properties[property] = propertyValue;
 
-				var logEvents = getLogEvents();
-				logEvents.Should().HaveCount(1);
-
-				var (_, info) = ToEcsEvents(logEvents).First();
-
-				info.Labels.Should().ContainKey(property);
-				info.Labels[property].Should().Be(propertyValue);
-			}
-			finally
-			{
-				GlobalContext.Properties.Remove(property);
-			}
-		});
-
-		[Fact]
-		public void ToEcs_EventWithThreadContextStack_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+		try
 		{
-			const string property = "thread-context-stack-prop";
-			const string propertyValue = "thread-context-stack-value";
-			using var _ = ThreadContext.Stacks[property].Push(propertyValue);
-
 			log.Info("DummyText");
 
 			var logEvents = getLogEvents();
@@ -215,40 +192,40 @@ namespace Elastic.CommonSchema.Log4net.Tests
 
 			info.Labels.Should().ContainKey(property);
 			info.Labels[property].Should().Be(propertyValue);
-		});
-
-		[Fact]
-		public void ToEcs_EventWithThreadContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+		}
+		finally
 		{
-			const string property = "thread-context-prop";
-			const string propertyValue = "thread-context-value";
-			ThreadContext.Properties[property] = propertyValue;
+			GlobalContext.Properties.Remove(property);
+		}
+	});
 
-			try
-			{
-				log.Info("DummyText");
+	[Fact]
+	public void ToEcs_EventWithThreadContextStack_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	{
+		const string property = "thread-context-stack-prop";
+		const string propertyValue = "thread-context-stack-value";
+		using var _ = ThreadContext.Stacks[property].Push(propertyValue);
 
-				var logEvents = getLogEvents();
-				logEvents.Should().HaveCount(1);
+		log.Info("DummyText");
 
-				var (_, info) = ToEcsEvents(logEvents).First();
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
 
-				info.Labels.Should().ContainKey(property);
-				info.Labels[property].Should().Be(propertyValue);
-			}
-			finally
-			{
-				ThreadContext.Properties.Remove(property);
-			}
-		});
+		var (_, info) = ToEcsEvents(logEvents).First();
 
-		[Fact]
-		public void ToEcs_EventInLogicalThreadContextStack_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+		info.Labels.Should().ContainKey(property);
+		info.Labels[property].Should().Be(propertyValue);
+	});
+
+	[Fact]
+	public void ToEcs_EventWithThreadContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	{
+		const string property = "thread-context-prop";
+		const string propertyValue = "thread-context-value";
+		ThreadContext.Properties[property] = propertyValue;
+
+		try
 		{
-			const string property = "logical-thread-context-stack-prop";
-			const string propertyValue = "logical-thread-context-stack-value";
-			using var _ = LogicalThreadContext.Stacks[property].Push(propertyValue);
-
 			log.Info("DummyText");
 
 			var logEvents = getLogEvents();
@@ -256,51 +233,48 @@ namespace Elastic.CommonSchema.Log4net.Tests
 
 			var (_, info) = ToEcsEvents(logEvents).First();
 
-			info.Metadata.Should().BeNull();
-			info.Labels.Should().NotBeNull();
-
 			info.Labels.Should().ContainKey(property);
 			info.Labels[property].Should().Be(propertyValue);
-		});
-
-		[Fact]
-		public void ToEcs_EventWithLogicalThreadContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+		}
+		finally
 		{
-			const string property = "logical-thread-context-prop";
-			const string propertyValue = "logical-thread-context-value";
-			const string metadataProperty = "logical-thread-context-prop-metadata";
-			LogicalThreadContext.Properties[property] = propertyValue;
-			LogicalThreadContext.Properties[metadataProperty] = 2.0;
+			ThreadContext.Properties.Remove(property);
+		}
+	});
 
-			try
-			{
-				log.Info("DummyText");
+	[Fact]
+	public void ToEcs_EventInLogicalThreadContextStack_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	{
+		const string property = "logical-thread-context-stack-prop";
+		const string propertyValue = "logical-thread-context-stack-value";
+		using var _ = LogicalThreadContext.Stacks[property].Push(propertyValue);
 
-				var logEvents = getLogEvents();
-				logEvents.Should().HaveCount(1);
+		log.Info("DummyText");
 
-				var (_, info) = ToEcsEvents(logEvents).First();
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
 
-				info.Labels.Should().ContainKey(property);
-				info.Labels[property].Should().Be(propertyValue);
-				info.Metadata.Should().ContainKey(metadataProperty);
-				info.Metadata[metadataProperty].Should().Be(2.0);
-			}
-			finally
-			{
-				LogicalThreadContext.Properties.Remove(property);
-			}
-		});
+		var (_, info) = ToEcsEvents(logEvents).First();
 
-		[Fact]
-		public void ToEcs_EventWithProperties_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+		info.Metadata.Should().BeNull();
+		info.Labels.Should().NotBeNull();
+
+		info.Labels.Should().ContainKey(property);
+		info.Labels[property].Should().Be(propertyValue);
+	});
+
+	[Fact]
+	public void ToEcs_EventWithLogicalThreadContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	{
+		const string property = "logical-thread-context-prop";
+		const string propertyValue = "logical-thread-context-value";
+		const string metadataProperty = "logical-thread-context-prop-metadata";
+		LogicalThreadContext.Properties[property] = propertyValue;
+		LogicalThreadContext.Properties[metadataProperty] = 2.0;
+
+		try
 		{
-			const string property = "additional-prop";
-			const string propertyValue = "additional-value";
-
-			var loggingEvent = new LoggingEvent(GetType(), log.Logger.Repository, log.Logger.Name, Level.Info, "DummyText", null);
-			loggingEvent.Properties[property] = propertyValue;
-			log.Logger.Log(loggingEvent);
+			log.Info("DummyText");
 
 			var logEvents = getLogEvents();
 			logEvents.Should().HaveCount(1);
@@ -309,6 +283,31 @@ namespace Elastic.CommonSchema.Log4net.Tests
 
 			info.Labels.Should().ContainKey(property);
 			info.Labels[property].Should().Be(propertyValue);
-		});
-	}
+			info.Metadata.Should().ContainKey(metadataProperty);
+			info.Metadata[metadataProperty].Should().Be(2.0);
+		}
+		finally
+		{
+			LogicalThreadContext.Properties.Remove(property);
+		}
+	});
+
+	[Fact]
+	public void ToEcs_EventWithProperties_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	{
+		const string property = "additional-prop";
+		const string propertyValue = "additional-value";
+
+		var loggingEvent = new LoggingEvent(GetType(), log.Logger.Repository, log.Logger.Name, Level.Info, "DummyText", null);
+		loggingEvent.Properties[property] = propertyValue;
+		log.Logger.Log(loggingEvent);
+
+		var logEvents = getLogEvents();
+		logEvents.Should().HaveCount(1);
+
+		var (_, info) = ToEcsEvents(logEvents).First();
+
+		info.Labels.Should().ContainKey(property);
+		info.Labels[property].Should().Be(propertyValue);
+	});
 }

--- a/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
@@ -134,7 +134,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_EventWithFormat_MetadataContainsTemplateAndArgs() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_EventWithFormat_LabelsContainTemplateAndArgs() => TestLogger((log, getLogEvents) =>
 	{
 		log.InfoFormat("Log with {0}", "format");
 
@@ -151,7 +151,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_AnyEvent_PopulatesMetadataFieldWithoutLog4netProperties() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_AnyEvent_PopulatesMetadataAndLabelsFieldsWithoutLog4netProperties() => TestLogger((log, getLogEvents) =>
 	{
 		log.Info("DummyText");
 
@@ -175,7 +175,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_EventWithGlobalContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_EventWithGlobalContextProperty_PopulatesLabelsField() => TestLogger((log, getLogEvents) =>
 	{
 		const string property = "global-prop";
 		const string propertyValue = "global-value";
@@ -200,7 +200,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_EventWithThreadContextStack_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_EventWithThreadContextStack_PopulatesLabelsField() => TestLogger((log, getLogEvents) =>
 	{
 		const string property = "thread-context-stack-prop";
 		const string propertyValue = "thread-context-stack-value";
@@ -218,7 +218,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_EventWithThreadContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_EventWithThreadContextProperty_PopulatesLabelsField() => TestLogger((log, getLogEvents) =>
 	{
 		const string property = "thread-context-prop";
 		const string propertyValue = "thread-context-value";
@@ -243,7 +243,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_EventInLogicalThreadContextStack_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_EventInLogicalThreadContextStack_PopulatesLabelsField() => TestLogger((log, getLogEvents) =>
 	{
 		const string property = "logical-thread-context-stack-prop";
 		const string propertyValue = "logical-thread-context-stack-value";
@@ -264,7 +264,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_EventWithLogicalThreadContextProperty_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_EventWithLogicalThreadContextProperty_PopulatesLabelsAndMetadataFields() => TestLogger((log, getLogEvents) =>
 	{
 		const string property = "logical-thread-context-prop";
 		const string propertyValue = "logical-thread-context-value";
@@ -293,7 +293,7 @@ public class MessageTests : LogTestsBase
 	});
 
 	[Fact]
-	public void ToEcs_EventWithProperties_PopulatesMetadataField() => TestLogger((log, getLogEvents) =>
+	public void ToEcs_EventWithProperties_PopulatesLabelsField() => TestLogger((log, getLogEvents) =>
 	{
 		const string property = "additional-prop";
 		const string propertyValue = "additional-value";


### PR DESCRIPTION
**Motivation**
If a property is added to the log scope multiple times, currently all its values are logged in metadata/labels. This is how log4net also behaves but in most of the cases it is undesired behavior. Only latest property value should be included (e.g., Serilog behaves the same way).

Example:
```cs
using (LogicalThreadContext.Stacks["Id"].Push("123"))
{
    log.Info("Log 1"); // currently has "123" in the log metadata

    using (LogicalThreadContext.Stacks["Id"].Push("456"))
    {
        log.Info("Log 2"); // currently has "123 456" in the log metadata; should have "456" instead

        using (LogicalThreadContext.Stacks["Id"].Push("789"))
        {
            log.Info("Log 3"); // currently has "123 456 789" in the log metadata; should have "789" instead
        }
    }
}
```

**Breaking change:** yes (comparing to how log4net behaves by default)

**Changes**
- Log latest property value
- Update to the latest log4net version (2.0.17), this is required to use [`Peek()` method](https://github.com/apache/logging-log4net/pull/101)
- Update test names
- Use file-scoped namespaces
- Update readme to reflect the latest version of generated events