### PR TITLE
[backport] AOT Annotations and CI smoke tests for AOT publishes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,4 +119,4 @@ jobs:
         run: dotnet publish examples/ecs-aot-smoketest
 
       - name: Invoke AOT
-        run: ./examples/ecs-aot-smoketest/bin/release/net9.0/${{ matrix.os.folder }}/${{ matrix.os.binary }}
+        run: ./examples/ecs-aot-smoketest/bin/Release/net9.0/${{ matrix.os.folder }}/publish/${{ matrix.os.binary }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,4 +119,4 @@ jobs:
         run: dotnet publish examples/ecs-aot-smoketest
 
       - name: Invoke AOT
-        run: ./examples/ecs-aot-smoketest/bin/Release/net9.0/${{ matrix.os.folder }}/${{ matrix.os.binary }}
+        run: ./examples/ecs-aot-smoketest/bin/release/net9.0/${{ matrix.os.folder }}/${{ matrix.os.binary }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,3 +92,31 @@ jobs:
       with:
         name: test-results-linux
         path: build/output/junit-*.xml
+
+  aot-validate:
+    runs-on: ${{ matrix.os.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - runner: ubuntu-latest
+            folder: linux-x64
+            binary: ecs-aot-smoketest
+          - runner: macos-latest
+            folder: osx-arm64
+            binary: ecs-aot-smoketest
+          - runner: windows-latest
+            folder: win-x64
+            binary: ecs-aot-smoketest.exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: ./global.json
+
+      - name: Publish AOT
+        run: dotnet publish examples/ecs-aot-smoketest
+
+      - name: Invoke AOT
+        run: ./examples/ecs-aot-smoketest/bin/Release/net9.0/${{ matrix.os.folder }}/${{ matrix.os.binary }}

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "nupkg-validator": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "commands": [
         "nupkg-validator"
       ],

--- a/ecs-dotnet.sln
+++ b/ecs-dotnet.sln
@@ -141,6 +141,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Serilog.Sinks.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Serilog.Enrichers.Web", "src\Elastic.Serilog.Enrichers.Web\Elastic.Serilog.Enrichers.Web.csproj", "{B6DCC4C4-1287-41BE-A19D-8F311C6E39F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ecs-aot-smoketest", "examples\ecs-aot-smoketest\ecs-aot-smoketest.csproj", "{46706BAE-BBCD-4DD9-ADBD-AC099C770854}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -311,6 +313,10 @@ Global
 		{B6DCC4C4-1287-41BE-A19D-8F311C6E39F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6DCC4C4-1287-41BE-A19D-8F311C6E39F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6DCC4C4-1287-41BE-A19D-8F311C6E39F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46706BAE-BBCD-4DD9-ADBD-AC099C770854}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46706BAE-BBCD-4DD9-ADBD-AC099C770854}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46706BAE-BBCD-4DD9-ADBD-AC099C770854}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46706BAE-BBCD-4DD9-ADBD-AC099C770854}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -358,6 +364,7 @@ Global
 		{5EDF109F-9DFF-4957-8864-BA2702FB78F6} = {7610B796-BB3E-4CB2-8296-79BBFF6D23FC}
 		{933FD923-A2DC-49E3-B21E-8BA888DB5924} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 		{B6DCC4C4-1287-41BE-A19D-8F311C6E39F7} = {7610B796-BB3E-4CB2-8296-79BBFF6D23FC}
+		{46706BAE-BBCD-4DD9-ADBD-AC099C770854} = {05075402-8669-45BD-913A-BD40A29BBEAB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/examples/Elastic.Extensions.Logging.Console.Example/Program.cs
+++ b/examples/Elastic.Extensions.Logging.Console.Example/Program.cs
@@ -6,6 +6,7 @@ using Elastic.Extensions.Logging.Console.Example;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Host = Microsoft.Extensions.Hosting.Host;
 
 await Host.CreateDefaultBuilder(args)
@@ -24,4 +25,3 @@ await Host.CreateDefaultBuilder(args)
 	})
 	.Build()
 	.RunAsync();
-

--- a/examples/Elastic.Serilog.Sinks.Example/Elastic.Serilog.Sinks.Example.csproj
+++ b/examples/Elastic.Serilog.Sinks.Example/Elastic.Serilog.Sinks.Example.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="Elastic.Apm" Version="1.22.0" />
-      <PackageReference Include="Serilog" Version="4.1.0" />
+      <PackageReference Include="Serilog" Version="4.3.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
       <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.16.2" />
       <PackageReference Include="Elastic.Elasticsearch.Ephemeral" Version="0.6.0" />

--- a/examples/aspnetcore-with-serilog/AspnetCoreExample.csproj
+++ b/examples/aspnetcore-with-serilog/AspnetCoreExample.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Apm" Version="1.22.0" />
     <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.22.0" />
-    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/examples/ecs-aot-smoketest/ExtensionsLogger.cs
+++ b/examples/ecs-aot-smoketest/ExtensionsLogger.cs
@@ -1,0 +1,50 @@
+using Elastic.Channels.Diagnostics;
+using Elastic.Extensions.Logging;
+using Elastic.Extensions.Logging.Options;
+using Elastic.Transport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+public class ExtensionsLogger(ITransport<ITransportConfiguration> transport)
+{
+	public IDisposable CreateExtensionsLogger(
+		out ILogger logger,
+		out ElasticsearchLoggerProvider provider,
+		out string @namespace,
+		out WaitHandle waitHandle,
+		out IChannelDiagnosticsListener listener
+	)
+	{
+		@namespace = Guid.NewGuid().ToString("N").ToLowerInvariant().Substring(0, 6);
+		var slim = new CountdownEvent(1);
+		waitHandle = slim.WaitHandle;
+		var s = @namespace;
+		var options = new ConfigureOptions<ElasticsearchLoggerOptions>(o =>
+		{
+			o.Transport = transport;
+			o.DataStream = new DataStreamNameOptions { Type = "x", Namespace = s, DataSet = "dotnet" };
+			var nodes = transport.Configuration.NodePool.Nodes.Select(n => n.Uri).ToArray();
+			o.ShipTo = new ShipToOptions { NodeUris = nodes, NodePoolType = NodePoolType.Static };
+		});
+
+		var channelSetup = new IChannelSetup[]
+		{
+			new ChannelSetup(c =>
+			{
+				c.BufferOptions.WaitHandle = slim;
+				c.BufferOptions.OutboundBufferMaxSize = 1;
+				c.BufferOptions.OutboundBufferMaxLifetime = TimeSpan.FromSeconds(1);
+				c.BufferOptions.ExportMaxRetries = 0;
+				c.BufferOptions.ExportMaxConcurrency = 1;
+			})
+		};
+
+		var optionsFactory = new OptionsFactory<ElasticsearchLoggerOptions>([options], []);
+		var optionsMonitor = new OptionsMonitor<ElasticsearchLoggerOptions>(optionsFactory, [], new OptionsCache<ElasticsearchLoggerOptions>());
+		provider = new ElasticsearchLoggerProvider(optionsMonitor, channelSetup);
+		var loggerFactory = new LoggerFactory( [provider], new LoggerFilterOptions { MinLevel = LogLevel.Information });
+		logger = loggerFactory.CreateLogger<ElasticsearchLogger>();
+		listener = provider.DiagnosticsListener!;
+		return loggerFactory;
+	}
+}

--- a/examples/ecs-aot-smoketest/NLogExporter.cs
+++ b/examples/ecs-aot-smoketest/NLogExporter.cs
@@ -1,0 +1,41 @@
+using Elastic.Channels.Diagnostics;
+using Elastic.Transport;
+using NLog.Targets;
+
+public class NLogExporter(ITransport<ITransportConfiguration> transport)
+{
+	public IDisposable CreateNLogLogger(
+		out NLog.Logger logger,
+		out NLog.LogFactory logFactory,
+		out string @namespace,
+		out WaitHandle waitHandle,
+		out IChannelDiagnosticsListener listener
+	)
+	{
+		var slim = new CountdownEvent(1);
+		waitHandle = slim.WaitHandle;
+		@namespace = Guid.NewGuid().ToString("N").ToLowerInvariant().Substring(0, 6);
+
+		logFactory = new NLog.LogFactory();
+		var logConfig = new NLog.Config.LoggingConfiguration(logFactory);
+		var logTarget = new ElasticsearchTarget { Name = "elastic" };
+		logTarget.RequestInvoker = transport.Configuration.RequestInvoker;
+		logTarget.DataStreamNamespace = @namespace;
+		logTarget.OutboundBufferMaxSize = 1;
+		logTarget.OutboundBufferMaxLifetimeSeconds = 1;
+		logTarget.ExportMaxRetries = 0;
+		logTarget.ExportMaxConcurrency = 1;
+		logTarget.ConfigureChannel = (cfg) => cfg.BufferOptions.WaitHandle = slim;
+
+		logTarget.DataStreamType = "x";
+		logTarget.DataStreamSet = "dotnet";
+		var nodesUris = string.Join(",", transport.Configuration.NodePool.Nodes.Select(n => n.Uri.ToString()).ToArray());
+		logTarget.NodeUris = nodesUris;
+		logTarget.NodePoolType = ElasticPoolType.Static;
+		logConfig.AddRuleForAllLevels(logTarget);
+		logFactory.Configuration = logConfig;
+		listener = logTarget.DiagnosticsListener!;
+		logger = logFactory.GetLogger("TestLogger");
+		return logFactory;
+	}
+}

--- a/examples/ecs-aot-smoketest/Program.cs
+++ b/examples/ecs-aot-smoketest/Program.cs
@@ -1,0 +1,22 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using Elastic.CommonSchema;
+
+Console.WriteLine("Hello, World!");
+
+var serialized = @$"{{}}";
+var deserialized = EcsDocument.Deserialize(serialized);
+if (deserialized == null) throw new Exception("deserialized is null");
+
+serialized = @$"{{ ""agent"": {{ ""unknown"": ""value"" }} }}";
+deserialized = EcsDocument.Deserialize(serialized);
+if (deserialized == null) throw new Exception("deserialized is null");
+if (deserialized.Agent == null) throw new Exception("deserialized agent is null");
+
+
+
+var d = new EcsDocument { Agent = new Agent { Name = "some-agent" }, Log = new Log { Level = "debug" } };
+
+serialized = d.Serialize();
+if (string.IsNullOrEmpty(serialized)) throw new Exception("serialized is null");
+Console.WriteLine(serialized);

--- a/examples/ecs-aot-smoketest/Program.cs
+++ b/examples/ecs-aot-smoketest/Program.cs
@@ -1,6 +1,10 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 using Elastic.CommonSchema;
+using Elastic.Transport;
+using Microsoft.Extensions.Logging;
+using Log = Elastic.CommonSchema.Log;
+using LogLevel = NLog.LogLevel;
 
 Console.WriteLine("Hello, World!");
 
@@ -13,10 +17,69 @@ deserialized = EcsDocument.Deserialize(serialized);
 if (deserialized == null) throw new Exception("deserialized is null");
 if (deserialized.Agent == null) throw new Exception("deserialized agent is null");
 
-
-
 var d = new EcsDocument { Agent = new Agent { Name = "some-agent" }, Log = new Log { Level = "debug" } };
 
 serialized = d.Serialize();
 if (string.IsNullOrEmpty(serialized)) throw new Exception("serialized is null");
 Console.WriteLine(serialized);
+
+var invoker = new InMemoryRequestInvoker();
+var pool = new StaticNodePool([new Node(new Uri("http://localhost:9200"))]);
+var configuration = new TransportConfiguration(pool, invoker);
+var transport = new DistributedTransport(configuration);
+
+var extension = new ExtensionsLogger(transport);
+LogInMemoryExtensionsLogger(extension);
+
+var nlog = new NLogExporter(transport);
+LogInMemoryNLog(nlog);
+
+/*
+var serilog = new SerilogExporter(transport);
+LogInMemorySerilog(serilog);
+
+void LogInMemorySerilog(SerilogExporter serilogExporter)
+{
+	using var logger = serilogExporter.CreateSerilogLogger(out var waitHandle, out var listener);
+	logger.Information("an error occurred {Status}", "failure");
+
+	if (!waitHandle.WaitOne(TimeSpan.FromSeconds(10)))
+		throw new Exception($"No flush occurred in 10 seconds: {listener}", listener.ObservedException);
+
+	if (!listener.PublishSuccess)
+		throw new Exception("Serilog Logger did not export correctly");
+	if (listener.ObservedException != null)
+		throw new Exception("Serilog Logger received exception", listener.ObservedException);
+	Console.WriteLine("Serilog Logger export success");
+}
+*/
+
+void LogInMemoryExtensionsLogger(ExtensionsLogger extensionsLogger)
+{
+	using var _ = extensionsLogger.CreateExtensionsLogger(out var logger, out var provider, out var @namespace, out var waitHandle, out var listener);
+	logger.LogError("an error occurred {Status}", "failure");
+
+	if (!waitHandle.WaitOne(TimeSpan.FromSeconds(10)))
+		throw new Exception($"No flush occurred in 10 seconds: {listener}", listener.ObservedException);
+
+	if (!listener.PublishSuccess)
+		throw new Exception("Extensions Logger did not export correctly");
+	if (listener.ObservedException != null)
+		throw new Exception("Extensions Logger received exception", listener.ObservedException);
+	Console.WriteLine("Extensions Logger export success");
+}
+
+void LogInMemoryNLog(NLogExporter serilogExporter)
+{
+	using var _ = serilogExporter.CreateNLogLogger(out var logger, out var _, out var _, out var waitHandle, out var listener);
+	logger.Log(LogLevel.Error, "an error occurred {Status}", "failure");
+
+	if (!waitHandle.WaitOne(TimeSpan.FromSeconds(10)))
+		throw new Exception($"No flush occurred in 10 seconds: {listener}", listener.ObservedException);
+
+	if (!listener.PublishSuccess)
+		throw new Exception("NLog did not export correctly");
+	if (listener.ObservedException != null)
+		throw new Exception("NLog export received exception", listener.ObservedException);
+	Console.WriteLine("NLog export success");
+}

--- a/examples/ecs-aot-smoketest/SerilogExporter.cs
+++ b/examples/ecs-aot-smoketest/SerilogExporter.cs
@@ -1,0 +1,39 @@
+using Elastic.Channels;
+using Elastic.Channels.Diagnostics;
+using Elastic.Ingest.Elasticsearch.DataStreams;
+using Elastic.Serilog.Sinks;
+using Elastic.Transport;
+using Serilog;
+using Serilog.Core;
+
+public class SerilogExporter(ITransport<ITransportConfiguration> transport)
+{
+	public Logger CreateSerilogLogger(out WaitHandle waitHandle, out IChannelDiagnosticsListener listener)
+	{
+		var countdown = new CountdownEvent(1);
+		waitHandle = countdown.WaitHandle;
+
+		IChannelDiagnosticsListener? listen = null;
+		var options = new ElasticsearchSinkOptions(transport)
+		{
+			DataStream = new DataStreamName("logs", "serilog", "tests"),
+			ConfigureChannel = c =>
+			{
+				c.BufferOptions = new BufferOptions
+				{
+					WaitHandle = countdown,
+					OutboundBufferMaxSize = 1
+				};
+			},
+			ChannelDiagnosticsCallback = l => listen = l
+		};
+		listener = listen ?? throw new Exception("No listener");
+
+		var loggerConfig = new LoggerConfiguration()
+			.MinimumLevel.Information()
+			.WriteTo.Elasticsearch(options);
+
+		var logger = loggerConfig.CreateLogger();
+		return logger;
+	}
+}

--- a/examples/ecs-aot-smoketest/ecs-aot-smoketest.csproj
+++ b/examples/ecs-aot-smoketest/ecs-aot-smoketest.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>ecs_aot_smoketest</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.CommonSchema\Elastic.CommonSchema.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/examples/ecs-aot-smoketest/ecs-aot-smoketest.csproj
+++ b/examples/ecs-aot-smoketest/ecs-aot-smoketest.csproj
@@ -13,6 +13,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.CommonSchema\Elastic.CommonSchema.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Extensions.Logging\Elastic.Extensions.Logging.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Ingest.Elasticsearch.CommonSchema\Elastic.Ingest.Elasticsearch.CommonSchema.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.NLog.Targets\Elastic.NLog.Targets.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Serilog.Sinks\Elastic.Serilog.Sinks.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/ecs-aot-smoketest/ecs-aot-smoketest.csproj
+++ b/examples/ecs-aot-smoketest/ecs-aot-smoketest.csproj
@@ -18,5 +18,8 @@
     <ProjectReference Include="..\..\src\Elastic.NLog.Targets\Elastic.NLog.Targets.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Serilog.Sinks\Elastic.Serilog.Sinks.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="6.0.3" />
+  </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,7 +21,7 @@
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
-  <PropertyGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+  <PropertyGroup>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,21 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+  </PropertyGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all"
+                      IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="README.md" Pack="true" PackagePath="README.md" CopyToOutputDirectory="PreserveNewest"/>
     <Content Include="../../nuget-icon.png" CopyToOutputDirectory="PreserveNewest">

--- a/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNameLayoutRenderer.cs
@@ -13,7 +13,7 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmServiceName as special logging variable to render the current Elastic APM Service Name
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe, ThreadAgnostic]
+[ThreadAgnostic]
 public class ApmServiceNameLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceNodeNameLayoutRenderer.cs
@@ -9,7 +9,7 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmServiceNodeName as special logging variable to render the current Elastic APM Service Node Name
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe, ThreadAgnostic]
+[ThreadAgnostic]
 public class ApmServiceNodeNameLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmServiceVersionLayoutRenderer.cs
@@ -9,7 +9,7 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmServiceVersion as special logging variable to render the current Elastic APM Service Version
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe, ThreadAgnostic]
+[ThreadAgnostic]
 public class ApmServiceVersionLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmSpanIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmSpanIdLayoutRenderer.cs
@@ -9,7 +9,6 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmSpanId as special logging variable to render the current Elastic APM Span Id
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe]
 public class ApmSpanIdLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTraceIdLayoutRenderer.cs
@@ -13,7 +13,6 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmTraceId as special logging variable to render the current Elastic APM Trace Id
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe]
 public class ApmTraceIdLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
+++ b/src/Elastic.Apm.NLog/ApmTransactionIdLayoutRenderer.cs
@@ -13,7 +13,6 @@ namespace Elastic.Apm.NLog;
 /// Provides ElasticApmTransactionId as special logging variable to render the current Elastic APM Transaction Id
 /// </summary>
 [LayoutRenderer(Name)]
-[ThreadSafe]
 public class ApmTransactionIdLayoutRenderer : LayoutRenderer
 {
 	/// <summary>

--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -13,7 +13,7 @@
       Feel free to open an issue on our repos to discuss if you feel you need to target 
       a lower NLog version
     -->
-    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="NLog" Version="6.0.2" />
     <PackageReference Include="Elastic.Apm" Version="1.22.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
+++ b/src/Elastic.Apm.NLog/Elastic.Apm.NLog.csproj
@@ -13,7 +13,7 @@
       Feel free to open an issue on our repos to discuss if you feel you need to target 
       a lower NLog version
     -->
-    <PackageReference Include="NLog" Version="6.0.2" />
+    <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="Elastic.Apm" Version="1.22.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm.SerilogEnricher/Elastic.Apm.SerilogEnricher.csproj
+++ b/src/Elastic.Apm.SerilogEnricher/Elastic.Apm.SerilogEnricher.csproj
@@ -6,7 +6,7 @@
     <IsPackable>True</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Elastic.Apm" Version="1.22.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
+++ b/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
@@ -11,6 +11,6 @@
       <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NLog" Version="6.0.2" />
+      <PackageReference Include="NLog" Version="5.5.1" />
     </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
+++ b/src/Elastic.CommonSchema.NLog/Elastic.CommonSchema.NLog.csproj
@@ -11,6 +11,6 @@
       <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="NLog" Version="4.7.15" />
+      <PackageReference Include="NLog" Version="6.0.2" />
     </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema.Serilog/Elastic.CommonSchema.Serilog.csproj
+++ b/src/Elastic.CommonSchema.Serilog/Elastic.CommonSchema.Serilog.csproj
@@ -13,9 +13,6 @@
     <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.1.0" />
-    <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.CommonSchema/EcsDocument.DefaultService.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.DefaultService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -67,6 +68,8 @@ public partial class EcsDocument
 			? entryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
 			: null;
 
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 	private static Assembly? GetEntryAssembly()
 	{
 		var entryAssembly = Assembly.GetEntryAssembly();

--- a/src/Elastic.CommonSchema/EcsDocument.Serialization.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.Serialization.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -68,10 +69,14 @@ namespace Elastic.CommonSchema
 			EcsSerializerFactory<EcsDocument>.DeserializeAsync(stream, ctx);
 
 		/// <summary> Serialize this <see cref="EcsDocument"/> instance to string</summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		public string Serialize() => JsonSerializer.Serialize(this, GetType(), SerializerOptions);
 
 		// ReSharper disable once UnusedMember.Global
 		/// <summary> Serialize this <see cref="EcsDocument"/> instance to utf8 bytes</summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		public byte[] SerializeToUtf8Bytes() => JsonSerializer.SerializeToUtf8Bytes(this, GetType(), SerializerOptions);
 
 		private static readonly ReusableUtf8JsonWriter ReusableJsonWriter = new();
@@ -87,6 +92,8 @@ namespace Elastic.CommonSchema
 
 		// ReSharper disable once UnusedMember.Global
 		/// <summary> Serialize this <see cref="EcsDocument"/> instance to a Stream</summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		public void Serialize(Stream stream)
 		{
 			using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
@@ -97,9 +104,13 @@ namespace Elastic.CommonSchema
 			JsonSerializer.Serialize(writer, this, SerializerOptions);
 		}
 
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		internal void Serialize(Utf8JsonWriter writer) => JsonSerializer.Serialize(writer, this, SerializerOptions);
 
 		/// <summary> Serialize this <see cref="EcsDocument"/> instance to a Stream asynchronously</summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		public Task SerializeAsync(Stream stream, CancellationToken ctx = default) =>
 			JsonSerializer.SerializeAsync(stream, this, GetType(), SerializerOptions, ctx);
 	}

--- a/src/Elastic.CommonSchema/EcsDocument.cs
+++ b/src/Elastic.CommonSchema/EcsDocument.cs
@@ -226,7 +226,7 @@ public partial class EcsDocument
 		// see: https://github.com/elastic/apm-agent-dotnet/pull/847
 		// see: https://github.com/elastic/apm-agent-dotnet/issues/6
 		// Mentions observed exceptions however this extension method itself is wrapped in try/catch
-		var exString = exception.ToStringDemystified();
+		var exString = exception.ToString();
 
 		return new Error { Message = exception.Message, Type = exception.GetType().FullName, StackTrace = exString };
 	}

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -1,22 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0;net9.0</TargetFrameworks>
     <Title>Elastic Common Schema (ECS) Types</Title>
     <Description>Maps Elastic Common Schema (ECS) to .NET types including (de)serialization using System.Text.Json</Description>
     <LangVersion>latest</LangVersion>
     <IsPackable>True</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+  </PropertyGroup>
