### PR TITLE
NLog v5.2.5

### DIFF
--- a/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
@@ -13,7 +13,7 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmServiceName as special logging variable to render the current Elastic APM Service Name
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe, ThreadAgnostic]
+[ThreadAgnostic]
 public class ApmServiceNameLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
@@ -9,7 +9,7 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmServiceNodeName as special logging variable to render the current Elastic APM Service Node Name
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe, ThreadAgnostic]
+[ThreadAgnostic]
 public class ApmServiceNodeNameLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
@@ -9,7 +9,7 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmServiceVersion as special logging variable to render the current Elastic APM Service Version
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe, ThreadAgnostic]
+[ThreadAgnostic]
 public class ApmServiceVersionLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmSpanIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmSpanIdLayoutRenderer.cs
@@ -9,7 +9,6 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmSpanId as special logging variable to render the current Elastic APM Span Id
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe]
 public class ApmSpanIdLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
@@ -13,7 +13,6 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmTraceId as special logging variable to render the current Elastic APM Trace Id
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe]
 public class ApmTraceIdLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
@@ -13,7 +13,6 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmTransactionId as special logging variable to render the current Elastic APM Transaction Id
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe]
 public class ApmTransactionIdLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -13,7 +13,7 @@
       Feel free to open an issue on our repos to discuss if you feel you need to target 
       a lower NLog version
     -->
-    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog" Version="5.2.5" />
     <PackageReference Include="Elastic.Apm" Version="1.22.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.NLog/EcsLayout.cs
+++ b/src/Elastic.CommonSchema.NLog/EcsLayout.cs
@@ -27,7 +27,6 @@ namespace Elastic.CommonSchema.NLog
 
 	/// <summary> An NLOG layout implementation that renders logs as ECS json</summary>
 	[Layout(Name)]
-	[ThreadSafe]
 	[ThreadAgnostic]
 	public class EcsLayout : Layout
 	{
@@ -59,7 +58,6 @@ namespace Elastic.CommonSchema.NLog
 			ProcessThreadId = "${threadid}";
 
 			HostName = "${hostname}";	// NLog 4.6
-			HostIp = "${local-ip:cachedSeconds=60}"; // NLog 4.6.8
 
 			ServerUser = "${environment-user}"; // NLog 4.6.4
 
@@ -103,9 +101,6 @@ namespace Elastic.CommonSchema.NLog
 				UrlPort = "${aspnet-request-url:IncludeScheme=false:IncludeHost=false:IncludePath=false:IncludePort=true}";
 				UrlQuery = "${aspnet-request-url:IncludeScheme=false:IncludeHost=false:IncludePath=false:IncludeQueryString=true}";
 				UrlUserName = "${aspnet-user-identity}";
-
-				if (!NLogApmLoaded.Value)
-					ApmTraceId = "${scopeproperty:item=RequestId:whenEmpty=${aspnet-TraceIdentifier}}";
 			}
 
 			base.InitializeLayout();
@@ -392,15 +387,14 @@ namespace Elastic.CommonSchema.NLog
 
 			if (IncludeScopeProperties)
 			{
-				foreach (var key in MappedDiagnosticsLogicalContext.GetNames())
+				foreach (var scopeProperty in ScopeContext.GetAllProperties())
 				{
-					if (string.IsNullOrEmpty(key) || ExcludeProperties.Contains(key))
+					if (string.IsNullOrEmpty(scopeProperty.Key) || ExcludeProperties.Contains(scopeProperty.Key))
 						continue;
 
-					var propertyValue = MappedDiagnosticsLogicalContext.GetObject(key);
-					if (!TryPopulateWhenSafe(metadata, key, propertyValue))
+					if (!TryPopulateWhenSafe(metadata, scopeProperty.Key, scopeProperty.Value))
 					{
-						Populate(metadata, key, propertyValue.ToString());
+						Populate(metadata, scopeProperty.Key, scopeProperty.Value.ToString());
 					}
 				}
 			}

--- a/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
+++ b/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
@@ -11,6 +11,6 @@
       <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NLog" Version="4.7.15" />
+      <PackageReference Include="NLog" Version="5.2.5" />
     </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.NLog/README.md
