### PR TITLE
Add support for custom event writer

### DIFF
--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.Generated.cs
@@ -5,7 +5,7 @@
 /*
 IMPORTANT NOTE
 ==============
-This file has been generated.
+This file has been generated. 
 If you wish to submit a PR please modify the original csharp file and submit the PR with that change. Thanks!
 */
 
@@ -20,9 +20,9 @@ namespace Elastic.CommonSchema.Serialization
 		where TBase : EcsDocument, new()
 	{
 		private static bool ReadProperties(
-			ref Utf8JsonReader reader,
-			TBase ecsEvent,
-			ref DateTimeOffset? timestamp,
+			ref Utf8JsonReader reader, 
+			TBase ecsEvent, 
+			ref DateTimeOffset? timestamp, 
 			ref string loglevel,
 			ref string ecsVersion,
 			JsonSerializerOptions options
@@ -119,10 +119,11 @@ namespace Elastic.CommonSchema.Serialization
 
 			// Base fields
 			WriteProp(writer, "tags", value.Tags, options);
-				WriteProp(writer, "span.id", value.SpanId, options);
-				WriteProp(writer, "trace.id", value.TraceId, options);
-				WriteProp(writer, "transaction.id", value.TransactionId, options);
+			WriteProp(writer, "span.id", value.SpanId, options);
+			WriteProp(writer, "trace.id", value.TraceId, options);
+			WriteProp(writer, "transaction.id", value.TransactionId, options);
 			WriteProp(writer, "labels", value.Labels, options);
+
 			// Complex types
 			WriteProp(writer, "agent", value.Agent, EcsJsonContext.Default.Agent, options);
 			WriteProp(writer, "as", value.As, EcsJsonContext.Default.As, options);
@@ -174,7 +175,7 @@ namespace Elastic.CommonSchema.Serialization
 			WriteProp(writer, "metadata", value.Metadata, options);
 
 			if (typeof(EcsDocument) != value.GetType())
-				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v,options));
+				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v, options));
 			writer.WriteEndObject();
 		}
 	}

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.Generated.cs
@@ -5,7 +5,7 @@
 /*
 IMPORTANT NOTE
 ==============
-This file has been generated. 
+This file has been generated.
 If you wish to submit a PR please modify the original csharp file and submit the PR with that change. Thanks!
 */
 
@@ -20,11 +20,12 @@ namespace Elastic.CommonSchema.Serialization
 		where TBase : EcsDocument, new()
 	{
 		private static bool ReadProperties(
-			ref Utf8JsonReader reader, 
-			TBase ecsEvent, 
-			ref DateTimeOffset? timestamp, 
+			ref Utf8JsonReader reader,
+			TBase ecsEvent,
+			ref DateTimeOffset? timestamp,
 			ref string loglevel,
-			ref string ecsVersion
+			ref string ecsVersion,
+			JsonSerializerOptions options
 		)
 		{
 			var propertyName = reader.GetString();
@@ -33,14 +34,14 @@ namespace Elastic.CommonSchema.Serialization
 			{
 				"log.level" => ReadString(ref reader, ref loglevel),
 				"ecs.version" => ReadString(ref reader, ref ecsVersion),
-				"metadata" => ReadProp<MetadataDictionary>(ref reader, "metadata", ecsEvent, (b, v) => b.Metadata = v),
-				"@timestamp" => ReadDateTime(ref reader, ref @timestamp),
-				"message" => ReadProp<string>(ref reader, "message", ecsEvent, (b, v) => b.Message = v),
-				"tags" => ReadProp<string[]>(ref reader, "tags", ecsEvent, (b, v) => b.Tags = v),
-				"span.id" => ReadProp<string>(ref reader, "span.id", ecsEvent, (b, v) => b.SpanId = v),
-				"trace.id" => ReadProp<string>(ref reader, "trace.id", ecsEvent, (b, v) => b.TraceId = v),
-				"transaction.id" => ReadProp<string>(ref reader, "transaction.id", ecsEvent, (b, v) => b.TransactionId = v),
-				"labels" => ReadProp<Labels>(ref reader, "labels", ecsEvent, (b, v) => b.Labels = v),
+				"metadata" => ReadProp<MetadataDictionary>(ref reader, "metadata", ecsEvent, (b, v) => b.Metadata = v, options),
+				"@timestamp" => ReadDateTime(ref reader, ref @timestamp, options),
+				"message" => ReadProp<string>(ref reader, "message", ecsEvent, (b, v) => b.Message = v, options),
+				"tags" => ReadProp<string[]>(ref reader, "tags", ecsEvent, (b, v) => b.Tags = v, options),
+				"span.id" => ReadProp<string>(ref reader, "span.id", ecsEvent, (b, v) => b.SpanId = v, options),
+				"trace.id" => ReadProp<string>(ref reader, "trace.id", ecsEvent, (b, v) => b.TraceId = v, options),
+				"transaction.id" => ReadProp<string>(ref reader, "transaction.id", ecsEvent, (b, v) => b.TransactionId = v, options),
+				"labels" => ReadProp<Labels>(ref reader, "labels", ecsEvent, (b, v) => b.Labels = v, options),
 				"agent" => ReadProp<Agent>(ref reader, "agent", EcsJsonContext.Default.Agent, ecsEvent, (b, v) => b.Agent = v),
 				"as" => ReadProp<As>(ref reader, "as", EcsJsonContext.Default.As, ecsEvent, (b, v) => b.As = v),
 				"client" => ReadProp<Client>(ref reader, "client", EcsJsonContext.Default.Client, ecsEvent, (b, v) => b.Client = v),
@@ -94,7 +95,7 @@ namespace Elastic.CommonSchema.Serialization
 					typeof(EcsDocument) == ecsEvent.GetType()
 						? false
 						: ecsEvent.TryRead(propertyName, out var t)
-							? ecsEvent.ReceiveProperty(propertyName, ReadPropDeserialize(ref reader, t))
+							? ecsEvent.ReceiveProperty(propertyName, ReadPropDeserialize(ref reader, t, options))
 							: false
 			};
 		}
@@ -109,71 +110,71 @@ namespace Elastic.CommonSchema.Serialization
 			}
 			writer.WriteStartObject();
 
-			WriteTimestamp(writer, value);
+			WriteTimestamp(writer, value, options);
 			WriteLogLevel(writer, value);
 			WriteMessage(writer, value);
 			WriteEcsVersion(writer, value);
-			WriteLogEntity(writer, value.Log);
-			WriteEcsEntity(writer, value.Ecs);
+			WriteLogEntity(writer, value.Log, options);
+			WriteEcsEntity(writer, value.Ecs, options);
 
 			// Base fields
-			WriteProp(writer, "tags", value.Tags);
-				WriteProp(writer, "span.id", value.SpanId);
-				WriteProp(writer, "trace.id", value.TraceId);
-				WriteProp(writer, "transaction.id", value.TransactionId);
-			WriteProp(writer, "labels", value.Labels);
+			WriteProp(writer, "tags", value.Tags, options);
+				WriteProp(writer, "span.id", value.SpanId, options);
+				WriteProp(writer, "trace.id", value.TraceId, options);
+				WriteProp(writer, "transaction.id", value.TransactionId, options);
+			WriteProp(writer, "labels", value.Labels, options);
 			// Complex types
