### PR TITLE
Making logger provider the sole manager of channel lifecycle.

### DIFF
--- a/src/Elastic.Extensions.Logging/ElasticsearchLogger.cs
+++ b/src/Elastic.Extensions.Logging/ElasticsearchLogger.cs
@@ -21,25 +21,25 @@ namespace Elastic.Extensions.Logging
 	public class ElasticsearchLogger : ILogger
 	{
 		private readonly string _categoryName;
-		private readonly IBufferedChannel<LogEvent> _channel;
+		private IBufferedChannel<LogEvent> _channel => _channelProvider.GetChannel();
+		private readonly IChannelProvider _channelProvider;
 		private readonly ElasticsearchLoggerOptions _options;
 		private readonly IExternalScopeProvider? _scopeProvider;
 
 		/// <inheritdoc cref="IChannelDiagnosticsListener"/>
-		public IChannelDiagnosticsListener? DiagnosticsListener { get; }
+		public IChannelDiagnosticsListener? DiagnosticsListener => _channel.DiagnosticsListener;
 
 		internal ElasticsearchLogger(
 			string categoryName,
-			IBufferedChannel<LogEvent> channel,
+			IChannelProvider channelProvider,
 			ElasticsearchLoggerOptions options,
 			IExternalScopeProvider? scopeProvider
 		)
 		{
 			_categoryName = categoryName;
-			_channel = channel;
 			_options = options;
+			_channelProvider = channelProvider;
 			_scopeProvider = scopeProvider;
-			DiagnosticsListener = channel.DiagnosticsListener;
 		}
 
 		/// <inheritdoc cref="ILogger.BeginScope{TState}"/>

--- a/src/Elastic.Extensions.Logging/ElasticsearchLoggerProvider.cs
+++ b/src/Elastic.Extensions.Logging/ElasticsearchLoggerProvider.cs
@@ -25,7 +25,7 @@ namespace Elastic.Extensions.Logging
 	/// instances to <see cref="LoggerFactory"/>
 	/// </summary>
 	[ProviderAlias("Elasticsearch")]
-	public class ElasticsearchLoggerProvider : ILoggerProvider, ISupportExternalScope
+	public class ElasticsearchLoggerProvider : ILoggerProvider, ISupportExternalScope, IChannelProvider
 	{
 		private readonly IChannelSetup[] _channelConfigurations;
 		private readonly IOptionsMonitor<ElasticsearchLoggerOptions> _options;
@@ -59,7 +59,7 @@ namespace Elastic.Extensions.Logging
 
 		/// <inheritdoc cref="ILoggerProvider.CreateLogger"/>
 		public ILogger CreateLogger(string name) =>
-			new ElasticsearchLogger(name, _shipper, _options.CurrentValue, _scopeProvider);
+			new ElasticsearchLogger(name, this, _options.CurrentValue, _scopeProvider);
 
 		/// <inheritdoc cref="IDisposable.Dispose"/>
 		public void Dispose()
@@ -189,5 +189,8 @@ namespace Elastic.Extensions.Logging
 				return channel;
 			}
 		}
+
+		/// <inheritdoc cref="IChannelProvider.GetChannel"/>
+		public IBufferedChannel<LogEvent> GetChannel() => _shipper;
 	}
 }

--- a/src/Elastic.Extensions.Logging/IChannelProvider.cs
+++ b/src/Elastic.Extensions.Logging/IChannelProvider.cs
@@ -1,0 +1,20 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Channels;
+
+namespace Elastic.Extensions.Logging
+{
+	/// <summary>
+	/// Instantiates and manages <see cref="IBufferedChannel{TEvent}"/>
+	/// </summary>
+	internal interface IChannelProvider
+	{
+		/// <summary>
+		/// Provides <see cref="IBufferedChannel{TEvent}"/> instance managed by provider
+		/// </summary>
+		/// <returns></returns>
+		IBufferedChannel<LogEvent> GetChannel();
+	}
+}


### PR DESCRIPTION
Fixes a bug where ElasticsearchLoggerProvider passes a reference to EcsDataStreamChannel when instantiating ElasticsearchLogger and disposes of the channel on configuration reload events, leading to ElasticsearchLogger instances hanging on to a disposed channel and silently dropping log events.