+++ b/src/Elastic.CommonSchema.NLog/README.md
@@ -76,7 +76,7 @@ the NLog FileTarget and [Elastic Filebeat](https://www.elastic.co/downloads/beat
 
 * **Host Options**
   -	_HostId_ -
-  -	_HostIp_ - Default: `${local-ip:cachedSeconds=60}`
+  -	_HostIp_ - 
   -	_HostName_ - Default: `${machinename}`
 
 * **Log Origin Options**
@@ -100,7 +100,8 @@ the NLog FileTarget and [Elastic Filebeat](https://www.elastic.co/downloads/beat
   - _UrlUserName_ - Default: `${aspnet-user-identity}`
 
 * **Trace Options**
-  - _ApmTraceId_ - Default: `${ElasticApmTraceId}`
+  - _ApmTraceId_ - Default: `System.Diagnostics.Activity.Current.TraceId`
+  - _ApmSpanId_ - Default: `System.Diagnostics.Activity.Current.SpanId`
 
 * **Transaction Options**
   - _ApmTransactionId_ - Default: `${ElasticApmTransactionId}`

--- a/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
+++ b/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Apm" Version="1.22.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NLog" Version="4.7.15" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.5" />
+    <PackageReference Include="NLog" Version="5.2.5" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.5" />
     <PackageReference Update="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/tests/Elastic.Apm.NLog.Tests/NLogTests.cs
+++ b/tests/Elastic.Apm.NLog.Tests/NLogTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -14,8 +14,15 @@ namespace Elastic.Apm.NLog.Tests
 	{
 		public NLogTests()
 		{
-			var assembly = typeof(ApmTraceIdLayoutRenderer).Assembly;
-			global::NLog.Config.ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
+			global::NLog.LogManager.Setup().SetupExtensions(ext =>
+			{
+				ext.RegisterLayoutRenderer<ApmTraceIdLayoutRenderer>(ApmTraceIdLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmTransactionIdLayoutRenderer>(ApmTransactionIdLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmSpanIdLayoutRenderer>(ApmSpanIdLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmServiceNameLayoutRenderer>(ApmServiceNameLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmServiceVersionLayoutRenderer>(ApmServiceVersionLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmServiceNodeNameLayoutRenderer>(ApmServiceNodeNameLayoutRenderer.Name);
+			});
 
 			var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
 			if (!Agent.IsConfigured)
@@ -33,9 +40,9 @@ namespace Elastic.Apm.NLog.Tests
 			var target = new MemoryTarget();
 			target.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${ElasticApmSpanId}|${message}";
 
-			global::NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Debug);
+			var logFactory = new global::NLog.LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(target)).LogFactory;
 
-			var logger = LogManager.GetLogger("Example");
+			var logger = logFactory.GetLogger("Example");
 
 			logger.Debug("PreTransaction");
 
@@ -72,9 +79,9 @@ namespace Elastic.Apm.NLog.Tests
 			var target = new MemoryTarget();
 			target.Layout = "${ElasticApmServiceName}|${ElasticApmServiceNodeName}|${ElasticApmServiceVersion}|${message}";
 
-			global::NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Debug);
+			var logFactory = new global::NLog.LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(target)).LogFactory;
 
-			var logger = LogManager.GetLogger("Example");
+			var logger = logFactory.GetLogger("Example");
 
 			logger.Debug("Some log");
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NLog" Version="4.7.15" />
-        <PackageReference Include="NLog.Web.AspNetCore" Version="4.15.0" />
+        <PackageReference Include="NLog" Version="5.2.5" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.5" />
         <PackageReference Include="Elastic.Apm" Version="1.22.0" />
         <PackageReference Update="xunit" Version="2.9.3" />
     </ItemGroup>

--- a/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
@@ -228,7 +228,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 		[Fact]
 		public void MetadataWithSameKeys() => TestLogger((logger, getLogEvents) =>
 		{
-			using (MappedDiagnosticsLogicalContext.SetScoped("DupKey", "Mdlc"))
+			using (ScopeContext.PushProperty("DupKey", "Mdlc"))
 			{
 				logger.Info("Info {DupKey}", "LoggerArg");
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/WebTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/WebTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using FluentAssertions;
+using NLog;
 using NLog.Config;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,25 +18,16 @@ namespace Elastic.CommonSchema.NLog.Tests
 
 		private void TestLayout(bool withNLogWeb, Action<EcsLayout> setup, Action<EcsLayout> act)
 		{
-			// Setup basic factory without automatic loading of NLog extensions.
-			ConfigurationItemFactory.Default = new(typeof(ConfigurationItemFactory).Assembly);
-
-			try
+			if (withNLogWeb)
 			{
-				if (withNLogWeb)
-				{
-					var nlogWebAssemblyName = new AssemblyName("NLog.Web.AspNetCore");
-					var nlogWebAssembly = Assembly.Load(nlogWebAssemblyName);
-					ConfigurationItemFactory.Default.RegisterItemsFromAssembly(nlogWebAssembly);
-				}
+				var nlogWebAssemblyName = new AssemblyName("NLog.Web.AspNetCore");
+				var nlogWebAssembly = Assembly.Load(nlogWebAssemblyName);
+#pragma warning disable CS0618 // Type or member is obsolete
+				ConfigurationItemFactory.Default.RegisterItemsFromAssembly(nlogWebAssembly);
+#pragma warning restore CS0618 // Type or member is obsolete
+			}
 
-				TestLoggerAndLayout(setup, (layout, logger, events) => act(layout));
-			}
-			finally
-			{
-				// Cleanup for the sake of other tests.
-				ConfigurationItemFactory.Default = null;
-			}
+			TestLoggerAndLayout(setup, (layout, logger, events) => act(layout));
 		}
 
 		[Theory]


### PR DESCRIPTION
Maybe the next major-version could also include NLog upgrade?

- NLog v5.2.5 released 15 Oct 2023

Also removed assignment of `HostIp = "${local-ip:cachedSeconds=60}`, since NLog v6 requires extra dependencies for network-stack.