### PR TITLE
Update to latest ingest libraries

### DIFF
--- a/ecs-dotnet.sln
+++ b/ecs-dotnet.sln
@@ -125,6 +125,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "docs", "docs\docs.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aspnetcore-with-extensions-logging", "examples\aspnetcore-with-extensions-logging\aspnetcore-with-extensions-logging.csproj", "{D866F335-BC19-49A8-AF72-4BA66CC7AFFB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "playground", "examples\playground\playground.csproj", "{86AEB76A-C210-4250-8541-B349C26C1683}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -259,6 +261,10 @@ Global
 		{D866F335-BC19-49A8-AF72-4BA66CC7AFFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D866F335-BC19-49A8-AF72-4BA66CC7AFFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D866F335-BC19-49A8-AF72-4BA66CC7AFFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86AEB76A-C210-4250-8541-B349C26C1683}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86AEB76A-C210-4250-8541-B349C26C1683}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86AEB76A-C210-4250-8541-B349C26C1683}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86AEB76A-C210-4250-8541-B349C26C1683}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -298,6 +304,7 @@ Global
 		{EC19A9E1-79CC-46A8-94D7-EE66ED22D3BD} = {B268060B-83ED-4944-B135-C362DFCBFC0C}
 		{1CAEFBD7-B800-41C4-81D3-CB6839FA563D} = {05075402-8669-45BD-913A-BD40A29BBEAB}
 		{D866F335-BC19-49A8-AF72-4BA66CC7AFFB} = {05075402-8669-45BD-913A-BD40A29BBEAB}
+		{86AEB76A-C210-4250-8541-B349C26C1683} = {05075402-8669-45BD-913A-BD40A29BBEAB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/examples/playground/Program.cs
+++ b/examples/playground/Program.cs
@@ -1,0 +1,123 @@
+﻿using Elastic.Channels;
+using Elastic.CommonSchema;
+using Elastic.Elasticsearch.Ephemeral;
+using Elastic.Ingest.Elasticsearch;
+using Elastic.Ingest.Elasticsearch.CommonSchema;
+using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Serilog.Sinks;
+using Elastic.Transport;
+using Serilog;
+using Serilog.Events;
+using Log = Serilog.Log;
+
+var testSerilog = true;
+
+var random = new Random();
+var ctxs = new CancellationTokenSource();
+var parallelOpts = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, CancellationToken = ctxs.Token };
+const int numDocs = 1_000_000;
+var bufferOptions = new BufferOptions { };
+var config = new EphemeralClusterConfiguration("8.13.0");
+using var cluster = new EphemeralCluster(config);
+using var channel = SetupElasticsearchChannel();
+
+Console.CancelKeyPress += (sender, eventArgs) =>
+{
+	ctxs.Cancel();
+	cluster.Dispose();
+	eventArgs.Cancel = true;
+};
+
+
+using var started = cluster.Start();
+
+if (testSerilog)
+	await PushToSerilog();
+else
+	await PushToChannel(channel);
+
+Console.WriteLine($"Press any key...");
+Console.ReadKey();
+
+
+async Task PushToSerilog()
+{
+	SetupSerilog();
+
+	Parallel.For(0, numDocs, parallelOpts, i =>
+	{
+		var randomData = $"Logging information {i} - Random value: {random.NextDouble()}";
+		Log.Information(randomData);
+	});
+
+	/*
+	foreach (var i in Enumerable.Range(0, numDocs))
+	{
+		var randomData = $"Logging information {i} - Random value: {random.NextDouble()}";
+		Log.Information(randomData);
+	}
+	*/
+
+	Log.CloseAndFlush();
+	await Task.Delay(TimeSpan.FromMinutes(1), ctxs.Token);
+
+	void SetupSerilog()
+	{
+		Serilog.Debugging.SelfLog.Enable(s => Console.WriteLine(s));
+		Log.Logger = new LoggerConfiguration()
+			.WriteTo.Elasticsearch(new[] { new Uri("http://localhost:9200") }, o =>
+			{
+				o.ConfigureChannel = c =>
+				{
+					c.BufferOptions = bufferOptions;
+				};
+				o.BootstrapMethod = BootstrapMethod.Failure;
+				o.MinimumLevel = LogEventLevel.Verbose;
+				o.DataStream = new DataStreamName("logs");
+			})
+			.CreateLogger();
+	}
+}
+
+
+async Task PushToChannel(EcsDataStreamChannel<EcsDocument> c)
+{
+	if (c == null) throw new ArgumentNullException(nameof(c));
+
+	await c.BootstrapElasticsearchAsync(BootstrapMethod.Failure);
+
+	foreach (var i in Enumerable.Range(0, numDocs))
+		await DoChannelWrite(i, ctxs.Token);
+
+	/*
+	await Parallel.ForEachAsync(Enumerable.Range(0, numDocs), parallelOpts, async (i, ctx) =>
+	{
+		await DoChannelWrite(i, ctx);
+	});
+	*/
+
+
+	async Task DoChannelWrite(int i, CancellationToken cancellationToken)
+	{
+		var message = $"Logging information {i} - Random value: {random.NextDouble()}";
+		var doc = EcsDocument.CreateNewWithDefaults<EcsDocument>();
+		doc.Message = message;
+		if (await c.WaitToWriteAsync(cancellationToken) && c.TryWrite(doc))
+			return;
+
+		Console.WriteLine("Failed To write");
+		await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+	}
+}
+
+EcsDataStreamChannel<EcsDocument> SetupElasticsearchChannel()
+{
+	var transportConfiguration = new TransportConfiguration(new Uri("http://localhost:9200"));
+	var c = new EcsDataStreamChannel<EcsDocument>(
+		new DataStreamChannelOptions<EcsDocument>(new DistributedTransport(transportConfiguration))
+		{
+			BufferOptions = bufferOptions
+		});
+
+	return c;
+}

--- a/examples/playground/playground.csproj
+++ b/examples/playground/playground.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Elastic.Serilog.Sinks\Elastic.Serilog.Sinks.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Elastic.Elasticsearch.Ephemeral" Version="0.5.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
+++ b/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.6.0" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.7.0" />
   </ItemGroup>
 
 </Project>

--- a/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
+++ b/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" />
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.3" />
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.6.0" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.7.0" />
 
   </ItemGroup>
 


### PR DESCRIPTION
This brings in the latest improvements from https://github.com/elastic/elastic-ingest-dotnet

https://github.com/elastic/elastic-ingest-dotnet/pull/53
https://github.com/elastic/elastic-ingest-dotnet/pull/52

Ensure we act way nicer when logging in a very tight loop. 

<img width="1134" alt="image" src="https://github.com/elastic/ecs-dotnet/assets/245275/1c0e37b5-99ee-4543-b1d5-88852cb3ebc1">


<img width="1134" alt="image" src="https://github.com/elastic/ecs-dotnet/assets/245275/8039657d-bbcf-4c86-96fa-7f9879eec986">

This fixes #341 

As noted on: https://github.com/elastic/elastic-ingest-dotnet/pull/54#issuecomment-2045438105

The defaults scenarios still have 'high' gen2 allocations but they are all owned by the TlsOverPerCoreLockedStacksArrayPool backing the System.Channels BoundedBuffer.

Unsure if there is anything we can do to control it.

See e.g this proposal to .NET https://github.com/dotnet/runtime/issues/53895