+  <PropertyGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2.')) OR $(TargetFramework.StartsWith('net4')) ">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all"
+                      IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\NullableExtensions.cs" />

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -12,9 +12,6 @@
     <IsAotCompatible>true</IsAotCompatible>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
-  <PropertyGroup>
-    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
-  </PropertyGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -16,16 +16,9 @@
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-  </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-  </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all"
-                      IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\NullableExtensions.cs" />

--- a/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
+++ b/src/Elastic.CommonSchema/Elastic.CommonSchema.csproj
@@ -12,7 +12,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
-  <PropertyGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+  <PropertyGroup>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 

--- a/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverterFactory.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsDocumentJsonConverterFactory.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -14,7 +16,10 @@ namespace Elastic.CommonSchema.Serialization
 		public override bool CanConvert(Type typeToConvert) => typeof(EcsDocument).IsAssignableFrom(typeToConvert);
 
 		/// <inheritdoc cref="JsonConverterFactory.CreateConverter"/>
-		public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL2092:DynamicallyAccessedMemberTypes", Justification = "More concrete then override")]
+		public override JsonConverter CreateConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]Type typeToConvert, JsonSerializerOptions options)
 		{
 			if (typeToConvert == typeof(EcsDocument))
 				return EcsJsonConfiguration.DefaultEcsDocumentJsonConverter;

--- a/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -13,6 +14,8 @@ namespace Elastic.CommonSchema.Serialization
 	public abstract class EcsJsonConverterBase<T> : JsonConverter<T>
 	{
 		/// <summary></summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		protected static JsonConverter<DateTimeOffset> GetDateTimeOffsetConverter(JsonSerializerOptions options) =>
 			options == EcsJsonConfiguration.SerializerOptions
 				? EcsJsonConfiguration.DateTimeOffsetConverter
@@ -59,6 +62,8 @@ namespace Elastic.CommonSchema.Serialization
 		}
 
 		/// <summary></summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		protected static void WriteProp<TValue>(Utf8JsonWriter writer, string key, TValue value, JsonSerializerOptions options)
 		{
 			if (value == null) return;
@@ -70,6 +75,8 @@ namespace Elastic.CommonSchema.Serialization
 		}
 
 		/// <summary></summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		protected static void WriteProp<TValue>(Utf8JsonWriter writer, string key, TValue value, JsonTypeInfo<TValue> typeInfo,
 			JsonSerializerOptions options)
 		{
@@ -84,6 +91,8 @@ namespace Elastic.CommonSchema.Serialization
 			else JsonSerializer.Serialize(writer, value, typeInfo);
 		}
 
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		internal static object? ReadPropDeserialize(ref Utf8JsonReader reader, Type type, JsonSerializerOptions options)
 		{
 			if (reader.TokenType == JsonTokenType.Null) return null;
@@ -122,6 +131,8 @@ namespace Elastic.CommonSchema.Serialization
 
 		/// <summary></summary>
 		// ReSharper disable once UnusedParameter.Local (key is used for readability)
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		private static TValue? ReadProp<TValue>(ref Utf8JsonReader reader, string key, JsonSerializerOptions options)  where TValue : class
 		{
 			if (reader.TokenType == JsonTokenType.Null) return null;

--- a/src/Elastic.CommonSchema/Serialization/EcsSerializerFactory.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsSerializerFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -21,18 +22,24 @@ public static class EcsSerializerFactory<TEcsDocument> where TEcsDocument : EcsD
 	/// <summary>
 	/// Deserialize a <typeparamref name="TEcsDocument"/> instance from a Stream asynchronously.
 	/// </summary>
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 	public static ValueTask<TEcsDocument?> DeserializeAsync(Stream stream, CancellationToken ctx = default) =>
 		JsonSerializer.DeserializeAsync<TEcsDocument>(stream, EcsJsonConfiguration.SerializerOptions, ctx);
 
 	/// <summary>
 	/// Deserialize a <typeparamref name="TEcsDocument"/> instance from a json string.
 	/// </summary>
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 	public static TEcsDocument? Deserialize(string json) =>
 		JsonSerializer.Deserialize<TEcsDocument>(json, EcsJsonConfiguration.SerializerOptions);
 
 	/// <summary>
 	/// Deserialize a <typeparamref name="TEcsDocument"/> instance from a readonly span of bytes.
 	/// </summary>
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 	public static TEcsDocument? Deserialize(ReadOnlySpan<byte> json) =>
 		JsonSerializer.Deserialize<TEcsDocument>(json, EcsJsonConfiguration.SerializerOptions);
 

--- a/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
+++ b/src/Elastic.CommonSchema/Serialization/JsonConfiguration.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,7 +14,16 @@ namespace Elastic.CommonSchema.Serialization
 	/// <summary>Static class holding <see cref="JsonSerializerOptions"/></summary>
 	public static class EcsJsonConfiguration
 	{
+		/// <summary> ahas </summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		static EcsJsonConfiguration()
+		{
+		}
+
 		/// <summary>Default <see cref="JsonSerializerOptions"/> used by ECS integrations</summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		public static JsonSerializerOptions SerializerOptions { get; } = new()
 		{
 			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
@@ -38,10 +48,14 @@ namespace Elastic.CommonSchema.Serialization
 			}
 		};
 
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		internal static readonly JsonConverter<DateTimeOffset> DateTimeOffsetConverter =
 			(JsonConverter<DateTimeOffset>)SerializerOptions.GetConverter(typeof(DateTimeOffset));
 
 		/// <summary>Default <see cref="JsonConverter{T}"/> for <see cref="EcsDocument"/></summary>
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		public static readonly EcsDocumentJsonConverter DefaultEcsDocumentJsonConverter = new();
 
 		private sealed class EcsJsonStringConverter<T> : JsonConverter<T>

--- a/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -53,6 +54,8 @@ namespace Elastic.CommonSchema.Serialization
 			return dictionary.Count > 0 ? dictionary : null;
 		}
 
+		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		public override void Write(Utf8JsonWriter writer, MetadataDictionary value, JsonSerializerOptions options)
 		{
 			writer.WriteStartObject();

--- a/src/Elastic.Extensions.Logging.Common/LogEventJsonContext.cs
+++ b/src/Elastic.Extensions.Logging.Common/LogEventJsonContext.cs
@@ -7,4 +7,4 @@ namespace Elastic.Extensions.Logging.Common;
 /// </summary>
 [JsonSerializable(typeof(LogEvent))]
 [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-public partial class LogEventJsonContext : JsonSerializerContext { }
+public partial class LogEventJsonContext : JsonSerializerContext;

--- a/src/Elastic.Extensions.Logging.Console/LoggingBuilderExtensions.cs
+++ b/src/Elastic.Extensions.Logging.Console/LoggingBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
 namespace Elastic.Extensions.Logging.Console;
@@ -6,7 +7,14 @@ namespace Elastic.Extensions.Logging.Console;
 public static class LoggingBuilderExtensions
 {
 	/// <summary> Adds ECS output to console output</summary>
-	public static ILoggingBuilder AddEcsConsole(this ILoggingBuilder builder, LogLevel stdErrorThreshold = LogLevel.Warning, Action<EcsConsoleFormatterOptions>? configure = null)
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Action is not bound")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "Action is not bound")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL2092:DynamicallyAccessedMemberTypes", Justification = "More concrete then override")]
+	public static ILoggingBuilder AddEcsConsole(
+		this ILoggingBuilder builder,
+		LogLevel stdErrorThreshold = LogLevel.Warning,
+		Action<EcsConsoleFormatterOptions>? configure = null
+	)
 	{
 		builder.AddConsole(c=>
 		{

--- a/src/Elastic.Extensions.Logging/Elastic.Extensions.Logging.csproj
+++ b/src/Elastic.Extensions.Logging/Elastic.Extensions.Logging.csproj
@@ -14,9 +14,6 @@
     <ProjectReference Include="..\Elastic.CommonSchema\Elastic.CommonSchema.csproj" />
     <ProjectReference Include="..\Elastic.Extensions.Logging.Common\Elastic.Extensions.Logging.Common.csproj" />
     <ProjectReference Include="..\Elastic.Ingest.Elasticsearch.CommonSchema\Elastic.Ingest.Elasticsearch.CommonSchema.csproj" />
-    <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
+++ b/src/Elastic.Ingest.Elasticsearch.CommonSchema/Elastic.Ingest.Elasticsearch.CommonSchema.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.12.3" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.14.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Elastic.NLog.Targets/ElasticsearchTarget.cs
+++ b/src/Elastic.NLog.Targets/ElasticsearchTarget.cs
@@ -419,7 +419,6 @@ namespace NLog.Targets
 					foreach (var itemResult in response.Items)
 						if (itemResult?.Status >= 300)
 							Common.InternalLogger.Error("ElasticSearch - Export Item failed to {0} document status {1} - {2}", itemResult.Action, itemResult.Status, itemResult.Error);
-					}
 				}
 			};
 		}

--- a/src/Elastic.NLog.Targets/ElasticsearchTarget.cs
+++ b/src/Elastic.NLog.Targets/ElasticsearchTarget.cs
@@ -26,8 +26,8 @@ namespace NLog.Targets
 	public class ElasticsearchTarget : TargetWithLayout
 	{
 		/// <inheritdoc />
-		public override Layout Layout { get => _layout; set => _layout = value as Elastic.CommonSchema.NLog.EcsLayout ?? _layout; }
-		private Elastic.CommonSchema.NLog.EcsLayout _layout = new Elastic.CommonSchema.NLog.EcsLayout();
+		public override Layout Layout { get => _layout; set => _layout = value as EcsLayout ?? _layout; }
+		private EcsLayout _layout = new EcsLayout();
 		private IBufferedChannel<NLogEcsDocument>? _channel;
 
 		/// <summary>
@@ -189,6 +189,9 @@ namespace NLog.Targets
 		/// </summary>
 		public Action<ElasticsearchChannelOptionsBase<NLogEcsDocument>>? ConfigureChannel { get; set; }
 
+		/// <summary> Provide a <see cref="IRequestInvoker"/> to the <see cref="ITransport{TConfiguration}"/> this target uses</summary>
+		public IRequestInvoker? RequestInvoker { get; set; }
+
 		/// <inheritdoc cref="IChannelDiagnosticsListener"/>
 		public IChannelDiagnosticsListener? DiagnosticsListener => _channel?.DiagnosticsListener;
 
@@ -200,7 +203,11 @@ namespace NLog.Targets
 			var indexOffset = string.IsNullOrEmpty(indexOffsetHours) ? default(TimeSpan?) : TimeSpan.FromHours(int.Parse(indexOffsetHours));
 
 			var connectionPool = CreateNodePool();
-			var config = new TransportConfigurationDescriptor(connectionPool, productRegistration: ElasticsearchProductRegistration.Default);
+			var config = new TransportConfigurationDescriptor(
+				connectionPool,
+				productRegistration: ElasticsearchProductRegistration.Default,
+				invoker: RequestInvoker
+			);
 			// Cloud sets authentication as required parameter in the constructor
 			if (NodePoolType != ElasticPoolType.Cloud)
 				config = SetAuthenticationOnTransport(config);
@@ -254,7 +261,7 @@ namespace NLog.Targets
 			var channelOptions = new DataStreamChannelOptions<NLogEcsDocument>(transport)
 			{
 				DataStream = new DataStreamName(dataStreamType, dataStreamSet, dataStreamNamespace),
-				SerializerContexts = [EcsJsonContext.Default, Elastic.CommonSchema.NLog.NLogEcsJsonContext.Default]
+				SerializerContexts = [EcsJsonContext.Default, NLogEcsJsonContext.Default]
 			};
 			SetupChannelOptions(channelOptions);
 			var channel = new EcsDataStreamChannel<NLogEcsDocument>(channelOptions, new[] { new InternalLoggerCallbackListener<NLogEcsDocument>() });
@@ -270,7 +277,7 @@ namespace NLog.Targets
 				IndexOffset = indexOffset,
 				TimestampLookup = l => l.Timestamp,
 				OperationMode = indexOperation,
-				SerializerContexts = [EcsJsonContext.Default, Elastic.CommonSchema.NLog.NLogEcsJsonContext.Default]
+				SerializerContexts = [EcsJsonContext.Default, NLogEcsJsonContext.Default]
 			};
 
 			if (_hasIndexEventId) indexChannelOptions.BulkOperationIdLookup = (logEvent) => (logEvent.Event?.Id)!;
@@ -287,7 +294,7 @@ namespace NLog.Targets
 		}
 
 		/// <inheritdoc />
