### PR TITLE
NLog EcsLayout stop using obsolete ConfigurationItemFactory members

### DIFF
--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -68,7 +68,7 @@ namespace Elastic.CommonSchema.NLog
 			_defaultAgent = EcsDocument.CreateAgent(typeof(EcsLayout));
 
 			// These values are set by the Elastic.Apm.NLog package
-			if (NLogApmLoaded())
+			if (NLogApmLoaded.Value)
 			{
 				ApmTraceId = "${ElasticApmTraceId}";
 				ApmTransactionId = "${ElasticApmTransactionId}";
@@ -88,7 +88,7 @@ namespace Elastic.CommonSchema.NLog
 		{
 			if (CanIncludeAspNetProperties())
 			{
-				if (NLogWeb5Registered())
+				if (NLogWeb5Registered.Value)
 					EventDurationMs = "${aspnet-request-duration}";
 
 				HttpRequestId = "${aspnet-TraceIdentifier}";
@@ -104,25 +104,25 @@ namespace Elastic.CommonSchema.NLog
 				UrlQuery = "${aspnet-request-url:IncludeScheme=false:IncludeHost=false:IncludePath=false:IncludeQueryString=true}";
 				UrlUserName = "${aspnet-user-identity}";
 
-				if (!NLogApmLoaded())
+				if (!NLogApmLoaded.Value)
 					ApmTraceId = "${scopeproperty:item=RequestId:whenEmpty=${aspnet-TraceIdentifier}}";
 			}
 
 			base.InitializeLayout();
 		}
 
-		private static bool NLogApmLoaded() => Type.GetType("Elastic.Apm.NLog.ApmTraceIdLayoutRenderer, Elastic.Apm.NLog") != null;
+		private static Lazy<bool> NLogApmLoaded { get; } = new Lazy<bool>(() => Type.GetType("Elastic.Apm.NLog.ApmTraceIdLayoutRenderer, Elastic.Apm.NLog") != null);
 
 #if NETFRAMEWORK
-		private static bool NLogWeb4Registered() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestCookieLayoutRenderer, NLog.Web") != null;
+		private static Lazy<bool> NLogWeb4Registered { get; } = new Lazy<bool>(() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestCookieLayoutRenderer, NLog.Web") != null);
 #else
-		private static bool NLogWeb4Registered() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestCookieLayoutRenderer, NLog.Web.AspNetCore") != null;
+		private static Lazy<bool> NLogWeb4Registered { get; } = new Lazy<bool>(() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestCookieLayoutRenderer, NLog.Web.AspNetCore") != null);
 #endif
 
 #if NETFRAMEWORK
-		private static bool NLogWeb5Registered() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestDurationLayoutRenderer, NLog.Web") != null;
+		private static Lazy<bool> NLogWeb5Registered { get; } = new Lazy<bool>(() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestDurationLayoutRenderer, NLog.Web") != null);
 #else
-		private static bool NLogWeb5Registered() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestDurationLayoutRenderer, NLog.Web.AspNetCore") != null;
+		private static Lazy<bool> NLogWeb5Registered { get; } = new Lazy<bool>(() => Type.GetType("NLog.Web.LayoutRenderers.AspNetRequestDurationLayoutRenderer, NLog.Web.AspNetCore") != null);
 #endif
 
 		/// <summary></summary>
@@ -216,7 +216,7 @@ namespace Elastic.CommonSchema.NLog
 		/// <summary>
 		/// Tests if aspnet properties would be rendered
 		/// </summary>
-		public bool CanIncludeAspNetProperties() => IncludeAspNetProperties && NLogWeb4Registered();
+		public bool CanIncludeAspNetProperties() => IncludeAspNetProperties && NLogWeb4Registered.Value;
 
 		/// <summary></summary>
 		[ArrayParameter(typeof(TargetPropertyWithContext), "label")]

--- a/src/Elastic.NLog.Targets/ElasticsearchTarget.cs
+++ b/src/Elastic.NLog.Targets/ElasticsearchTarget.cs
@@ -295,8 +295,7 @@ namespace NLog.Targets
 						+ $"'{nameof(Username)}' and '{nameof(Password)}");
 				//case ElasticPoolType.StickySniffing:
 				default:
-					throw new NLogConfigurationException($"Unrecognised ElasticSearch connection pool type '{NodePoolType}' specified in the configuration.",
-						nameof(NodePoolType));
+					throw new NLogConfigurationException($"Unrecognised ElasticSearch connection pool type '{NodePoolType}' specified in the configuration.");
 			}
 		}
 


### PR DESCRIPTION
NLog v5 have marked the `ConfigurationItemFactory`-members as obsolete, and they will be removed with NLog v6 (to fix build-warnings about .NET trimming and AOT).

This PullRequest will allow the NLog EcsLayout to continue to work, when NLog v6 is released, and users are upgrading.