-			WriteProp(writer, "agent", value.Agent, EcsJsonContext.Default.Agent);
-			WriteProp(writer, "as", value.As, EcsJsonContext.Default.As);
-			WriteProp(writer, "client", value.Client, EcsJsonContext.Default.Client);
-			WriteProp(writer, "cloud", value.Cloud, EcsJsonContext.Default.Cloud);
-			WriteProp(writer, "code_signature", value.CodeSignature, EcsJsonContext.Default.CodeSignature);
-			WriteProp(writer, "container", value.Container, EcsJsonContext.Default.Container);
-			WriteProp(writer, "data_stream", value.DataStream, EcsJsonContext.Default.DataStream);
-			WriteProp(writer, "destination", value.Destination, EcsJsonContext.Default.Destination);
-			WriteProp(writer, "device", value.Device, EcsJsonContext.Default.Device);
-			WriteProp(writer, "dll", value.Dll, EcsJsonContext.Default.Dll);
-			WriteProp(writer, "dns", value.Dns, EcsJsonContext.Default.Dns);
-			WriteProp(writer, "elf", value.Elf, EcsJsonContext.Default.Elf);
-			WriteProp(writer, "email", value.Email, EcsJsonContext.Default.Email);
-			WriteProp(writer, "error", value.Error, EcsJsonContext.Default.Error);
-			WriteProp(writer, "event", value.Event, EcsJsonContext.Default.Event);
-			WriteProp(writer, "faas", value.Faas, EcsJsonContext.Default.Faas);
-			WriteProp(writer, "file", value.File, EcsJsonContext.Default.File);
-			WriteProp(writer, "geo", value.Geo, EcsJsonContext.Default.Geo);
-			WriteProp(writer, "group", value.Group, EcsJsonContext.Default.Group);
-			WriteProp(writer, "hash", value.Hash, EcsJsonContext.Default.Hash);
-			WriteProp(writer, "host", value.Host, EcsJsonContext.Default.Host);
-			WriteProp(writer, "http", value.Http, EcsJsonContext.Default.Http);
-			WriteProp(writer, "interface", value.Interface, EcsJsonContext.Default.Interface);
-			WriteProp(writer, "macho", value.Macho, EcsJsonContext.Default.Macho);
-			WriteProp(writer, "network", value.Network, EcsJsonContext.Default.Network);
-			WriteProp(writer, "observer", value.Observer, EcsJsonContext.Default.Observer);
-			WriteProp(writer, "orchestrator", value.Orchestrator, EcsJsonContext.Default.Orchestrator);
-			WriteProp(writer, "organization", value.Organization, EcsJsonContext.Default.Organization);
-			WriteProp(writer, "os", value.Os, EcsJsonContext.Default.Os);
-			WriteProp(writer, "package", value.Package, EcsJsonContext.Default.Package);
-			WriteProp(writer, "pe", value.Pe, EcsJsonContext.Default.Pe);
-			WriteProp(writer, "process", value.Process, EcsJsonContext.Default.Process);
-			WriteProp(writer, "registry", value.Registry, EcsJsonContext.Default.Registry);
-			WriteProp(writer, "related", value.Related, EcsJsonContext.Default.Related);
-			WriteProp(writer, "risk", value.Risk, EcsJsonContext.Default.Risk);
-			WriteProp(writer, "rule", value.Rule, EcsJsonContext.Default.Rule);
-			WriteProp(writer, "server", value.Server, EcsJsonContext.Default.Server);
-			WriteProp(writer, "service", value.Service, EcsJsonContext.Default.Service);
-			WriteProp(writer, "source", value.Source, EcsJsonContext.Default.Source);
-			WriteProp(writer, "threat", value.Threat, EcsJsonContext.Default.Threat);
-			WriteProp(writer, "tls", value.Tls, EcsJsonContext.Default.Tls);
-			WriteProp(writer, "url", value.Url, EcsJsonContext.Default.Url);
-			WriteProp(writer, "user", value.User, EcsJsonContext.Default.User);
-			WriteProp(writer, "user_agent", value.UserAgent, EcsJsonContext.Default.UserAgent);
-			WriteProp(writer, "vlan", value.Vlan, EcsJsonContext.Default.Vlan);
-			WriteProp(writer, "vulnerability", value.Vulnerability, EcsJsonContext.Default.Vulnerability);
-			WriteProp(writer, "x509", value.X509, EcsJsonContext.Default.X509);
-			WriteProp(writer, "metadata", value.Metadata);
+			WriteProp(writer, "agent", value.Agent, EcsJsonContext.Default.Agent, options);
+			WriteProp(writer, "as", value.As, EcsJsonContext.Default.As, options);
+			WriteProp(writer, "client", value.Client, EcsJsonContext.Default.Client, options);
+			WriteProp(writer, "cloud", value.Cloud, EcsJsonContext.Default.Cloud, options);
+			WriteProp(writer, "code_signature", value.CodeSignature, EcsJsonContext.Default.CodeSignature, options);
+			WriteProp(writer, "container", value.Container, EcsJsonContext.Default.Container, options);
+			WriteProp(writer, "data_stream", value.DataStream, EcsJsonContext.Default.DataStream, options);
+			WriteProp(writer, "destination", value.Destination, EcsJsonContext.Default.Destination, options);
+			WriteProp(writer, "device", value.Device, EcsJsonContext.Default.Device, options);
+			WriteProp(writer, "dll", value.Dll, EcsJsonContext.Default.Dll, options);
+			WriteProp(writer, "dns", value.Dns, EcsJsonContext.Default.Dns, options);
+			WriteProp(writer, "elf", value.Elf, EcsJsonContext.Default.Elf, options);
+			WriteProp(writer, "email", value.Email, EcsJsonContext.Default.Email, options);
+			WriteProp(writer, "error", value.Error, EcsJsonContext.Default.Error, options);
+			WriteProp(writer, "event", value.Event, EcsJsonContext.Default.Event, options);
+			WriteProp(writer, "faas", value.Faas, EcsJsonContext.Default.Faas, options);
+			WriteProp(writer, "file", value.File, EcsJsonContext.Default.File, options);
+			WriteProp(writer, "geo", value.Geo, EcsJsonContext.Default.Geo, options);
+			WriteProp(writer, "group", value.Group, EcsJsonContext.Default.Group, options);
+			WriteProp(writer, "hash", value.Hash, EcsJsonContext.Default.Hash, options);
+			WriteProp(writer, "host", value.Host, EcsJsonContext.Default.Host, options);
+			WriteProp(writer, "http", value.Http, EcsJsonContext.Default.Http, options);
+			WriteProp(writer, "interface", value.Interface, EcsJsonContext.Default.Interface, options);
+			WriteProp(writer, "macho", value.Macho, EcsJsonContext.Default.Macho, options);
+			WriteProp(writer, "network", value.Network, EcsJsonContext.Default.Network, options);
+			WriteProp(writer, "observer", value.Observer, EcsJsonContext.Default.Observer, options);
+			WriteProp(writer, "orchestrator", value.Orchestrator, EcsJsonContext.Default.Orchestrator, options);
+			WriteProp(writer, "organization", value.Organization, EcsJsonContext.Default.Organization, options);
+			WriteProp(writer, "os", value.Os, EcsJsonContext.Default.Os, options);
+			WriteProp(writer, "package", value.Package, EcsJsonContext.Default.Package, options);
+			WriteProp(writer, "pe", value.Pe, EcsJsonContext.Default.Pe, options);
+			WriteProp(writer, "process", value.Process, EcsJsonContext.Default.Process, options);
+			WriteProp(writer, "registry", value.Registry, EcsJsonContext.Default.Registry, options);
+			WriteProp(writer, "related", value.Related, EcsJsonContext.Default.Related, options);
+			WriteProp(writer, "risk", value.Risk, EcsJsonContext.Default.Risk, options);
+			WriteProp(writer, "rule", value.Rule, EcsJsonContext.Default.Rule, options);
+			WriteProp(writer, "server", value.Server, EcsJsonContext.Default.Server, options);
+			WriteProp(writer, "service", value.Service, EcsJsonContext.Default.Service, options);
+			WriteProp(writer, "source", value.Source, EcsJsonContext.Default.Source, options);
+			WriteProp(writer, "threat", value.Threat, EcsJsonContext.Default.Threat, options);
+			WriteProp(writer, "tls", value.Tls, EcsJsonContext.Default.Tls, options);
+			WriteProp(writer, "url", value.Url, EcsJsonContext.Default.Url, options);
+			WriteProp(writer, "user", value.User, EcsJsonContext.Default.User, options);
+			WriteProp(writer, "user_agent", value.UserAgent, EcsJsonContext.Default.UserAgent, options);
+			WriteProp(writer, "vlan", value.Vlan, EcsJsonContext.Default.Vlan, options);
+			WriteProp(writer, "vulnerability", value.Vulnerability, EcsJsonContext.Default.Vulnerability, options);
+			WriteProp(writer, "x509", value.X509, EcsJsonContext.Default.X509, options);
+			WriteProp(writer, "metadata", value.Metadata, options);
 
 			if (typeof(EcsDocument) != value.GetType())