-		protected override void Write(NLog.Common.AsyncLogEventInfo logEvent)
+		protected override void Write(Common.AsyncLogEventInfo logEvent)
 		{
 			try
 			{
@@ -296,7 +303,7 @@ namespace NLog.Targets
 					logEvent.Continuation(null);
 				else
 				{
-					NLog.Common.InternalLogger.Error("ElasticSearch - Failed writing to Elastic channel (Buffer full)");
+					Common.InternalLogger.Error("ElasticSearch - Failed writing to Elastic channel (Buffer full)");
 					logEvent.Continuation(new System.Threading.Tasks.TaskCanceledException("Failed writing to Elastic channel (Buffer full)"));
 				}
 			}
@@ -389,15 +396,15 @@ namespace NLog.Targets
 		{
 			ExportExceptionCallback = ex =>
 			{
-				NLog.Common.InternalLogger.Error(ex, "ElasticSearch - Export Exception");
+				Common.InternalLogger.Error(ex, "ElasticSearch - Export Exception");
 			};
 			PublishToInboundChannelFailureCallback = () =>
 			{
-				NLog.Common.InternalLogger.Error("ElasticSearch - Inbound Channel Failure (Buffer full)");
+				Common.InternalLogger.Error("ElasticSearch - Inbound Channel Failure (Buffer full)");
 			};
 			PublishToOutboundChannelFailureCallback = () =>
 			{
-				NLog.Common.InternalLogger.Error("ElasticSearch - Outbound Channel Failure (Flush failed)");
+				Common.InternalLogger.Error("ElasticSearch - Outbound Channel Failure (Flush failed)");
 			};
 			ExportResponseCallback = (response, _) =>
 			{
@@ -405,13 +412,14 @@ namespace NLog.Targets
 					return;
 
 				if (response.TryGetElasticsearchServerError(out var error))
-					NLog.Common.InternalLogger.Error("ElasticSearch - Export Response Server Error - {0}", error);
+					Common.InternalLogger.Error("ElasticSearch - Export Response Server Error - {0}", error);
 
 				if (response.Items?.Count > 0)
 				{
 					foreach (var itemResult in response.Items)
 						if (itemResult?.Status >= 300)
-							NLog.Common.InternalLogger.Error("ElasticSearch - Export Item failed to {0} document status {1} - {2}", itemResult.Action, itemResult.Status, itemResult.Error);
+							Common.InternalLogger.Error("ElasticSearch - Export Item failed to {0} document status {1} - {2}", itemResult.Action, itemResult.Status, itemResult.Error);
+					}
 				}
 			};
 		}

