### PR TITLE
github-action: fix permissions

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   DOTNET_VERSION: '6.0.400'
@@ -15,8 +14,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: write
+      id-token: write
+      packages: write
     steps:
     - uses: actions/checkout@v4
     - name: Bootstrap Action Workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,15 @@ on:
   #  tags: [ '[0-9]+.[0-9]+.[0-9]+.*' ]
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
+      issues: write
     steps:
     - uses: actions/checkout@v4
     - name: Bootstrap Action Workspace


### PR DESCRIPTION
Top-level permissions are not honoured when job-level permissions are set. Hence, use read top-level permission and apply the job-level permissions that are required