-				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v));
+				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v,options));
 			writer.WriteEndObject();
 		}
 	}

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
@@ -42,7 +42,7 @@ namespace Elastic.CommonSchema.Serialization
 				if (reader.TokenType != JsonTokenType.PropertyName)
 					throw new JsonException();
 
-				var _ = ReadProperties(ref reader, ecsEvent, ref timestamp, ref loglevel, ref ecsVersion);
+				var _ = ReadProperties(ref reader, ecsEvent, ref timestamp, ref loglevel, ref ecsVersion, options);
 			}
 			if (!string.IsNullOrEmpty(loglevel))
 			{
@@ -65,11 +65,11 @@ namespace Elastic.CommonSchema.Serialization
 				writer.WriteString("message", value.Message);
 		}
 
-		private static void WriteLogEntity(Utf8JsonWriter writer, Log? value) {
+		private static void WriteLogEntity(Utf8JsonWriter writer, Log? value, JsonSerializerOptions options) {
 			if (value == null) return;
 			if (!value.ShouldSerialize) return;
 
-			WriteProp(writer, "log", value, EcsJsonContext.Default.Log);
+			WriteProp(writer, "log", value, EcsJsonContext.Default.Log, options);
 		}
 
 		private static void WriteLogLevel(Utf8JsonWriter writer, EcsDocument value)
@@ -78,23 +78,24 @@ namespace Elastic.CommonSchema.Serialization
 				writer.WriteString("log.level", value.Log?.Level);
 		}
 
-		private static void WriteEcsEntity(Utf8JsonWriter writer, Ecs? value)
+		private static void WriteEcsEntity(Utf8JsonWriter writer, Ecs? value, JsonSerializerOptions options)
 		{
 			if (value == null) return;
 			if (!value.ShouldSerialize) return;
 
-			WriteProp(writer, "ecs", value, EcsJsonContext.Default.Ecs);
+			WriteProp(writer, "ecs", value, EcsJsonContext.Default.Ecs, options);
 		}
 
 		private static void WriteEcsVersion(Utf8JsonWriter writer, EcsDocument value) =>
 			writer.WriteString("ecs.version", value.Ecs?.Version ?? EcsDocument.Version);
 
-		private static void WriteTimestamp(Utf8JsonWriter writer, BaseFieldSet value)
+		private static void WriteTimestamp(Utf8JsonWriter writer, BaseFieldSet value, JsonSerializerOptions options)
 		{
 			if (!value.Timestamp.HasValue) return;
 
 			writer.WritePropertyName("@timestamp");
-			EcsJsonConfiguration.DateTimeOffsetConverter.Write(writer, value.Timestamp.Value, EcsJsonConfiguration.SerializerOptions);
+			var converter = (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
+			converter.Write(writer, value.Timestamp.Value, options);
 		}
 	}
 

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
@@ -94,7 +94,11 @@ namespace Elastic.CommonSchema.Serialization
 			if (!value.Timestamp.HasValue) return;
 
 			writer.WritePropertyName("@timestamp");
-			var converter = (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
+
+			var converter = options == EcsJsonConfiguration.SerializerOptions
+				? EcsJsonConfiguration.DateTimeOffsetConverter
+				: (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
+
 			converter.Write(writer, value.Timestamp.Value, options);
 		}
 	}

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverter.cs
@@ -94,11 +94,7 @@ namespace Elastic.CommonSchema.Serialization
 			if (!value.Timestamp.HasValue) return;
 
 			writer.WritePropertyName("@timestamp");
-
-			var converter = options == EcsJsonConfiguration.SerializerOptions
-				? EcsJsonConfiguration.DateTimeOffsetConverter
-				: (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
-
+			var converter = GetDateTimeOffsetConverter(options);
 			converter.Write(writer, value.Timestamp.Value, options);
 		}
 	}

--- a/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
@@ -35,6 +35,24 @@ namespace Elastic.CommonSchema.Serialization
 		}
 
 		/// <summary></summary>
+		protected static void WritePropLong(Utf8JsonWriter writer, string key, long? value)
+		{
+			if (value == null) return;
+
+			writer.WritePropertyName(key);
+			writer.WriteNumberValue(value.Value);
+		}
+
+		/// <summary></summary>
+		protected static void WritePropString(Utf8JsonWriter writer, string key, string? value)
+		{
+			if (value == null) return;
+
+			writer.WritePropertyName(key);
+			writer.WriteStringValue(value);
+		}
+
+		/// <summary></summary>
 		protected static void WriteProp<TValue>(Utf8JsonWriter writer, string key, TValue value, JsonSerializerOptions options)
 		{
 			if (value == null) return;

--- a/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
@@ -21,7 +21,10 @@ namespace Elastic.CommonSchema.Serialization
 				return true;
 			}
 
-			var converter = (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
+			var converter = options == EcsJsonConfiguration.SerializerOptions
+				? EcsJsonConfiguration.DateTimeOffsetConverter
+				: (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
+
 			dateTime = converter.Read(ref reader, typeof(DateTimeOffset), options);
 			return true;
 		}

--- a/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
@@ -13,6 +13,12 @@ namespace Elastic.CommonSchema.Serialization
 	public abstract class EcsJsonConverterBase<T> : JsonConverter<T>
 	{
 		/// <summary></summary>
+		protected static JsonConverter<DateTimeOffset> GetDateTimeOffsetConverter(JsonSerializerOptions options) =>
+			options == EcsJsonConfiguration.SerializerOptions
+				? EcsJsonConfiguration.DateTimeOffsetConverter
+				: (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
+
+		/// <summary></summary>
 		protected static bool ReadDateTime(ref Utf8JsonReader reader, ref DateTimeOffset? dateTime, JsonSerializerOptions options)
 		{
 			if (reader.TokenType == JsonTokenType.Null)
@@ -21,10 +27,7 @@ namespace Elastic.CommonSchema.Serialization
 				return true;
 			}
 
-			var converter = options == EcsJsonConfiguration.SerializerOptions
-				? EcsJsonConfiguration.DateTimeOffsetConverter
-				: (JsonConverter<DateTimeOffset>)options.GetConverter(typeof(DateTimeOffset));
-
+			var converter = GetDateTimeOffsetConverter(options);
 			dateTime = converter.Read(ref reader, typeof(DateTimeOffset), options);
 			return true;
 		}

--- a/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
+++ b/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
@@ -36,6 +36,9 @@ namespace Elastic.CommonSchema.Serialization
 			}
 		};
 
+		internal static readonly JsonConverter<DateTimeOffset> DateTimeOffsetConverter =
+			(JsonConverter<DateTimeOffset>)SerializerOptions.GetConverter(typeof(DateTimeOffset));
+
 		/// <summary>Default <see cref="JsonConverter{T}"/> for <see cref="EcsDocument"/></summary>
 		public static readonly EcsDocumentJsonConverter DefaultEcsDocumentJsonConverter = new();
 

--- a/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
+++ b/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
@@ -36,9 +36,6 @@ namespace Elastic.CommonSchema.Serialization
 			}
 		};
 
-		internal static readonly JsonConverter<DateTimeOffset> DateTimeOffsetConverter =
-			(JsonConverter<DateTimeOffset>)SerializerOptions.GetConverter(typeof(DateTimeOffset));
-
 		/// <summary>Default <see cref="JsonConverter{T}"/> for <see cref="EcsDocument"/></summary>
 		public static readonly EcsDocumentJsonConverter DefaultEcsDocumentJsonConverter = new();
 

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
@@ -5,7 +5,7 @@
 /*
 IMPORTANT NOTE
 ==============
-This file has been generated. 
+This file has been generated.
 If you wish to submit a PR please modify the original csharp file and submit the PR with that change. Thanks!
 */
 
