### PR TITLE
MetadataDictionaryConverter - Reduce allocation and ensure decimal point

### DIFF
--- a/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
+++ b/src/Elastic.CommonSchema/Serialization/EcsJsonConverterBase.cs
@@ -62,6 +62,9 @@ namespace Elastic.CommonSchema.Serialization
 		}
 
 		/// <summary></summary>
+		protected static void WriteProp(Utf8JsonWriter writer, string key, string? value, JsonSerializerOptions options) => WritePropString(writer, key, value);
+
+		/// <summary></summary>
 		[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
 		protected static void WriteProp<TValue>(Utf8JsonWriter writer, string key, TValue value, JsonSerializerOptions options)

--- a/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
@@ -69,28 +69,17 @@ public class MetadataDictionaryConverter : JsonConverter<MetadataDictionary>
 		{
 			var propertyName = kvp.Key;
 
-			if (kvp.Value == null)
+			try
 			{
-				writer.WritePropertyName(propertyName);
-				writer.WriteNullValue();
+				// The following is not safe
+				// JsonSerializer.Serialize(writer, kvp.Value, inputType, options);
+				// If a getter throws an exception we risk not logging anything
+				WriteProp(writer, propertyName, kvp.Value, options);
 			}
-			else
+			catch (Exception e)
 			{
-				try
-				{
-					// The following is not safe
-					// JsonSerializer.Serialize(writer, kvp.Value, inputType, options);
-					// If a getter throws an exception we risk not logging anything
-
-					var bytes = JsonSerializer.SerializeToUtf8Bytes(kvp.Value, options);
-					writer.WritePropertyName(propertyName);
-					writer.WriteRawValue(bytes);
-				}
-				catch (Exception e)
-				{
-					failures ??= new List<MetaDataSerializationFailure>();
-					failures.Add(new MetaDataSerializationFailure { Property = propertyName, SerializationFailure = e.Message });
-				}
+				failures ??= new List<MetaDataSerializationFailure>();
+				failures.Add(new MetaDataSerializationFailure { Property = propertyName, SerializationFailure = e.Message });
 			}
 		}
 		if (failures != null)
@@ -100,6 +89,158 @@ public class MetadataDictionaryConverter : JsonConverter<MetadataDictionary>
 		}
 		writer.WriteEndObject();
 	}
