### PR TITLE
Update to latest ingest that attempts to flush out buffer before fully disposing

### DIFF
--- a/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
+++ b/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.7.0" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Elastic.Serilog.Sinks/ElasticsearchSink.cs
+++ b/src/Elastic.Serilog.Sinks/ElasticsearchSink.cs
@@ -93,7 +93,7 @@ namespace Elastic.Serilog.Sinks
 	}
 
 	/// <inheritdoc cref="ElasticsearchSink"/>>
-	public class ElasticsearchSink<TEcsDocument> : ILogEventSink
+	public class ElasticsearchSink<TEcsDocument> : ILogEventSink, IDisposable
 		where TEcsDocument : EcsDocument, new()
 	{
 		private readonly EcsTextFormatterConfiguration<TEcsDocument> _formatterConfiguration;
@@ -121,6 +121,8 @@ namespace Elastic.Serilog.Sinks
 			_channel.TryWrite(ecsDoc);
 		}
 
+		/// <summary> Disposes and flushed <see cref="EcsDataStreamChannel{TEcsDocument}"/> </summary>
+		public void Dispose() => _channel.Dispose();
 	}
 
 	internal class SelfLogCallbackListener<TEcsDocument> : IChannelCallbacks<TEcsDocument, BulkResponse> where TEcsDocument : EcsDocument, new()

--- a/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
+++ b/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" />
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.3" />
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.7.0" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.7.1" />
 
   </ItemGroup>
 


### PR DESCRIPTION
This also updates our serology sink to implement `IDisposable` so it waits to flush as well. See also #411 