@@ -21,7 +21,7 @@ namespace Elastic.CommonSchema.Serialization;
 internal partial class LogEntityJsonConverter : PropertiesReaderJsonConverterBase<Log>
 {
 	/// <inheritdoc cref="PropertiesReaderJsonConverterBase{T}.ReadProperties"/>
-	protected override bool ReadProperties(ref Utf8JsonReader reader, Log ecsEvent)
+	protected override bool ReadProperties(ref Utf8JsonReader reader, Log ecsEvent, JsonSerializerOptions options)
 	{
 		var propertyName = reader.GetString();
 		reader.Read();
@@ -33,13 +33,13 @@ internal partial class LogEntityJsonConverter : PropertiesReaderJsonConverterBas
 			"origin.file.line" => ReadPropLong(ref reader, "origin.file.line", ecsEvent, (b, v) => b.OriginFileLine = v),
 			"origin.file.name" => ReadPropString(ref reader, "origin.file.name", ecsEvent, (b, v) => b.OriginFileName = v),
 			"origin.function" => ReadPropString(ref reader, "origin.function", ecsEvent, (b, v) => b.OriginFunction = v),
-	"syslog" => ReadProp<LogSyslog>(ref reader, "syslog", ecsEvent, (b, v) => b.Syslog = v),
-			_ => ReadProperty(ref reader, propertyName, ecsEvent)
+			"syslog" => ReadProp<LogSyslog>(ref reader, "syslog", ecsEvent, (b, v) => b.Syslog = v, options),
+			_ => ReadProperty(ref reader, propertyName, ecsEvent, options)
 		};
 	}
 
-	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Log ecsEvent);
-		
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Log ecsEvent, JsonSerializerOptions options);
+
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, Log value, JsonSerializerOptions options)
 	{
@@ -50,12 +50,12 @@ internal partial class LogEntityJsonConverter : PropertiesReaderJsonConverterBas
 		}
 		writer.WriteStartObject();
 
-		WriteProp(writer, "file.path", value.FilePath);
-		WriteProp(writer, "logger", value.Logger);
-		WriteProp(writer, "origin.file.line", value.OriginFileLine);
-		WriteProp(writer, "origin.file.name", value.OriginFileName);
-		WriteProp(writer, "origin.function", value.OriginFunction);
-		WriteProp(writer, "syslog", value.Syslog);
+		WriteProp(writer, "file.path", value.FilePath, options);
+		WriteProp(writer, "logger", value.Logger, options);
+		WriteProp(writer, "origin.file.line", value.OriginFileLine, options);
+		WriteProp(writer, "origin.file.name", value.OriginFileName, options);
+		WriteProp(writer, "origin.function", value.OriginFunction, options);
+		WriteProp(writer, "syslog", value.Syslog, options);
 
 		writer.WriteEndObject();
 	}
@@ -65,7 +65,7 @@ internal partial class LogEntityJsonConverter : PropertiesReaderJsonConverterBas
 internal partial class EcsEntityJsonConverter : PropertiesReaderJsonConverterBase<Ecs>
 {
 	/// <inheritdoc cref="PropertiesReaderJsonConverterBase{T}.ReadProperties"/>
-	protected override bool ReadProperties(ref Utf8JsonReader reader, Ecs ecsEvent)
+	protected override bool ReadProperties(ref Utf8JsonReader reader, Ecs ecsEvent, JsonSerializerOptions options)
 	{
 		var propertyName = reader.GetString();
 		reader.Read();
@@ -77,7 +77,7 @@ internal partial class EcsEntityJsonConverter : PropertiesReaderJsonConverterBas
 	}
 
 	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Ecs ecsEvent);
-		
+
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, Ecs value, JsonSerializerOptions options)
 	{

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
@@ -50,11 +50,11 @@ internal partial class LogEntityJsonConverter : PropertiesReaderJsonConverterBas
 		}
 		writer.WriteStartObject();
 
-		WriteProp(writer, "file.path", value.FilePath, options);
-		WriteProp(writer, "logger", value.Logger, options);
-		WriteProp(writer, "origin.file.line", value.OriginFileLine, options);
-		WriteProp(writer, "origin.file.name", value.OriginFileName, options);
-		WriteProp(writer, "origin.function", value.OriginFunction, options);
+		WritePropString(writer, "file.path", value.FilePath);
+		WritePropString(writer, "logger", value.Logger);
+		WritePropLong(writer, "origin.file.line", value.OriginFileLine);
+		WritePropString(writer, "origin.file.name", value.OriginFileName);
+		WritePropString(writer, "origin.function", value.OriginFunction);
 		WriteProp(writer, "syslog", value.Syslog, options);
 
 		writer.WriteEndObject();

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.Generated.cs
@@ -5,7 +5,7 @@
 /*
 IMPORTANT NOTE
 ==============
-This file has been generated.
+This file has been generated. 
 If you wish to submit a PR please modify the original csharp file and submit the PR with that change. Thanks!
 */
 
@@ -39,7 +39,7 @@ internal partial class LogEntityJsonConverter : PropertiesReaderJsonConverterBas
 	}
 
 	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Log ecsEvent, JsonSerializerOptions options);
-
+		
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, Log value, JsonSerializerOptions options)
 	{
@@ -72,12 +72,12 @@ internal partial class EcsEntityJsonConverter : PropertiesReaderJsonConverterBas
 		return propertyName switch
 		{
 			"version" => ReadPropString(ref reader, "version", ecsEvent, (b, v) => b.Version = v),
-			_ => ReadProperty(ref reader, propertyName, ecsEvent)
+			_ => ReadProperty(ref reader, propertyName, ecsEvent, options)
 		};
 	}
 
-	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Ecs ecsEvent);
-
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Ecs ecsEvent, JsonSerializerOptions options);
+		
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, Ecs value, JsonSerializerOptions options)
 	{

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
@@ -42,14 +42,14 @@ public abstract class PropertiesReaderJsonConverterBase<T> : EcsJsonConverterBas
 			if (reader.TokenType != JsonTokenType.PropertyName)
 				throw new JsonException();
 
-			var _ = ReadProperties(ref reader, ecsEvent);
+			var _ = ReadProperties(ref reader, ecsEvent, options);
 		}
 
 		return ecsEvent;
 	}
 
 	/// <summary> Handle reading the current property</summary>
-	protected abstract bool ReadProperties(ref Utf8JsonReader reader, T ecsEvent);
+	protected abstract bool ReadProperties(ref Utf8JsonReader reader, T ecsEvent, JsonSerializerOptions options);
 }
 
 internal partial class EcsEntityJsonConverter
@@ -76,7 +76,7 @@ internal partial class LogEntityJsonConverter
 		public LogFileOriginInvalid? File { get; set; }
 	}
 
-	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Log ecsEvent) =>
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Log ecsEvent, JsonSerializerOptions options) =>
 		propertyName switch
 		{
 			"origin" => ReadProp<LogOriginInvalid>(ref reader, "origin", ecsEvent, (b, v) =>
@@ -86,7 +86,7 @@ internal partial class LogEntityJsonConverter
 				if (v.File == null) return;
 				b.OriginFileLine = v.File.Line;
 				b.OriginFileName = v.File.Name;
-			}),
+			}, options),
 			_ => false
 		};
 }

