### PR TITLE
Skip ActivityData capture for NLog, since doing Layout capture

### DIFF
--- a/src/Elastic.CommonSchema.NLog/ActivityExtensions.cs
+++ b/src/Elastic.CommonSchema.NLog/ActivityExtensions.cs
@@ -7,29 +7,23 @@ namespace Elastic.CommonSchema.NLog
 	/// </summary>
 	internal static class ActivityExtensions
 	{
-		private static readonly System.Diagnostics.ActivitySpanId EmptySpanId = default(System.Diagnostics.ActivitySpanId);
-		private static readonly System.Diagnostics.ActivityTraceId EmptyTraceId = default(System.Diagnostics.ActivityTraceId);
+		private static readonly ActivitySpanId EmptySpanId = default;
+		private static readonly ActivityTraceId EmptyTraceId = default;
 
-		public static string GetSpanId(this Activity activity)
-		{
-			return activity.IdFormat == ActivityIdFormat.W3C ?
+		public static string GetSpanId(this Activity activity) =>
+			activity.IdFormat == ActivityIdFormat.W3C ?
 				SpanIdToHexString(activity.SpanId) :
 				activity.Id;
-		}
 
-		public static string GetTraceId(this Activity activity)
-		{
-			return activity.IdFormat == ActivityIdFormat.W3C ?
+		public static string GetTraceId(this Activity activity) =>
+			activity.IdFormat == ActivityIdFormat.W3C ?
 				TraceIdToHexString(activity.TraceId) :
 				activity.RootId;
-		}
 
-		public static string GetParentId(this Activity activity)
-		{
-			return activity.IdFormat == ActivityIdFormat.W3C ?
+		public static string GetParentId(this Activity activity) =>
+			activity.IdFormat == ActivityIdFormat.W3C ?
 				SpanIdToHexString(activity.ParentSpanId) :
 				activity.ParentId;
-		}
 
 		private static string SpanIdToHexString(ActivitySpanId spanId)
 		{
@@ -49,10 +43,9 @@ namespace Elastic.CommonSchema.NLog
 				return string.Empty;
 
 			var traceHexString = traceId.ToHexString();
-			if (ReferenceEquals(traceHexString, EmptyTraceId.ToHexString()))
-				return string.Empty;
-
-			return traceHexString;
+			return ReferenceEquals(traceHexString, EmptyTraceId.ToHexString())
+				? string.Empty
+				: traceHexString;
 		}
 	}
 }

--- a/src/Elastic.CommonSchema.NLog/ActivityExtensions.cs
+++ b/src/Elastic.CommonSchema.NLog/ActivityExtensions.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+
+namespace Elastic.CommonSchema.NLog
+{
+	/// <summary>
+	/// Helpers for getting the right values from Activity no matter the format (w3c or hierarchical)
+	/// </summary>
+	internal static class ActivityExtensions
+	{
+		private static readonly System.Diagnostics.ActivitySpanId EmptySpanId = default(System.Diagnostics.ActivitySpanId);
+		private static readonly System.Diagnostics.ActivityTraceId EmptyTraceId = default(System.Diagnostics.ActivityTraceId);
+
+		public static string GetSpanId(this Activity activity)
+		{
+			return activity.IdFormat == ActivityIdFormat.W3C ?
+				SpanIdToHexString(activity.SpanId) :
+				activity.Id;
+		}
+
+		public static string GetTraceId(this Activity activity)
+		{
+			return activity.IdFormat == ActivityIdFormat.W3C ?
+				TraceIdToHexString(activity.TraceId) :
+				activity.RootId;
+		}
+
+		public static string GetParentId(this Activity activity)
+		{
+			return activity.IdFormat == ActivityIdFormat.W3C ?
+				SpanIdToHexString(activity.ParentSpanId) :
+				activity.ParentId;
+		}
+
+		private static string SpanIdToHexString(ActivitySpanId spanId)
+		{
+			if (EmptySpanId.Equals(spanId))
+				return string.Empty;
+
+			var spanHexString = spanId.ToHexString();
+			if (ReferenceEquals(spanHexString, EmptySpanId.ToHexString()))
+				return string.Empty;
+
+			return spanHexString;
+		}
+
+		private static string TraceIdToHexString(ActivityTraceId traceId)
+		{
+			if (EmptyTraceId.Equals(traceId))
+				return string.Empty;
+
+			var traceHexString = traceId.ToHexString();
+			if (ReferenceEquals(traceHexString, EmptyTraceId.ToHexString()))
+				return string.Empty;
+
+			return traceHexString;
+		}
+	}
+}

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -147,11 +148,11 @@ namespace Elastic.CommonSchema.NLog
 
 		// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 		/// <inheritdoc cref="BaseFieldSet.TraceId"/>