--- a/src/Elastic.Serilog.Enrichers.Web/Elastic.Serilog.Enrichers.Web.csproj
+++ b/src/Elastic.Serilog.Enrichers.Web/Elastic.Serilog.Enrichers.Web.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
+++ b/tests-integration/Elasticsearch.IntegrationDefaults/Elasticsearch.IntegrationDefaults.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.16.2" />
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.6.0" />
-    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.12.3" />
+    <PackageReference Include="Elastic.Ingest.Elasticsearch" Version="0.14.0" />
 
   </ItemGroup>
 

--- a/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
+++ b/tests/Elastic.Apm.NLog.Tests/Elastic.Apm.NLog.Tests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Elastic.Apm" Version="1.22.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NLog" Version="4.7.15" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.5" />
+    <PackageReference Include="NLog" Version="6.0.2" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.0.2" />
     <PackageReference Update="xunit" Version="2.9.3" />
   </ItemGroup>
 

--- a/tests/Elastic.Apm.NLog.Tests/NLogTests.cs
+++ b/tests/Elastic.Apm.NLog.Tests/NLogTests.cs
@@ -14,8 +14,15 @@ namespace Elastic.Apm.NLog.Tests
 	{
 		public NLogTests()
 		{
-			var assembly = typeof(ApmTraceIdLayoutRenderer).Assembly;
-			global::NLog.Config.ConfigurationItemFactory.Default.RegisterItemsFromAssembly(assembly);
+			global::NLog.LogManager.Setup().SetupExtensions(ext =>
+			{
+				ext.RegisterLayoutRenderer<ApmTraceIdLayoutRenderer>(ApmTraceIdLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmTransactionIdLayoutRenderer>(ApmTransactionIdLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmSpanIdLayoutRenderer>(ApmSpanIdLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmServiceNameLayoutRenderer>(ApmServiceNameLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmServiceVersionLayoutRenderer>(ApmServiceVersionLayoutRenderer.Name);
+				ext.RegisterLayoutRenderer<ApmServiceNodeNameLayoutRenderer>(ApmServiceNodeNameLayoutRenderer.Name);
+			});
 
 			var configuration = new MockConfiguration("my-service", "my-service-node-name", "0.2.1");
 			if (!Agent.IsConfigured)
@@ -33,9 +40,9 @@ namespace Elastic.Apm.NLog.Tests
 			var target = new MemoryTarget();
 			target.Layout = "${ElasticApmTraceId}|${ElasticApmTransactionId}|${ElasticApmSpanId}|${message}";
 
-			global::NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Debug);
+			var logFactory = new global::NLog.LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(target)).LogFactory;
 
-			var logger = LogManager.GetLogger("Example");
+			var logger = logFactory.GetLogger("Example");
 
 			logger.Debug("PreTransaction");
 
@@ -72,9 +79,9 @@ namespace Elastic.Apm.NLog.Tests
 			var target = new MemoryTarget();
 			target.Layout = "${ElasticApmServiceName}|${ElasticApmServiceNodeName}|${ElasticApmServiceVersion}|${message}";
 
-			global::NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Debug);
+			var logFactory = new global::NLog.LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(target)).LogFactory;
 
-			var logger = LogManager.GetLogger("Example");
+			var logger = logFactory.GetLogger("Example");
 
 			logger.Debug("Some log");
 

--- a/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.Log4net.Tests/MessageTests.cs
@@ -127,10 +127,9 @@ public class MessageTests : LogTestsBase
 			info.Error.Type.Should().Be(e.GetType().FullName);
 
 			info.Error.StackTrace.Should().Contain(e.Message);
-			info.Error.StackTrace.Should().Contain("at void");
+			info.Error.StackTrace.Should().Contain("at Elastic.CommonSchema.Log4net.Tests.MessageTests");
 
 			info.Error.StackTrace.Should().Contain(innerException.Message);
-			info.Error.StackTrace.Should().Contain("at void");
 		}
 	});
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/EcsFieldsInTemplateTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/EcsFieldsInTemplateTests.cs
@@ -24,7 +24,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 			var ecsEvents = ToEcsEvents(logEvents);
 
 			var (_, info) = ecsEvents.First();