--- a/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/PropertiesReaderJsonConverterBase.cs
@@ -54,7 +54,7 @@ public abstract class PropertiesReaderJsonConverterBase<T> : EcsJsonConverterBas
 
 internal partial class EcsEntityJsonConverter
 {
-	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Ecs ecsEvent) => false;
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, Ecs ecsEvent, JsonSerializerOptions options) => false;
 }
 
 internal partial class LogEntityJsonConverter

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/CustomEventWriter.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/CustomEventWriter.cs
@@ -1,0 +1,27 @@
+﻿using System.Buffers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elastic.CommonSchema.Serialization;
+
+namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests;
+
+public class CustomEventWriter<T> : IElasticsearchEventWriter<T>
+{
+	// ReSharper disable once StaticMemberInGenericType
+	private static readonly JsonSerializerOptions s_serializerOptions;
+
+	static CustomEventWriter()
+	{
+		s_serializerOptions = EcsJsonConfiguration.SerializerOptions;
+		s_serializerOptions.Converters.Add(new JsonStringEnumConverter());
+	}
+
+	public Action<ArrayBufferWriter<byte>, T>? WriteToArrayBuffer
+	{
+		get => throw new NotImplementedException();
+		set => throw new NotImplementedException();
+	}
+
+	public Func<Stream, T, CancellationToken, Task>? WriteToStreamAsync { get; set; } =
+		(stream, doc, ctx) => JsonSerializer.SerializeAsync(stream, doc, typeof(T), s_serializerOptions, ctx);
+}

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/CustomEventWriter.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/CustomEventWriter.cs
@@ -1,20 +1,13 @@
 ﻿using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Elastic.CommonSchema.Serialization;
 
 namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests;
 
 public class CustomEventWriter<T> : IElasticsearchEventWriter<T>
 {
 	// ReSharper disable once StaticMemberInGenericType
-	private static readonly JsonSerializerOptions s_serializerOptions;
-
-	static CustomEventWriter()
-	{
-		s_serializerOptions = EcsJsonConfiguration.SerializerOptions;
-		s_serializerOptions.Converters.Add(new JsonStringEnumConverter());
-	}
+	private static readonly JsonSerializerOptions s_serializerOptions = new() { Converters = { new JsonStringEnumConverter() } };
 
 	public Action<ArrayBufferWriter<byte>, T>? WriteToArrayBuffer
 	{
@@ -23,5 +16,5 @@ public class CustomEventWriter<T> : IElasticsearchEventWriter<T>
 	}
 
 	public Func<Stream, T, CancellationToken, Task>? WriteToStreamAsync { get; set; } =
-		(stream, doc, ctx) => JsonSerializer.SerializeAsync(stream, doc, typeof(T), s_serializerOptions, ctx);
+		(stream, doc, ctx) => JsonSerializer.SerializeAsync<T>(stream, doc, s_serializerOptions, ctx);
 }

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/DataStreamIngestionTests.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/DataStreamIngestionTests.cs
@@ -2,75 +2,118 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Text.Json;
 using Elastic.Channels;
-using Elastic.Channels.Diagnostics;
 using Elastic.Clients.Elasticsearch.IndexManagement;
+using Elastic.CommonSchema;
 using Elastic.Ingest.Elasticsearch.DataStreams;
-using Elastic.Ingest.Elasticsearch.Serialization;
 using Elastic.Transport;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 using HttpMethod = Elastic.Transport.HttpMethod;
 
-namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests
+namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests;
+
+public class DataStreamIngestionTests : IntegrationTestBase
 {
-	public class DataStreamIngestionTests : IntegrationTestBase
+	public DataStreamIngestionTests(IngestionCluster cluster, ITestOutputHelper output) : base(cluster, output)
 	{
-		public DataStreamIngestionTests(IngestionCluster cluster, ITestOutputHelper output) : base(cluster, output)
+	}
+
+	[Fact]
+	public async Task EnsureDocumentsEndUpInDataStream()
+	{
+		var targetDataStream = new DataStreamName("timeseriesdocs", "dotnet");
+		var slim = new CountdownEvent(1);
+		var options = new DataStreamChannelOptions<TimeSeriesDocument>(Client.Transport)
 		{
-		}
+			DataStream = targetDataStream,
+			BufferOptions = new BufferOptions { WaitHandle = slim, OutboundBufferMaxSize = 1 },
+		};
+		var channel = new EcsDataStreamChannel<TimeSeriesDocument>(options);
 
-		[Fact]
-		public async Task EnsureDocumentsEndUpInDataStream()
+		var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
+		bootstrapped.Should().BeTrue("Expected to be able to bootstrap data stream channel");
+
+		var dataStream =
+			await Client.Indices.GetDataStreamAsync(new GetDataStreamRequest(targetDataStream.ToString()));
+		dataStream.DataStreams.Should().BeNullOrEmpty();
+
+		channel.TryWrite(new TimeSeriesDocument { Timestamp = DateTimeOffset.Now, Message = "hello-world" });
+		if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
+			throw new Exception($"No flush occurred in 10 seconds: {channel}", channel.DiagnosticsListener?.ObservedException);
+
+		var refreshResult = await Client.Indices.RefreshAsync(targetDataStream.ToString());
+		refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);
+		var searchResult = await Client.SearchAsync<TimeSeriesDocument>(s => s.Indices(targetDataStream.ToString()));
+		searchResult.Total.Should().Be(1);
+
+		var storedDocument = searchResult.Documents.First();
+		storedDocument.Message.Should().Be("hello-world");
+
+		var hit = searchResult.Hits.First();
+		hit.Index.Should().StartWith($".ds-{targetDataStream}-");
+
+		// the following throws in the 8.0.4 version of the client
+		// The JSON value could not be converted to Elastic.Clients.Elasticsearch.HealthStatus. Path: $.data_stre...
+		// await Client.Indices.GetDataStreamAsync(new GetDataStreamRequest(targetDataStream.ToString())
+		var getDataStream =
+			await Client.Transport.RequestAsync<StringResponse>(HttpMethod.GET, $"/_data_stream/{targetDataStream}");
+
+		getDataStream.ApiCallDetails.HttpStatusCode.Should()
+			.Be(200, "{0}", getDataStream.ApiCallDetails.DebugInformation);
+
+		//this ensures the data stream was setup using the expected bootstrapped template
+		getDataStream.ApiCallDetails.DebugInformation.Should()
+			.Contain(@$"""template"" : ""{targetDataStream.GetTemplateName()}""");
+
+		//this ensures the data stream is managed by the expected ilm_policy
+		getDataStream.ApiCallDetails.DebugInformation.Should()
+			.Contain(@"""ilm_policy"" : ""7-days-default""");
+	}
+
+	[Fact]
+	public async Task UseCustomEventWriter()
+	{
+		var targetDataStream = new DataStreamName("customtimeseriesdocs", "dotnet");
+		var slim = new CountdownEvent(1);
+		var options = new DataStreamChannelOptions<TimeSeriesDocument>(Client.Transport)
 		{
-			var targetDataStream = new DataStreamName("timeseriesdocs", "dotnet");
-			var slim = new CountdownEvent(1);
-			var options = new DataStreamChannelOptions<TimeSeriesDocument>(Client.Transport)
-			{
-				DataStream = targetDataStream,
-				BufferOptions = new BufferOptions { WaitHandle = slim, OutboundBufferMaxSize = 1 },
-			};
-			var channel = new EcsDataStreamChannel<TimeSeriesDocument>(options);
+			DataStream = targetDataStream,
+			BufferOptions = new BufferOptions { WaitHandle = slim, OutboundBufferMaxSize = 1 },
+			EventWriter = new CustomEventWriter<TimeSeriesDocument>()
+		};
+		var channel = new EcsDataStreamChannel<TimeSeriesDocument>(options);
 
-			var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
-			bootstrapped.Should().BeTrue("Expected to be able to bootstrap data stream channel");
+		var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
+		bootstrapped.Should().BeTrue("Expected to be able to bootstrap data stream channel");
 
-			var dataStream =
-				await Client.Indices.GetDataStreamAsync(new GetDataStreamRequest(targetDataStream.ToString()));
-			dataStream.DataStreams.Should().BeNullOrEmpty();
+		var dataStream =
+			await Client.Indices.GetDataStreamAsync(new GetDataStreamRequest(targetDataStream.ToString()));
+		dataStream.DataStreams.Should().BeNullOrEmpty();
 
-			channel.TryWrite(new TimeSeriesDocument { Timestamp = DateTimeOffset.Now, Message = "hello-world" });
-			if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
-				throw new Exception($"No flush occurred in 10 seconds: {channel}", channel.DiagnosticsListener?.ObservedException);
+		channel.TryWrite(new TimeSeriesDocument
+		{
+			Timestamp = DateTimeOffset.Parse("2024-05-27T23:56:15.785Z"),
+			Message = "Hello World!",
+			Metadata = new MetadataDictionary { { "MyEnum", MyEnum.Two } },
+			Ecs = new Ecs { Version = "8.11.0" }
+		});
 
-			var refreshResult = await Client.Indices.RefreshAsync(targetDataStream.ToString());
-			refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);
-			var searchResult = await Client.SearchAsync<TimeSeriesDocument>(s => s.Indices(targetDataStream.ToString()));
-			searchResult.Total.Should().Be(1);
+		if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
+			throw new Exception($"No flush occurred in 10 seconds: {channel}", channel.DiagnosticsListener?.ObservedException);
 