-		public Layout ApmTraceId { get; set; } = Layout.FromMethod(() => ResolveTraceId());
+		public Layout ApmTraceId { get; set; } = FromMethod(_ => ResolveTraceId());
 		/// <inheritdoc cref="BaseFieldSet.TransactionId"/>
 		public Layout ApmTransactionId { get; set; }
 		/// <inheritdoc cref="BaseFieldSet.SpanId"/>
-		public Layout ApmSpanId { get; set; } = Layout.FromMethod(() => ResolveSpanId());
+		public Layout ApmSpanId { get; set; } = FromMethod(_ => ResolveSpanId());
 
 		/// <inheritdoc cref="ServiceFieldSet.Name"/>
 		public Layout ApmServiceName { get; set; }
@@ -776,15 +777,9 @@ namespace Elastic.CommonSchema.NLog
 			propertyBag.Add(usedKey, value);
 		}
 
-		private static string ResolveTraceId()
-		{
-			return System.Diagnostics.Activity.Current?.GetTraceId();
-		}
+		private static string ResolveTraceId() => Activity.Current?.GetTraceId();
 
-		private static string ResolveSpanId()
-		{
-			return System.Diagnostics.Activity.Current?.GetSpanId();
-		}
+		private static string ResolveSpanId() => Activity.Current?.GetSpanId();
 
 		/// <summary>
 		/// A subclass of <see cref="EcsDocument"/> that adds additional properties related to Extensions logging.

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -21,6 +21,7 @@ namespace Elastic.CommonSchema.NLog
 		public bool IncludeHost { get; set; } = false;
 		public bool IncludeProcess { get; set; } = false;
 		public bool IncludeUser { get; set; } = false;
+		public bool IncludeTraceId { get; set; } = false;
 	}
 
 	/// <summary> An NLOG layout implementation that renders logs as ECS json</summary>
@@ -146,11 +147,11 @@ namespace Elastic.CommonSchema.NLog
 
 		// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 		/// <inheritdoc cref="BaseFieldSet.TraceId"/>
-		public Layout ApmTraceId { get; set; }
+		public Layout ApmTraceId { get; set; } = Layout.FromMethod(() => ResolveTraceId());
 		/// <inheritdoc cref="BaseFieldSet.TransactionId"/>
 		public Layout ApmTransactionId { get; set; }
 		/// <inheritdoc cref="BaseFieldSet.SpanId"/>
-		public Layout ApmSpanId { get; set; }
+		public Layout ApmSpanId { get; set; } = Layout.FromMethod(() => ResolveSpanId());
 
 		/// <inheritdoc cref="ServiceFieldSet.Name"/>
 		public Layout ApmServiceName { get; set; }
@@ -773,6 +774,16 @@ namespace Elastic.CommonSchema.NLog
 			}
 
 			propertyBag.Add(usedKey, value);
+		}
+
+		private static string ResolveTraceId()
+		{
+			return System.Diagnostics.Activity.Current?.GetTraceId();
+		}
+
+		private static string ResolveSpanId()
+		{
+			return System.Diagnostics.Activity.Current?.GetSpanId();
 		}
 
 		/// <summary>

