### PR TITLE
Update extensions-logging documentation with a working example

### DIFF
--- a/docs/data-shippers/extensions-logging.asciidoc
+++ b/docs/data-shippers/extensions-logging.asciidoc
@@ -57,7 +57,9 @@ The other useful value to configure is a tag for the environment, e.g. Developme
 {
   "Logging": {
     "Elasticsearch": {
-      "NodeUris": [ "https://elastic-staging.example.com:9200" ],
+	  "ShipTo": {
+		"NodeUris": [ "https://elastic-staging.example.com:9200" ]
+	  },
       "Tags": [ "Staging" ]
     }
   }


### PR DESCRIPTION
The current example of the appsettings are incorrect and when using the example it will push to the logs to the default NodeUris which is `http://localhost:9200`.

The actual Configuration structure contains a `ShipTo` which needs to be reflected accordingly in the AppSettings as well.