-			var storedDocument = searchResult.Documents.First();
-			storedDocument.Message.Should().Be("hello-world");
+		var refreshResult = await Client.Indices.RefreshAsync(targetDataStream.ToString());
+		refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);
 
-			var hit = searchResult.Hits.First();
-			hit.Index.Should().StartWith($".ds-{targetDataStream}-");
+		var searchResult = await Client.SearchAsync<JsonDocument>(s => s.Indices(targetDataStream.ToString()));
+		searchResult.Total.Should().Be(1);
 
-			// the following throws in the 8.0.4 version of the client
-			// The JSON value could not be converted to Elastic.Clients.Elasticsearch.HealthStatus. Path: $.data_stre...
-			// await Client.Indices.GetDataStreamAsync(new GetDataStreamRequest(targetDataStream.ToString())
-			var getDataStream =
-				await Client.Transport.RequestAsync<StringResponse>(HttpMethod.GET, $"/_data_stream/{targetDataStream}");
-
-			getDataStream.ApiCallDetails.HttpStatusCode.Should()
-				.Be(200, "{0}", getDataStream.ApiCallDetails.DebugInformation);
-
-			//this ensures the data stream was setup using the expected bootstrapped template
-			getDataStream.ApiCallDetails.DebugInformation.Should()
-				.Contain(@$"""template"" : ""{targetDataStream.GetTemplateName()}""");
-
-			//this ensures the data stream is managed by the expected ilm_policy
-			getDataStream.ApiCallDetails.DebugInformation.Should()
-				.Contain(@"""ilm_policy"" : ""7-days-default""");
-		}
+		var root = searchResult.Documents.First().RootElement;
+		root.GetProperty("@timestamp").GetString().Should().Be("2024-05-27T23:56:15.785+00:00");
+		root.GetProperty("message").GetString().Should().Be("Hello World!");
+		root.GetProperty("metadata").GetProperty("MyEnum").GetString().Should().Be("Two");
+		root.GetProperty("ecs.version").GetString().Should().Be("8.11.0");
 	}
 }

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/DataStreamIngestionTests.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/DataStreamIngestionTests.cs
@@ -97,8 +97,7 @@ public class DataStreamIngestionTests : IntegrationTestBase
 		{
 			Timestamp = DateTimeOffset.Parse("2024-05-27T23:56:15.785Z"),
 			Message = "Hello World!",
-			Metadata = new MetadataDictionary { { "MyEnum", MyEnum.Two } },
-			Ecs = new Ecs { Version = "8.11.0" }
+			Metadata = new MetadataDictionary { { "MyEnum", MyEnum.Two } }
 		});
 
 		if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
@@ -114,6 +113,5 @@ public class DataStreamIngestionTests : IntegrationTestBase
 		root.GetProperty("@timestamp").GetString().Should().Be("2024-05-27T23:56:15.785+00:00");
 		root.GetProperty("message").GetString().Should().Be("Hello World!");
 		root.GetProperty("metadata").GetProperty("MyEnum").GetString().Should().Be("Two");
-		root.GetProperty("ecs.version").GetString().Should().Be("8.11.0");
 	}
 }

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/IndexIngestionTests.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/IndexIngestionTests.cs
@@ -105,8 +105,7 @@ public class IndexIngestionTests : IntegrationTestBase
 			Created = date,
 			Title = "Hello World!",
 			Id = "hello-world",
-			Metadata = new MetadataDictionary { { "MyEnum", MyEnum.Two } },
-			Ecs = new Ecs { Version = "8.11.0" }
+			Metadata = new MetadataDictionary { { "MyEnum", MyEnum.Two } }
 		});
 
 		if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
@@ -123,6 +122,5 @@ public class IndexIngestionTests : IntegrationTestBase
 		root.GetProperty("title").GetString().Should().Be("Hello World!");
 		root.GetProperty("id").GetString().Should().Be("hello-world");
 		root.GetProperty("metadata").GetProperty("MyEnum").GetString().Should().Be("Two");
-		root.GetProperty("ecs.version").GetString().Should().Be("8.11.0");
 	}
 }

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/IndexIngestionTests.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/IndexIngestionTests.cs
@@ -2,77 +2,127 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Text.Json;
 using Elastic.Channels;
-using Elastic.Channels.Diagnostics;
 using Elastic.Clients.Elasticsearch.IndexManagement;
+using Elastic.CommonSchema;
 using Elastic.Ingest.Elasticsearch.Indices;
-using Elastic.Ingest.Elasticsearch.Serialization;
 using Elastic.Transport;
-using Elasticsearch.IntegrationDefaults;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 using HttpMethod = Elastic.Transport.HttpMethod;
 
-namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests
+namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests;
+
+public class IndexIngestionTests : IntegrationTestBase
 {
-	public class IndexIngestionTests : IntegrationTestBase
+	public IndexIngestionTests(IngestionCluster cluster, ITestOutputHelper output) : base(cluster, output)
 	{
-		public IndexIngestionTests(IngestionCluster cluster, ITestOutputHelper output) : base(cluster, output)
-		{
-		}
+	}
 
-		[Fact]
-		public async Task EnsureDocumentsEndUpInIndex()
+	[Fact]
+	public async Task EnsureDocumentsEndUpInIndex()
+	{
+		var indexPrefix = "catalog-data-";
+		var slim = new CountdownEvent(1);
+		var options = new IndexChannelOptions<CatalogDocument>(Client.Transport)
 		{
-			var indexPrefix = "catalog-data-";
-			var slim = new CountdownEvent(1);
-			var options = new IndexChannelOptions<CatalogDocument>(Client.Transport)
+			IndexFormat = indexPrefix + "{0:yyyy.MM.dd}",
+			BulkOperationIdLookup = c => c.Id!,
+			TimestampLookup = c => c.Created,
+			BufferOptions = new BufferOptions
 			{
-				IndexFormat = indexPrefix + "{0:yyyy.MM.dd}",
-				BulkOperationIdLookup = c => c.Id!,
-				TimestampLookup = c => c.Created,
-				BufferOptions = new BufferOptions
-				{
-					WaitHandle = slim, ExportMaxConcurrency = 1,
-				},
-			};
-			var channel = new EcsIndexChannel<CatalogDocument>(options);
-			var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
-			bootstrapped.Should().BeTrue("Expected to be able to bootstrap index channel");
+				WaitHandle = slim, ExportMaxConcurrency = 1,
+			},
+		};
+		var channel = new EcsIndexChannel<CatalogDocument>(options);
+		var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
+		bootstrapped.Should().BeTrue("Expected to be able to bootstrap index channel");
 
-			var date = DateTimeOffset.Now;
-			var indexName = string.Format(options.IndexFormat, date);
+		var date = DateTimeOffset.Now;
+		var indexName = string.Format(options.IndexFormat, date);
 
-			var index = await Client.Indices.GetAsync(new GetIndexRequest(indexName));
-			index.Indices.Should().BeNullOrEmpty();
+		var index = await Client.Indices.GetAsync(new GetIndexRequest(indexName));
+		index.Indices.Should().BeNullOrEmpty();
 
-			channel.TryWrite(new CatalogDocument { Created = date, Title = "Hello World!", Id = "hello-world" });
-			if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
-				throw new Exception($"No flush occurred in 10 seconds: {channel.DiagnosticsListener}", channel.DiagnosticsListener?.ObservedException);
+		channel.TryWrite(new CatalogDocument { Created = date, Title = "Hello World!", Id = "hello-world" });
+		if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
+			throw new Exception($"No flush occurred in 10 seconds: {channel.DiagnosticsListener}", channel.DiagnosticsListener?.ObservedException);
 
-			var refreshResult = await Client.Indices.RefreshAsync(indexName);
-			refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);
-			var searchResult = await Client.SearchAsync<CatalogDocument>(s => s.Indices(indexName));
-			searchResult.Total.Should().Be(1);
+		var refreshResult = await Client.Indices.RefreshAsync(indexName);
+		refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);
+		var searchResult = await Client.SearchAsync<CatalogDocument>(s => s.Indices(indexName));
+		searchResult.Total.Should().Be(1);
 
