### PR TITLE
github-action: use actions/attest-build-provenance

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -32,7 +32,7 @@ jobs:
       run: ./build.sh generateapichanges -s true
 
     - name: generate build provenance
-      uses: github-early-access/generate-build-provenance@main
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4  # v1.1.1
       with:
         subject-path: "${{ github.workspace }}/build/output/*.nupkg"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       run: ./build.sh createreleaseongithub -s true --token ${{ secrets.GITHUB_TOKEN }}
 
     - name: generate build provenance
-      uses: github-early-access/generate-build-provenance@main
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4  # v1.1.1
       with:
         subject-path: "${{ github.workspace }}/build/output/*.nupkg"
 


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: github-early-access/generate-build-provenance has been deprecated in favor of 
actions/attest-build-provenance.

If there are any questions, please reach out to the @elastic/observablt-ci
