### PR TITLE
[DOCS] Fix broken link to `Elastic.Apm.SerilogEnricher`

### DIFF
--- a/docs/reference/serilog-data-shipper.md
+++ b/docs/reference/serilog-data-shipper.md
@@ -26,7 +26,7 @@ Log.Logger = new LoggerConfiguration()
 	.Enrich.FromLogContext()
 ```
 
-**NOTE:** Don’t forget we also publish an [`Elastic.Apm.SerilogEnricher`](https://github.com/elastic/ecs-dotnet/blob/main/src/Elastic.Apm.SerilogEnricher/readme.md) for the Elastic APM Agent!
+**NOTE:** Don’t forget we also publish an [`Elastic.Apm.SerilogEnricher`](https://github.com/elastic/ecs-dotnet/tree/main/src/Elastic.Apm.SerilogEnricher) for the Elastic APM Agent!
 
 Writing to `Elasticsearch`
 


### PR DESCRIPTION
Closes https://github.com/elastic/docs-content/issues/4041