-			var storedDocument = searchResult.Documents.First();
-			storedDocument.Id.Should().Be("hello-world");
-			storedDocument.Title.Should().Be("Hello World!");
+		var storedDocument = searchResult.Documents.First();
+		storedDocument.Id.Should().Be("hello-world");
+		storedDocument.Title.Should().Be("Hello World!");
 
-			var hit = searchResult.Hits.First();
-			hit.Index.Should().Be(indexName);
+		var hit = searchResult.Hits.First();
+		hit.Index.Should().Be(indexName);
 
-			// bug in client
-			// https://github.com/elastic/elasticsearch-net/issues/7221
-			var indexResponse =
-				await Client.Transport.RequestAsync<StringResponse>(HttpMethod.GET, $"/{indexName}");
+		// bug in client
+		// https://github.com/elastic/elasticsearch-net/issues/7221
+		var indexResponse =
+			await Client.Transport.RequestAsync<StringResponse>(HttpMethod.GET, $"/{indexName}");
 
-			indexResponse.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue("{0}", indexResponse.ApiCallDetails.DebugInformation);
+		indexResponse.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue("{0}", indexResponse.ApiCallDetails.DebugInformation);
 
-			// Bug in client, for now assume template was applied because the ILM policy is set on the index.
-			indexResponse.ApiCallDetails.DebugInformation.Should().Contain(@"""7-days-default""");
+		// Bug in client, for now assume template was applied because the ILM policy is set on the index.
+		indexResponse.ApiCallDetails.DebugInformation.Should().Contain(@"""7-days-default""");
+	}
 
-		}
+	[Fact]
+	public async Task UseCustomEventWriter()
+	{
+		var indexPrefix = "custom-catalog-data-";
+		var slim = new CountdownEvent(1);
+		var options = new IndexChannelOptions<CatalogDocument>(Client.Transport)
+		{
+			IndexFormat = indexPrefix + "{0:yyyy.MM.dd}",
+			BulkOperationIdLookup = c => c.Id!,
+			TimestampLookup = c => c.Created,
+			BufferOptions = new BufferOptions
+			{
+				WaitHandle = slim, ExportMaxConcurrency = 1,
+			},
+			EventWriter = new CustomEventWriter<CatalogDocument>()
+		};
+		var channel = new EcsIndexChannel<CatalogDocument>(options);
+
+		var bootstrapped = await channel.BootstrapElasticsearchAsync(BootstrapMethod.Failure, "7-days-default");
+		bootstrapped.Should().BeTrue("Expected to be able to bootstrap index channel");
+
+		var date = DateTimeOffset.Parse("2024-05-27T23:56:15.785Z");
+		var indexName = string.Format(options.IndexFormat, date);
+
+		var index = await Client.Indices.GetAsync(new GetIndexRequest(indexName));
+		index.Indices.Should().BeNullOrEmpty();
+
+		channel.TryWrite(new CatalogDocument
+		{
+			Created = date,
+			Title = "Hello World!",
+			Id = "hello-world",
+			Metadata = new MetadataDictionary { { "MyEnum", MyEnum.Two } },
+			Ecs = new Ecs { Version = "8.11.0" }
+		});
+
+		if (!slim.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)))
+			throw new Exception($"No flush occurred in 10 seconds: {channel.DiagnosticsListener}", channel.DiagnosticsListener?.ObservedException);
+
+		var refreshResult = await Client.Indices.RefreshAsync(indexName);
+		refreshResult.IsValidResponse.Should().BeTrue("{0}", refreshResult.DebugInformation);
+
+		var searchResult = await Client.SearchAsync<JsonDocument>(s => s.Indices(indexName));
+		searchResult.Total.Should().Be(1);
+
+		var root = searchResult.Documents.First().RootElement;
+		root.GetProperty("created").GetString().Should().Be("2024-05-27T23:56:15.785+00:00");
+		root.GetProperty("title").GetString().Should().Be("Hello World!");
+		root.GetProperty("id").GetString().Should().Be("hello-world");
+		root.GetProperty("metadata").GetProperty("MyEnum").GetString().Should().Be("Two");
+		root.GetProperty("ecs.version").GetString().Should().Be("8.11.0");
 	}
 }

--- a/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/TestDocument.cs
+++ b/tests-integration/Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests/TestDocument.cs
@@ -7,6 +7,8 @@ using Elastic.CommonSchema;
 
 namespace Elastic.Ingest.Elasticsearch.CommonSchema.IntegrationTests;
 
+public enum MyEnum { One, Two, Three }
+
 public class TimeSeriesDocument : EcsDocument
 {
 }

--- a/tests/Elastic.CommonSchema.Tests/Serializes.cs
+++ b/tests/Elastic.CommonSchema.Tests/Serializes.cs
@@ -247,12 +247,8 @@ namespace Elastic.CommonSchema.Tests
 				Ecs = new Ecs { Version = "8.11.0" }
 			};
 
-			var options = new JsonSerializerOptions
-			{
-				Converters = { new JsonStringEnumConverter() }
-			};
-
-			var json = JsonSerializer.Serialize(ecsDocument, options);
+			var serializerOptions = new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } };
+			var json = JsonSerializer.Serialize(ecsDocument, serializerOptions);
 
 			json.Should().Be("{\"@timestamp\":\"2024-05-27T23:56:15.785+00:00\",\"message\":\"Hello World!\",\"ecs.version\":\"8.11.0\",\"metadata\":{\"MyEnum\":\"Two\"}}");
 		}

--- a/tests/Elastic.CommonSchema.Tests/Serializes.cs
+++ b/tests/Elastic.CommonSchema.Tests/Serializes.cs
@@ -247,8 +247,10 @@ namespace Elastic.CommonSchema.Tests
 				Ecs = new Ecs { Version = "8.11.0" }
 			};
 
-			var options = EcsJsonConfiguration.SerializerOptions;
-			options.Converters.Add(new JsonStringEnumConverter());
+			var options = new JsonSerializerOptions
+			{
+				Converters = { new JsonStringEnumConverter() }
+			};
 
 			var json = JsonSerializer.Serialize(ecsDocument, options);
 

--- a/tools/Elastic.CommonSchema.Generator/Views/EcsDocumentJsonConverter.Generated.cshtml
+++ b/tools/Elastic.CommonSchema.Generator/Views/EcsDocumentJsonConverter.Generated.cshtml
@@ -27,7 +27,8 @@ namespace Elastic.CommonSchema.Serialization
 			TBase ecsEvent, 
 			ref DateTimeOffset? timestamp, 
 			ref string loglevel,
