### PR TITLE
Fix test-reporter permissions

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   actions: read
+  checks: write
 
 jobs:
   report:


### PR DESCRIPTION
This should fix https://github.com/elastic/ecs-dotnet/actions/runs/10830292993