### PR TITLE
Update serilog.asciidoc

### DIFF
--- a/docs/formatters/serilog.asciidoc
+++ b/docs/formatters/serilog.asciidoc
@@ -80,7 +80,7 @@ An example of the output is given below:
 
 |`MapCurrentThead` | `true` map `ecs.process` by looking up the `Process` from the current thread
 |`MapHttpAdapter` | `null` a way to map `HttpContextAccessor` to ECS fields. 
-|`LogEventsPropertiesToFilter` | A `Set<string>` of properties that should not be emitted as `labels.*` or `metadata.*`
+|`LogEventPropertiesToFilter` | A `Set<string>` of properties that should not be emitted as `labels.*` or `metadata.*`
 |`MapCustom` | A Func that allows you to mutate the EcsDocument before its fully converted.
 |===
 


### PR DESCRIPTION
Fixes typo of "LogEventsPropertiesToFilter" to "LogEventPropertiesToFilter" Example: https://github.com/elastic/ecs-dotnet/blob/4c58514ddebbf68964ddf2db486714e74ae68796/tests/Elastic.CommonSchema.Serilog.Tests/LogEventPropFilterTests.cs#L31