-			ref string ecsVersion
+			ref string ecsVersion,
+			JsonSerializerOptions options
 		)
 		{
 			var propertyName = reader.GetString();
@@ -36,21 +37,21 @@ namespace Elastic.CommonSchema.Serialization
 			{
 				"log.level" => ReadString(ref reader, ref loglevel),
 				"ecs.version" => ReadString(ref reader, ref ecsVersion),
-				"metadata" => ReadProp@(Raw("<MetadataDictionary>"))(ref reader, "metadata", ecsEvent, (b, v) => b.Metadata = v),
+				"metadata" => ReadProp@(Raw("<MetadataDictionary>"))(ref reader, "metadata", ecsEvent, (b, v) => b.Metadata = v, options),
 @foreach (var property in Model.Base.BaseFieldSet.ValueProperties)
 {
 	var name = property.JsonProperty;
 	if (name == "@timestamp")
-{<text>				"@(name)" => ReadDateTime(ref reader, ref @(name)),
+{<text>				"@(name)" => ReadDateTime(ref reader, ref @(name), options),
 </text>}
 	else
-{<text>				"@(name)" => ReadProp<@(Raw(property.ClrType))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v),
+{<text>				"@(name)" => ReadProp<@(Raw(property.ClrType))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v, options),
 </text>}
 }
 @foreach (var property in Model.Base.BaseFieldSet.InlineObjectProperties)
 {
 	var name = property.JsonProperty;
-<text>				"@(name)" => ReadProp<@(Raw(property.InlineObject.Name))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v),
+<text>				"@(name)" => ReadProp<@(Raw(property.InlineObject.Name))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v, options),
 </text>
 }
 @foreach (var entity in Model.EntityClasses)
@@ -62,7 +63,7 @@ namespace Elastic.CommonSchema.Serialization
 					typeof(@(Model.Base.Name)) == ecsEvent.GetType()
 						? false
 						: ecsEvent.TryRead(propertyName, out var t)
-							? ecsEvent.ReceiveProperty(propertyName, ReadPropDeserialize(ref reader, t))
+							? ecsEvent.ReceiveProperty(propertyName, ReadPropDeserialize(ref reader, t, options))
 							: false
 			};
 		}
@@ -77,12 +78,12 @@ namespace Elastic.CommonSchema.Serialization
 			}
 			writer.WriteStartObject();
 
-			WriteTimestamp(writer, value);
+			WriteTimestamp(writer, value, options);
 			WriteLogLevel(writer, value);
 			WriteMessage(writer, value);
 			WriteEcsVersion(writer, value);
-			WriteLogEntity(writer, value.Log);
-			WriteEcsEntity(writer, value.Ecs);
+			WriteLogEntity(writer, value.Log, options);
+			WriteEcsEntity(writer, value.Ecs, options);
 
 			// Base fields
 @{
@@ -94,15 +95,16 @@ namespace Elastic.CommonSchema.Serialization
 	{
 		continue;
 	}
-	<text>			WriteProp(writer, "@field.JsonProperty", value.@field.Name);
-	</text>
+<text>			WriteProp(writer, "@field.JsonProperty", value.@field.Name, options);
+</text>
 }
 @foreach (var property in Model.Base.BaseFieldSet.InlineObjectProperties)
 {
 	var name = property.JsonProperty;
-<text>		WriteProp(writer, "@(name)", value.@(property.InlineObject.Name));
+<text>			WriteProp(writer, "@(name)", value.@(property.InlineObject.Name), options);
 </text>
 }
+
 			// Complex types
 @foreach (var entity in Model.EntityClasses)
 {
@@ -111,13 +113,13 @@ namespace Elastic.CommonSchema.Serialization
 	{
 		continue;
 	}
-<text>			WriteProp(writer, "@(entityName)", value.@(entity.Name), EcsJsonContext.Default.@(entity.Name));
+<text>			WriteProp(writer, "@(entityName)", value.@(entity.Name), EcsJsonContext.Default.@(entity.Name), options);
 </text>
 }
-			WriteProp(writer, "metadata", value.Metadata);
+			WriteProp(writer, "metadata", value.Metadata, options);
 
 			if (typeof(@Model.Base.Name) != value.GetType())
-				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v));
+				value.WriteAdditionalProperties((k, v) => WriteProp(writer, k, v, options));
 			writer.WriteEndObject();
 		}
 	}

--- a/tools/Elastic.CommonSchema.Generator/Views/PropertiesReaderJsonConverterBase.Generated.cshtml
+++ b/tools/Elastic.CommonSchema.Generator/Views/PropertiesReaderJsonConverterBase.Generated.cshtml
@@ -67,7 +67,7 @@ internal partial class @(entity.Name)EntityJsonConverter : PropertiesReaderJsonC
 			{
 				continue;
 			}
-<text>		WriteProp(writer, "@field.JsonProperty", value.@field.Name, options);
+<text>		WriteProp@(Raw(field.ReadJsonType))(writer, "@field.JsonProperty", value.@field.Name);
 </text>
 		}
 		@foreach (var property in entity.BaseFieldSet.InlineObjectProperties)

--- a/tools/Elastic.CommonSchema.Generator/Views/PropertiesReaderJsonConverterBase.Generated.cshtml
+++ b/tools/Elastic.CommonSchema.Generator/Views/PropertiesReaderJsonConverterBase.Generated.cshtml
@@ -27,7 +27,7 @@ namespace Elastic.CommonSchema.Serialization;
 internal partial class @(entity.Name)EntityJsonConverter : PropertiesReaderJsonConverterBase@(Raw("<"))@(entity.Name)@Raw(">")
 {
 	/// <inheritdoc cref="PropertiesReaderJsonConverterBase{T}.ReadProperties"/>
-	protected override bool ReadProperties(ref Utf8JsonReader reader, @entity.Name ecsEvent)
+	protected override bool ReadProperties(ref Utf8JsonReader reader, @entity.Name ecsEvent, JsonSerializerOptions options)
 	{
 		var propertyName = reader.GetString();
 		reader.Read();
@@ -42,14 +42,14 @@ internal partial class @(entity.Name)EntityJsonConverter : PropertiesReaderJsonC
 		@foreach (var property in entity.BaseFieldSet.InlineObjectProperties)
 		{
 			var name = property.JsonProperty;
-<text>	"@(name)" => ReadProp<@(Raw(property.InlineObject.Name))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v),
+<text>			"@(name)" => ReadProp<@(Raw(property.InlineObject.Name))>(ref reader, "@name", ecsEvent, (b, v) => b.@(property.Name) = v, options),
 </text>
 		}
-			_ => ReadProperty(ref reader, propertyName, ecsEvent)
+			_ => ReadProperty(ref reader, propertyName, ecsEvent, options)
 		};
 	}
 
-	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, @entity.Name ecsEvent);
+	private partial bool ReadProperty(ref Utf8JsonReader reader, string propertyName, @entity.Name ecsEvent, JsonSerializerOptions options);
 		
 	/// <inheritdoc cref="JsonConverter{T}.Write"/>
 	public override void Write(Utf8JsonWriter writer, @entity.Name value, JsonSerializerOptions options)
@@ -67,13 +67,13 @@ internal partial class @(entity.Name)EntityJsonConverter : PropertiesReaderJsonC
 			{
 				continue;
 			}
-<text>		WriteProp(writer, "@field.JsonProperty", value.@field.Name);
+<text>		WriteProp(writer, "@field.JsonProperty", value.@field.Name, options);
 </text>
 		}
 		@foreach (var property in entity.BaseFieldSet.InlineObjectProperties)
 		{
 			var name = property.JsonProperty;
-<text>		WriteProp(writer, "@(name)", value.@(property.Name));
+<text>		WriteProp(writer, "@(name)", value.@(property.Name), options);
 </text>
 		}
 


### PR DESCRIPTION
This proposal enables users to supply their own event writers, while also honoring the serialization options they specify.
Furthermore, it introduces the capability to represent enums as strings, thereby enhancing flexibility and usability.

_Generated files have been updated by Elastic.CommonSchema.Generator project_