### PR TITLE
JsonSerializerOptions - Added JsonStringEnumConverter

### DIFF
--- a/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
+++ b/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
@@ -21,6 +21,7 @@ namespace Elastic.CommonSchema.Serialization
 			PropertyNamingPolicy = new SnakeCaseJsonNamingPolicy(),
 			Converters =
 			{
+				new JsonStringEnumConverter(),
 				new EcsDocumentJsonConverterFactory(),
 				new LogEntityJsonConverter(),
 				new EcsEntityJsonConverter(),


### PR DESCRIPTION
Makes easier for humans to query data in Elastic when Enum-Properties are saved as String-Values (instead of numeric values)