+
+	[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+	[UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "We always provide a static JsonTypeInfoResolver")]
+	private static void WriteProp(Utf8JsonWriter writer, string key, object? value, JsonSerializerOptions options)
+	{
+		if (value is null)
+		{
+			writer.WritePropertyName(key);
+			writer.WriteNullValue();
+			return;
+		}
+
+		// Recognize common types and write directly without GetTypeInfo<TValue>
+		switch (value)
+		{
+			case int v:
+				writer.WritePropertyName(key);
+				writer.WriteNumberValue(v);
+				break;
+			case uint v:
+				writer.WritePropertyName(key);
+				writer.WriteNumberValue(v);
+				break;
+			case long v:
+				writer.WritePropertyName(key);
+				writer.WriteNumberValue(v);
+				break;
+			case ulong v:
+				writer.WritePropertyName(key);
+				writer.WriteNumberValue(v);
+				break;
+			case float v:
+				{
+					writer.WritePropertyName(key);
+#if NET
+					Span<byte> buffer = stackalloc byte[32];
+					writer.WriteRawValue(TryFormatAndEnsureDecimal(v, buffer), skipInputValidation: true);
+#else
+					writer.WriteNumberValue(v);
+#endif
+				}
+				break;
+			case double v:
+				{
+					writer.WritePropertyName(key);
+#if NET
+					Span<byte> buffer = stackalloc byte[32];
+					writer.WriteRawValue(TryFormatAndEnsureDecimal(v, buffer), skipInputValidation: true);
+#else
+					writer.WriteNumberValue(v);
+#endif
+				}
+				break;
+			case decimal v:
+				{
+					writer.WritePropertyName(key);
+#if NET
+					Span<byte> buffer = stackalloc byte[32];
+					writer.WriteRawValue(TryFormatAndEnsureDecimal(v, buffer), skipInputValidation: true);
+#else
+					writer.WriteNumberValue(v);
+#endif
+				}
+				break;
+			case bool v:
+				writer.WritePropertyName(key);
+				writer.WriteBooleanValue(v);
+				break;
+			case char v:
+				{
+					writer.WritePropertyName(key);
+#if NET
+					Span<char> buffer = [v];
+#else
+					var buffer = v.ToString();
+#endif
+					writer.WriteStringValue(buffer);
+				}
+				break;
+			case string v:
+				writer.WritePropertyName(key);
+				writer.WriteStringValue(v);
+				break;
+			case Guid v:
+				writer.WritePropertyName(key);
+				writer.WriteStringValue(v);
+				break;
+			case DateTime v:
+				writer.WritePropertyName(key);
+				writer.WriteStringValue(v);
+				break;
+			case DateTimeOffset v:
+				writer.WritePropertyName(key);
+				writer.WriteStringValue(v);
+				break;
+			case Enum v:
+				writer.WritePropertyName(key);
+				writer.WriteStringValue(v.ToString());
+				break;
+			default:
+				// Unknown/Unsafe so serialize before writing property name to avoid writing an invalid JSON document.
+				var bytes = JsonSerializer.SerializeToUtf8Bytes(value, options);
+				writer.WritePropertyName(key);
+				writer.WriteRawValue(bytes);
+				break;
+		}
+	}
+
+#if NET
+	private static ReadOnlySpan<byte> TryFormatAndEnsureDecimal<TDouble>(TDouble value, Span<byte> buffer) where TDouble : IUtf8SpanFormattable
+	{
+		if (!value.TryFormat(buffer, out var written, default, System.Globalization.CultureInfo.InvariantCulture))
+			throw new InvalidOperationException("Buffer too small.");
+
+		var span = buffer[..written];
+		if (span.IndexOfAny((byte)'.', (byte)'e', (byte)'E') >= 0)
+			return span;
+
+		var firstChar = span[0];
+		if (firstChar == (byte)'N' || firstChar == (byte)'I' || (firstChar == (byte)'-' && span[1] == (byte)'I'))
+		{
+			// NaN or Infinity, wrap in quotes to make it valid JSON
+			span.CopyTo(buffer[1..]);   // Move 1 forward
+			buffer[0] = (byte)'"';
+			buffer[written + 1] = (byte)'"';
+			written += 2;
+		}
+		else
+		{
+			// Apply a decimal point
+			buffer[written++] = (byte)'.';
+			buffer[written++] = (byte)'0';
+		}
+		return buffer[..written];
+	}
+
+	private static ReadOnlySpan<byte> TryFormatAndEnsureDecimal(decimal value, Span<byte> buffer)
+	{
+		if (!value.TryFormat(buffer, out var written, default, System.Globalization.CultureInfo.InvariantCulture))
+			throw new InvalidOperationException("Buffer too small.");
+
+		var span = buffer[..written];
+
+		if (span.IndexOf((byte)'.') < 0)
+		{
+			buffer[written++] = (byte)'.';
+			buffer[written++] = (byte)'0';
+		}
+
+		return buffer[..written];
+	}
+#endif
 
 	private object? ExtractValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
 	{

--- a/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
+++ b/src/Elastic.CommonSchema/Serialization/MetadataDictionaryConverter.cs
@@ -123,31 +123,34 @@ public class MetadataDictionaryConverter : JsonConverter<MetadataDictionary>
 			case float v:
 				{
 					writer.WritePropertyName(key);
-#if NET
-					Span<byte> buffer = stackalloc byte[32];
-					writer.WriteRawValue(TryFormatAndEnsureDecimal(v, buffer), skipInputValidation: true);
+#if NET || NETSTANDARD2_1_OR_GREATER
+					WriteFormattedNumber(writer, v);
 #else
-					writer.WriteNumberValue(v);
+					if(float.IsNaN(v) || float.IsInfinity(v))
+						writer.WriteStringValue(v.ToString(System.Globalization.CultureInfo.InvariantCulture));
+					else
+						writer.WriteNumberValue(v);
 #endif
 				}
 				break;
 			case double v:
 				{
 					writer.WritePropertyName(key);
-#if NET
-					Span<byte> buffer = stackalloc byte[32];
-					writer.WriteRawValue(TryFormatAndEnsureDecimal(v, buffer), skipInputValidation: true);
+#if NET || NETSTANDARD2_1_OR_GREATER
+					WriteFormattedNumber(writer, v);
 #else
-					writer.WriteNumberValue(v);
+					if(double.IsNaN(v) || double.IsInfinity(v))
+						writer.WriteStringValue(v.ToString(System.Globalization.CultureInfo.InvariantCulture));
+					else
+						writer.WriteNumberValue(v);
 #endif
 				}
 				break;
 			case decimal v:
 				{
 					writer.WritePropertyName(key);
-#if NET
-					Span<byte> buffer = stackalloc byte[32];
-					writer.WriteRawValue(TryFormatAndEnsureDecimal(v, buffer), skipInputValidation: true);
+#if NET || NETSTANDARD2_1_OR_GREATER
+					WriteFormattedNumber(writer, v);
 #else
 					writer.WriteNumberValue(v);
 #endif
@@ -160,7 +163,7 @@ public class MetadataDictionaryConverter : JsonConverter<MetadataDictionary>
 			case char v:
 				{
 					writer.WritePropertyName(key);
-#if NET
+#if NET || NETSTANDARD2_1_OR_GREATER
 					Span<char> buffer = [v];
 #else
 					var buffer = v.ToString();
@@ -197,47 +200,71 @@ public class MetadataDictionaryConverter : JsonConverter<MetadataDictionary>
 		}
 	}
 
-#if NET
-	private static ReadOnlySpan<byte> TryFormatAndEnsureDecimal<TDouble>(TDouble value, Span<byte> buffer) where TDouble : IUtf8SpanFormattable
+#if NET || NETSTANDARD2_1_OR_GREATER
+	private static void WriteFormattedNumber(Utf8JsonWriter writer, float value)
 	{
-		if (!value.TryFormat(buffer, out var written, default, System.Globalization.CultureInfo.InvariantCulture))
+		Span<byte> buffer = stackalloc byte[32];
+
+		if (!System.Buffers.Text.Utf8Formatter.TryFormat(value, buffer, out var written))
 			throw new InvalidOperationException("Buffer too small.");
 
+		writer.WriteRawValue(EnsureDecimal(buffer, written), skipInputValidation: true);
+	}
+
+	private static void WriteFormattedNumber(Utf8JsonWriter writer, double value)
+	{
+		Span<byte> buffer = stackalloc byte[32];
+
+		if (!System.Buffers.Text.Utf8Formatter.TryFormat(value, buffer, out var written))
+			throw new InvalidOperationException("Buffer too small.");
+
+		writer.WriteRawValue(EnsureDecimal(buffer, written), skipInputValidation: true);
+	}
+
+	private static void WriteFormattedNumber(Utf8JsonWriter writer, decimal value)
+	{
+		Span<byte> buffer = stackalloc byte[32];
+		Span<char> chars = stackalloc char[32];
+
+		if (!value.TryFormat(chars, out var written, default, System.Globalization.CultureInfo.InvariantCulture))
+			throw new InvalidOperationException("Buffer too small.");
+
+		var hasDecimalPoint = false;
+		for (var i = 0; i < written; i++)
+		{
+			hasDecimalPoint |= chars[i] == '.';
+			buffer[i] = (byte)chars[i];
+		}
+
+		if (!hasDecimalPoint)
+		{
+			// Force an explicit decimal representation.
+			buffer[written++] = (byte)'.';
+			buffer[written++] = (byte)'0';
+		}
+
+		writer.WriteRawValue(buffer[..written], skipInputValidation: true);
+	}
+
+	private static ReadOnlySpan<byte> EnsureDecimal(Span<byte> buffer, int written)
+	{
 		var span = buffer[..written];
 		if (span.IndexOfAny((byte)'.', (byte)'e', (byte)'E') >= 0)
 			return span;
 
-		var firstChar = span[0];
+		var firstChar = span.Length > 0 ? span[0] : 0;
 		if (firstChar == (byte)'N' || firstChar == (byte)'I' || (firstChar == (byte)'-' && span[1] == (byte)'I'))
 		{
 			// NaN or Infinity, wrap in quotes to make it valid JSON
 			span.CopyTo(buffer[1..]);   // Move 1 forward
 			buffer[0] = (byte)'"';
 			buffer[written + 1] = (byte)'"';
-			written += 2;
-		}
-		else
-		{
-			// Apply a decimal point
-			buffer[written++] = (byte)'.';
-			buffer[written++] = (byte)'0';
-		}
-		return buffer[..written];
-	}
-
-	private static ReadOnlySpan<byte> TryFormatAndEnsureDecimal(decimal value, Span<byte> buffer)
-	{
-		if (!value.TryFormat(buffer, out var written, default, System.Globalization.CultureInfo.InvariantCulture))
-			throw new InvalidOperationException("Buffer too small.");
-
-		var span = buffer[..written];
-
-		if (span.IndexOf((byte)'.') < 0)
-		{
-			buffer[written++] = (byte)'.';
-			buffer[written++] = (byte)'0';
+			return buffer[..(written + 2)];
 		}
 
+		// Force an explicit decimal representation.
+		buffer[written++] = (byte)'.';
+		buffer[written++] = (byte)'0';
 		return buffer[..written];
 	}
 #endif

--- a/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
+++ b/tests/Elastic.CommonSchema.NLog.Tests/MessageTests.cs
@@ -54,6 +54,28 @@ namespace Elastic.CommonSchema.NLog.Tests
 			y.Should().HaveValue().And.Be(2.2);
 		});
 
+
+		[Fact]
+		public void SeesMessageWithSpecialDoubles() => TestLogger((logger, getLogEvents) =>
+		{
+			logger.Info("Info {ValueX} {SomeY} {NotX}", double.NaN, double.NegativeInfinity, "X");
+
+			var logEvents = getLogEvents();
+			logEvents.Should().HaveCount(1);
+
+			var ecsEvents = ToEcsEvents(logEvents);
+
+			var (_, info) = ecsEvents.First();
+			info.Message.Should().Be("Info NaN -Infinity X");
+			info.Metadata.Should().ContainKey("ValueX");
+			info.Metadata.Should().ContainKey("SomeY");
+
+			var x = info.Metadata["ValueX"] as string;
+			x.Should().Be("NaN");
+			var y = info.Metadata["SomeY"] as string;
+			y.Should().Be("-Infinity");
+		});
+
 		[Fact]
 		public void SeesMessageWithSafeProp() => TestLogger((logger, getLogEvents) =>
 		{


### PR DESCRIPTION
Reduce allocation when formatting simple MetaData-Properties, and ensure decimal point when raw double / float / decimal.

Trust that exceptions are not thrown when serializing primitive-values.