--- a/src/Elastic.CommonSchema.Serilog/EcsTextFormatterConfiguration.cs
+++ b/src/Elastic.CommonSchema.Serilog/EcsTextFormatterConfiguration.cs
@@ -57,6 +57,9 @@ namespace Elastic.CommonSchema.Serilog
 		/// <inheritdoc cref="IEcsDocumentCreationOptions.IncludeUser"/>
 		public bool IncludeUser { get; set; } = true;
 
+		/// <inheritdoc cref="IEcsDocumentCreationOptions.IncludeTraceId"/>
+		public bool IncludeTraceId { get; set; } = true;
+
 		/// <inheritdoc cref="IEcsTextFormatterConfiguration.MapHttpAdapter"/>
 		public IHttpAdapter? MapHttpAdapter { get; set; }
 

--- a/src/Elastic.CommonSchema/EcsDocument.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.cs
@@ -95,9 +95,7 @@ public partial class EcsDocument
 		if (options?.IncludeProcess is null or true) doc.Process = GetProcess(initialCache);
 		if (options?.IncludeUser is null or true) doc.User = GetUser();
 		if (options?.IncludeTraceId is null or true)
-		{
 			SetActivityData(doc);
-		}
 
 		return doc;
 	}

--- a/src/Elastic.CommonSchema/EcsDocument.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.cs
@@ -34,6 +34,11 @@ public interface IEcsDocumentCreationOptions
 	/// Gets or sets a flag indicating whether user details should be included in the message. Defaults to <c>true</c>.
 	/// </summary>
 	bool IncludeUser { get; set; }
+
+	/// <summary>
+	/// Gets or sets a flag indicating whether TraceId/SpanId should be included in the message. Defaults to <c>true</c>.
+	/// </summary>
+	bool IncludeTraceId { get; set; }
 }
 
 /// <summary>
@@ -85,11 +90,14 @@ public partial class EcsDocument
 			Error = GetError(exception),
 			Service = GetService(initialCache)
 		};
-		SetActivityData(doc);
 
 		if (options?.IncludeHost is null or true) doc.Host = GetHost(initialCache);
 		if (options?.IncludeProcess is null or true) doc.Process = GetProcess(initialCache);
 		if (options?.IncludeUser is null or true) doc.User = GetUser();
+		if (options?.IncludeTraceId is null or true)
+		{
+			SetActivityData(doc);
+		}
 
 		return doc;
 	}

--- a/src/Elastic.Extensions.Logging/Options/ElasticsearchLoggerOptions.cs
+++ b/src/Elastic.Extensions.Logging/Options/ElasticsearchLoggerOptions.cs
@@ -30,6 +30,11 @@ namespace Elastic.Extensions.Logging.Options
 		public bool IncludeUser { get; set; } = true;
 
 		/// <summary>
+		/// Gets or sets a flag indicating whether TraceId/SpanId should be included in the message. Defaults to <c>true</c>.
+		/// </summary>
+		public bool IncludeTraceId { get; set; } = true;
+
+		/// <summary>
 		/// The data stream to log into, defaults to <c>logs-generic-default</c> if neither <see cref="DataStream"/> or <see cref="Index"/> is set.
 		/// </summary>
 		public DataStreamNameOptions? DataStream { get; set; }


### PR DESCRIPTION
When enabling writing on background-thread, then one should not capture the activity-traceid of the background-thread.

I guess Serilog has the same issue, since it relies on its enricher-capture (similar to NLog layout capture)

This is ofcourse a breaking change, since adding new property to existing interface `IEcsDocumentCreationOptions`. Maybe change to use enum-flag-values?

Alternative only perform automatic capture for Elastic.Extensions.Logging? (Skip helping NLog / Serilog / Log4net)