-			info.Message.Should().Be("Info \"my-trace-id\": true");
+			info.Message.Should().Be("Info my-trace-id: true");
 			info.Labels.Should().BeNull();
 			info.Metadata.Should().BeNull();
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
+++ b/tests/Elastic.CommonSchema.NLog.Tests/Elastic.CommonSchema.NLog.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NLog" Version="4.7.15" />
-        <PackageReference Include="NLog.Web.AspNetCore" Version="4.15.0" />
+        <PackageReference Include="NLog" Version="6.0.2" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="6.0.2" />
         <PackageReference Include="Elastic.Apm" Version="1.22.0" />
         <PackageReference Update="xunit" Version="2.9.3" />
     </ItemGroup>

--- a/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
@@ -41,7 +41,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 			var ecsEvents = ToEcsEvents(logEvents);
 
 			var (_, info) = ecsEvents.First();
-			info.Message.Should().Be("Info \"X\" 2.2 42");
+			info.Message.Should().Be("Info X 2.2 42");
 			info.Labels.Should().ContainKey("ValueX");
 			info.Metadata.Should().ContainKey("SomeY");
 			info.Metadata.Should().NotContainKey("NotX");
@@ -228,7 +228,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 		[Fact]
 		public void MetadataWithSameKeys() => TestLogger((logger, getLogEvents) =>
 		{
-			using (MappedDiagnosticsLogicalContext.SetScoped("DupKey", "Mdlc"))
+			using (ScopeContext.PushProperty("DupKey", "Mdlc"))
 			{
 				logger.Info("Info {DupKey}", "LoggerArg");
 
@@ -239,7 +239,7 @@ namespace Elastic.CommonSchema.NLog.Tests
 
 				var (json, info) = ecsEvents.First();
 
-				info.Message.Should().Be("Info \"LoggerArg\"");
+				info.Message.Should().Be("Info LoggerArg");
 				info.Labels.Should().Contain("DupKey", "LoggerArg");
 				info.Labels.Should().Contain("DupKey_1", "Mdlc");
 

--- a/tests/Elastic.CommonSchema.NLog.Tests/WebTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/WebTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using FluentAssertions;
+using NLog;
 using NLog.Config;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,25 +18,16 @@ namespace Elastic.CommonSchema.NLog.Tests
 
 		private void TestLayout(bool withNLogWeb, Action<EcsLayout> setup, Action<EcsLayout> act)
 		{
-			// Setup basic factory without automatic loading of NLog extensions.
-			ConfigurationItemFactory.Default = new(typeof(ConfigurationItemFactory).Assembly);
-
-			try
+			if (withNLogWeb)
 			{
-				if (withNLogWeb)
-				{
-					var nlogWebAssemblyName = new AssemblyName("NLog.Web.AspNetCore");
-					var nlogWebAssembly = Assembly.Load(nlogWebAssemblyName);
-					ConfigurationItemFactory.Default.RegisterItemsFromAssembly(nlogWebAssembly);
-				}
+				var nlogWebAssemblyName = new AssemblyName("NLog.Web.AspNetCore");
+				var nlogWebAssembly = Assembly.Load(nlogWebAssemblyName);
+#pragma warning disable CS0618 // Type or member is obsolete
+				ConfigurationItemFactory.Default.RegisterItemsFromAssembly(nlogWebAssembly);
+#pragma warning restore CS0618 // Type or member is obsolete
+			}
 
-				TestLoggerAndLayout(setup, (layout, logger, events) => act(layout));
-			}
-			finally
-			{
-				// Cleanup for the sake of other tests.
-				ConfigurationItemFactory.Default = null;
-			}
+			TestLoggerAndLayout(setup, (layout, logger, events) => act(layout));
 		}
 
 		[Theory]

--- a/tests/Elastic.Serilog.Sinks.Tests/SerilogFailureOutputTests.cs
+++ b/tests/Elastic.Serilog.Sinks.Tests/SerilogFailureOutputTests.cs
@@ -1,9 +1,7 @@
 using Elastic.Channels;
 using Elastic.Channels.Diagnostics;
 using Elastic.Transport;
-using FluentAssertions;
 using Serilog;
-using Serilog.Sinks.TestCorrelator;
 using Xunit;
 using DataStreamName = Elastic.Ingest.Elasticsearch.DataStreams.DataStreamName;
 


### PR DESCRIPTION
Adds AOT annotations for all published projects and ensures they are advertised as AOT compatible.


Create a smoke test binary that writes to an in memory elasticsearch endpoint for our NLog and Extensions loggers. 

Serilog is currently failing with:

```
ecs-aot-smoketest failed with 2 error(s) (58.2s) → examples/ecs-aot-smoketest/bin/release/net9.0/osx-arm64/ecs-aot-smoketest.dll
    ILC : Trim analysis error IL2067: Serilog.Capturing.PropertyValueConverter.TryConvertStructure(Object,Type,Destructuring,StructureValue&): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'Serilog.Capturing.PropertyValueConverter.CreateStructureValue(Object,Type,Boolean)'. The parameter 'type' of method 'Serilog.Capturing.PropertyValueConverter.TryConvertStructure(Object,Type,Destructuring,StructureValue&)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
    /Users/mpdreamz/.nuget/packages/microsoft.dotnet.ilcompiler/9.0.7/build/Microsoft.NETCore.Native.targets(317,5): error MSB3073: The command ""/Users/mpdreamz/.nuget/packages/runtime.osx-arm64.microsoft.dotnet.ilcompiler/9.0.7/tools/ilc" @"obj/release/net9.0/osx-arm64/native/ecs-aot-smoketest.ilc.rsp"" exited with code -1.
```

Will create an issue with Serilog to see if it can be resolved.


This removes https://github.com/benaadams/Ben.Demystifier as its not AOT compatible. AOT compatibility beats nicer stacktrace strings as a feature to keep supporting IMO.

This bumps NLog to 6.0.0 to take benefit of its work to be AOT compatible (cc @snakefoot)

Also be aware wuth this backport we bump NLog to 6.0.0 for our `8.x` releases. 

We typically do not require major version bumps in our deps to force a bump in our major version. cc @snakefoot 

