### PR TITLE
docs: add `applies_to` frontmatter for docs v3 cumulative docs

### DIFF
--- a/docs/reference/_elasticsearch_security.md
+++ b/docs/reference/_elasticsearch_security.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_elasticsearch_security.html
 ---

--- a/docs/reference/_elasticsearch_security.md
+++ b/docs/reference/_elasticsearch_security.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_elasticsearch_security.html
 ---

--- a/docs/reference/_enrichers_2.md
+++ b/docs/reference/_enrichers_2.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_enrichers_2.html
 ---

--- a/docs/reference/_enrichers_2.md
+++ b/docs/reference/_enrichers_2.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_enrichers_2.html
 ---

--- a/docs/reference/_extending_ecsdocument.md
+++ b/docs/reference/_extending_ecsdocument.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_extending_ecsdocument.html
 ---

--- a/docs/reference/_extending_ecsdocument.md
+++ b/docs/reference/_extending_ecsdocument.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_extending_ecsdocument.html
 ---

--- a/docs/reference/_formatters.md
+++ b/docs/reference/_formatters.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_formatters.html
 ---

--- a/docs/reference/_formatters.md
+++ b/docs/reference/_formatters.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_formatters.html
 ---
@@ -22,6 +29,10 @@ All supported ECS message template properties are available as constants under t
 
 
 ## Ingest ECS log files [_ingest_ecs_log_files]
+
+```{applies_to}
+serverless: unavailable
+```
 
 If you are using one of our formatter libraries to log to file or stdout/stderr you can use the following options to get these logs into Elasticsearch or Elastic Cloud:
 

--- a/docs/reference/_usage.md
+++ b/docs/reference/_usage.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_usage.html
 ---

--- a/docs/reference/_usage.md
+++ b/docs/reference/_usage.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/_usage.html
 ---

--- a/docs/reference/apm-nlog-enricher.md
+++ b/docs/reference/apm-nlog-enricher.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/apm-nlog-enricher.html
 ---

--- a/docs/reference/apm-nlog-enricher.md
+++ b/docs/reference/apm-nlog-enricher.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/apm-nlog-enricher.html
 ---

--- a/docs/reference/apm-serilog-enricher.md
+++ b/docs/reference/apm-serilog-enricher.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/apm-serilog-enricher.html
 ---

--- a/docs/reference/apm-serilog-enricher.md
+++ b/docs/reference/apm-serilog-enricher.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/apm-serilog-enricher.html
 ---

--- a/docs/reference/benchmark-dotnet-data-shipper.md
+++ b/docs/reference/benchmark-dotnet-data-shipper.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/benchmark-dotnet-data-shipper.html
 ---

--- a/docs/reference/benchmark-dotnet-data-shipper.md
+++ b/docs/reference/benchmark-dotnet-data-shipper.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/benchmark-dotnet-data-shipper.html
 ---

--- a/docs/reference/data-shippers.md
+++ b/docs/reference/data-shippers.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/data-shippers.html
 ---

--- a/docs/reference/data-shippers.md
+++ b/docs/reference/data-shippers.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/data-shippers.html
 ---

--- a/docs/reference/ecs-dotnet.md
+++ b/docs/reference/ecs-dotnet.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/ecs-dotnet.html
 ---

--- a/docs/reference/ecs-dotnet.md
+++ b/docs/reference/ecs-dotnet.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/ecs-dotnet.html
 ---

--- a/docs/reference/ecs-ingest-channels.md
+++ b/docs/reference/ecs-ingest-channels.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/ecs-ingest-channels.html
 ---

--- a/docs/reference/ecs-ingest-channels.md
+++ b/docs/reference/ecs-ingest-channels.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/ecs-ingest-channels.html
 ---

--- a/docs/reference/extensions-logging-data-shipper.md
+++ b/docs/reference/extensions-logging-data-shipper.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/extensions-logging-data-shipper.html
 ---

--- a/docs/reference/extensions-logging-data-shipper.md
+++ b/docs/reference/extensions-logging-data-shipper.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/extensions-logging-data-shipper.html
 ---

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   # TO DO: Do we want this in addition to an intro page?
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/index.html

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   # TO DO: Do we want this in addition to an intro page?
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/index.html

--- a/docs/reference/intro_to_xyz.md
+++ b/docs/reference/intro_to_xyz.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/intro_to_xyz.html
 ---

--- a/docs/reference/intro_to_xyz.md
+++ b/docs/reference/intro_to_xyz.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/intro_to_xyz.html
 ---

--- a/docs/reference/log4net-formatter.md
+++ b/docs/reference/log4net-formatter.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/log4net-formatter.html
 ---

--- a/docs/reference/log4net-formatter.md
+++ b/docs/reference/log4net-formatter.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/log4net-formatter.html
 ---

--- a/docs/reference/nlog-formatter.md
+++ b/docs/reference/nlog-formatter.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/nlog-formatter.html
 ---

--- a/docs/reference/nlog-formatter.md
+++ b/docs/reference/nlog-formatter.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/nlog-formatter.html
 ---

--- a/docs/reference/serilog-data-shipper.md
+++ b/docs/reference/serilog-data-shipper.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/serilog-data-shipper.html
 ---

--- a/docs/reference/serilog-data-shipper.md
+++ b/docs/reference/serilog-data-shipper.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/serilog-data-shipper.html
 ---

--- a/docs/reference/serilog-formatter.md
+++ b/docs/reference/serilog-formatter.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/serilog-formatter.html
 ---

--- a/docs/reference/serilog-formatter.md
+++ b/docs/reference/serilog-formatter.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/serilog-formatter.html
 ---

--- a/docs/reference/setup.md
+++ b/docs/reference/setup.md
@@ -1,4 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga
+    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/setup.html
 navigation_title: 'Get started'
@@ -33,6 +40,10 @@ By default the ECS logging integrations will read tracing information from [Syst
 
 
 ## Step 3: Configure Filebeat (optional) [setup-step-3]
+
+```{applies_to}
+serverless: unavailable
+```
 
 If you are using one of our log formatters you can use the following methods to ship these logs to Elastic.
 

--- a/docs/reference/setup.md
+++ b/docs/reference/setup.md
@@ -2,10 +2,6 @@
 applies_to:
   stack: ga
   serverless: ga
-  deployment:
-    ess: ga
-    ece: ga
-    eck: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/dotnet/current/setup.html
 navigation_title: 'Get started'


### PR DESCRIPTION
## Summary

Adds mandatory `applies_to` frontmatter to all reference documentation pages to align with the [Docs versioning contributor guidelines](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs) and docs v3.

Tags are consistent with page/section content.

Relates to [#256](https://github.com/elastic/docs-content-internal/issues/256)

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude Sonnet 4.5 using Cursor to double-check the updated files, write PR description
